### PR TITLE
Deprecate `id_type` in favor of `type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Deprecated `id_type` in favor of `type`
 
 ## [0.7.1] - 2020-09-02
 

--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -7,7 +7,7 @@ struct DekuByte {
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-#[deku(id_type = "u8")]
+#[deku(type = "u8")]
 enum DekuEnum {
     #[deku(id = "0x01")]
     VariantA(u8),

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -104,7 +104,7 @@ impl DekuData {
             ast::Data::Struct(_) => {
                 // Validate id_* attributes are being used on an enum
                 if receiver.id_type.is_some() {
-                    Err((receiver.id_type.span(), "`id_type` only supported on enum"))
+                    Err((receiver.id_type.span(), "`type` only supported on enum"))
                 } else if receiver.id.is_some() {
                     Err((receiver.id.span(), "`id` only supported on enum"))
                 } else if receiver.id_bytes.is_some() {
@@ -119,19 +119,19 @@ impl DekuData {
                 }
             }
             ast::Data::Enum(_) => {
-                // Validate `id_type` or `id` is specified
+                // Validate `type` or `id` is specified
                 if receiver.id_type.is_none() && receiver.id.is_none() {
                     return Err((
                         receiver.ident.span(),
-                        "`id_type` or `id` must be specified on enum",
+                        "`type` or `id` must be specified on enum",
                     ));
                 }
 
-                // Validate either `id_type` or `id` is specified
+                // Validate either `type` or `id` is specified
                 if receiver.id_type.is_some() && receiver.id.is_some() {
                     return Err((
                         receiver.ident.span(),
-                        "conflicting: both `id_type` and `id` specified on enum",
+                        "conflicting: both `type` and `id` specified on enum",
                     ));
                 }
 
@@ -394,7 +394,7 @@ struct DekuReceiver {
     id: Option<TokenStream>,
 
     /// enum only: type of the enum `id`
-    #[darling(default)]
+    #[darling(rename = "type", default)]
     id_type: Option<syn::Ident>,
 
     /// enum only: bit size of the enum `id`
@@ -581,9 +581,9 @@ mod tests {
         }"#),
 
         // Valid Enum
-        case::enum_empty(r#"#[deku(id_type = "u8")] enum Test {}"#),
+        case::enum_empty(r#"#[deku(type = "u8")] enum Test {}"#),
         case::enum_all(r#"
-        #[deku(id_type = "u8")]
+        #[deku(type = "u8")]
         enum Test {
             #[deku(id = "1")]
             A,

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -214,7 +214,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             let (new_rest, variant_id) = #id_type::read(rest, (#id_args))?;
         }
     } else {
-        // either `id` or `id_type` needs to be specified
+        // either `id` or `type` needs to be specified
         unreachable!();
     };
 

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -194,7 +194,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 quote! {}
             }
         } else {
-            // either `id` or `id_type` needs to be specified
+            // either `id` or `type` needs to be specified
             unreachable!();
         };
 

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -3,7 +3,7 @@ use hex_literal::hex;
 use std::convert::TryFrom;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-#[deku(id_type = "u8")]
+#[deku(type = "u8")]
 enum DekuTest {
     #[deku(id = "0")]
     Var1,

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -20,7 +20,7 @@ A documentation-only module for #[deku] attributes
 | [ctx_default](#ctx_default) | top-level, field| Default context values
 | enum: [id](#id) | top-level, variant | enum or variant id value
 | enum: [id_pat](#id_pat) | variant | variant id match pattern
-| enum: [id_type](#id_type) | top-level | Set the type of the variant `id`
+| enum: [type](#type) | top-level | Set the type of the variant `id`
 | enum: [id_bits](#id_bits) | top-level | Set the bit-size of the variant `id`
 | enum: [id_bytes](#id_bytes) | top-level | Set the byte-size of the variant `id`
 
@@ -585,7 +585,7 @@ assert_eq!(ret_write, data)
 
 ## id (variant)
 
-Specify the identifier of the enum variant, must be paired with [id_type](#id_type)
+Specify the identifier of the enum variant, must be paired with [type](#type)
 or [id (top-level)](#id-top-level)
 
 **Note**: If no `id` is specified, the variant is treated as the "catch-all".
@@ -595,7 +595,7 @@ Example:
 # use deku::prelude::*;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(id_type = "u8")]
+#[deku(type = "u8")]
 enum DekuTest {
     #[deku(id = "0x01")]
     VariantA(u8),
@@ -653,7 +653,7 @@ Example:
 # use deku::prelude::*;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(id_type = "u8")]
+#[deku(type = "u8")]
 enum DekuTest {
     #[deku(id = "0x01")]
     VariantA(u8),
@@ -676,7 +676,7 @@ let variant_bytes: Vec<u8> = value.try_into().unwrap();
 assert_eq!(data, variant_bytes);
 ```
 
-# id_type
+# type
 
 Specify the type of the enum variant id to consume, see [example](#id-variant)
 
@@ -691,7 +691,7 @@ Example:
 # use deku::prelude::*;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(id_type = "u8", id_bits = "4")]
+#[deku(type = "u8", id_bits = "4")]
 enum DekuTest {
     #[deku(id = "0b1001")]
     VariantA( #[deku(bits = "4")] u8, u8),
@@ -721,7 +721,7 @@ Example:
 # use deku::prelude::*;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(id_type = "u32", id_bytes = "2")]
+#[deku(type = "u32", id_bytes = "2")]
 enum DekuTest {
     #[deku(id = "0xBEEF")]
     VariantA(u8),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,11 +141,11 @@ assert_eq!(DekuTest {
 As enums can have multiple variants, each variant must have a way to match on
 the incoming data.
 
-First the "type" is read using the `id_type`, then is matched against the
+First the "type" is read using the `type`, then is matched against the
 variants given `id`. What happens after is the same as structs!
 
 This is implemented with the [id](/attributes/index.html#id) and
-[id_type](attributes/index.html#id_type) attributes.
+[type](attributes/index.html#type) attributes.
 
 Example:
 
@@ -153,7 +153,7 @@ Example:
 use deku::prelude::*;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-#[deku(id_type = "u8")]
+#[deku(type = "u8")]
 enum DekuTest {
     #[deku(id = "0x01")]
     VariantA,

--- a/tests/macro_read/bits_bytes_conflict.rs
+++ b/tests/macro_read/bits_bytes_conflict.rs
@@ -1,11 +1,11 @@
 use deku::prelude::*;
 
 #[derive(DekuRead)]
-#[deku(id_type = "u8", id_bits = "1", id_bytes = "2")]
+#[deku(type = "u8", id_bits = "1", id_bytes = "2")]
 enum Test1 {}
 
 #[derive(DekuRead)]
-#[deku(id_type = "u8")]
+#[deku(type = "u8")]
 enum Test2 {
     A(#[deku(bits = "1", bytes = "2")] u8),
     B {

--- a/tests/macro_read/enum_validation.rs
+++ b/tests/macro_read/enum_validation.rs
@@ -4,21 +4,21 @@ use deku::prelude::*;
 #[derive(DekuRead)]
 enum Test1 {}
 
-// test conflict `id_type` and `id`
+// test conflict `type` and `id`
 #[derive(DekuRead)]
-#[deku(id_type = "u8", id = "test")]
+#[deku(type = "u8", id = "test")]
 enum Test2 {}
 
 // test conflict `id` and `id_pat`
 #[derive(DekuRead)]
-#[deku(id_type = "u8")]
+#[deku(type = "u8")]
 enum Test3 {
     #[deku(id = "1", id_pat = "2..=3")] A(u8),
 }
 
-// test `id_type` only allowed on enum
+// test `type` only allowed on enum
 #[derive(DekuRead)]
-#[deku(id_type = "u8")]
+#[deku(type = "u8")]
 struct Test4 {
     a: u8
 }

--- a/tests/macro_read/enum_validation.stderr
+++ b/tests/macro_read/enum_validation.stderr
@@ -1,10 +1,10 @@
-error: `id_type` or `id` must be specified on enum
+error: `type` or `id` must be specified on enum
  --> $DIR/enum_validation.rs:5:6
   |
 5 | enum Test1 {}
   |      ^^^^^
 
-error: conflicting: both `id_type` and `id` specified on enum
+error: conflicting: both `type` and `id` specified on enum
   --> $DIR/enum_validation.rs:10:6
    |
 10 | enum Test2 {}
@@ -16,11 +16,11 @@ error: conflicting: both `id` and `id_pat` specified on variant
 16 |     #[deku(id = "1", id_pat = "2..=3")] A(u8),
    |                 ^^^
 
-error: `id_type` only supported on enum
-  --> $DIR/enum_validation.rs:21:18
+error: `type` only supported on enum
+  --> $DIR/enum_validation.rs:21:15
    |
-21 | #[deku(id_type = "u8")]
-   |                  ^^^^
+21 | #[deku(type = "u8")]
+   |               ^^^^
 
 error: `id_bits` only supported on enum
   --> $DIR/enum_validation.rs:27:10

--- a/tests/macro_read/unknown_endian.rs
+++ b/tests/macro_read/unknown_endian.rs
@@ -13,11 +13,11 @@ struct Test2 {
 }
 
 #[derive(DekuRead)]
-#[deku(id_type = "u8", endian = "variable")]
+#[deku(type = "u8", endian = "variable")]
 enum Test3 {}
 
 #[derive(DekuRead)]
-#[deku(id_type = "u8")]
+#[deku(type = "u8")]
 enum Test4 {
     #[deku(id = "1")]
     A(#[deku(endian = "variable")] u8),

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -12,7 +12,7 @@ struct NestedStruct {
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-#[deku(id_type = "u8", ctx = "_endian: Endian")]
+#[deku(type = "u8", ctx = "_endian: Endian")]
 enum NestedEnum {
     #[deku(id = "0x01")]
     VarA(u8),

--- a/tests/test_from_bytes.rs
+++ b/tests/test_from_bytes.rs
@@ -31,7 +31,7 @@ fn test_from_bytes_struct() {
 #[test]
 fn test_from_bytes_enum() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8", id_bits = "4")]
+    #[deku(type = "u8", id_bits = "4")]
     enum TestDeku {
         #[deku(id = "0b0110")]
         VariantA(#[deku(bits = "4")] u8),

--- a/tests/test_macro.rs
+++ b/tests/test_macro.rs
@@ -51,7 +51,7 @@ pub mod samples {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8")]
+    #[deku(type = "u8")]
     pub enum EnumDeku {
         #[deku(id = "1")]
         VarA(u8),
@@ -72,7 +72,7 @@ pub mod samples {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8")]
+    #[deku(type = "u8")]
     pub enum EnumDekuDefault {
         #[deku(id = "1")]
         VarA(u8),
@@ -111,7 +111,7 @@ pub mod samples {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8")]
+    #[deku(type = "u8")]
     pub enum GenericEnumDeku<T: deku::DekuRead + deku::DekuWrite>
     where
         T: deku::DekuWrite + deku::DekuRead,
@@ -182,7 +182,7 @@ pub mod samples {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8", ctx = "a: u8, b: u8")]
+    #[deku(type = "u8", ctx = "a: u8, b: u8")]
     pub enum TopLevelCtxEnum {
         #[deku(id = "1")]
         VariantA(
@@ -195,7 +195,7 @@ pub mod samples {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8", ctx = "a: u8, b: u8", ctx_default = "1,2")]
+    #[deku(type = "u8", ctx = "a: u8, b: u8", ctx_default = "1,2")]
     pub enum TopLevelCtxEnumDefault {
         #[deku(id = "1")]
         VariantA(
@@ -208,7 +208,7 @@ pub mod samples {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8")]
+    #[deku(type = "u8")]
     pub enum VariantLevelCtxEnum {
         #[deku(id = "1")]
         VariantA {
@@ -243,7 +243,7 @@ pub mod samples {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(id_type = "u32", endian = "endian", ctx = "endian: deku::ctx::Endian")]
+    #[deku(type = "u32", endian = "endian", ctx = "endian: deku::ctx::Endian")]
     pub enum EnumTypeEndianCtx {
         #[deku(id = "0xDEADBEEF")]
         VarA(u8),


### PR DESCRIPTION
- Change darling input and use the darling rename attribute to take in `type`
  instead of `id_type`. This keeps the use of `id_type` internally,
  because of type being a rust-lang protected word.
- Update error messages, test fields

See #89