### PR TITLE
Deprecate `id_bits` in favor of `bits`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Deprecated `id_bits` in favor of `bits`
 
 ## [0.7.1] - 2020-09-02
 

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -137,10 +137,7 @@ impl DekuData {
 
                 // Validate `id_*` used correctly
                 if receiver.id.is_some() && receiver.bits.is_some() {
-                    return Err((
-                        receiver.ident.span(),
-                        "error: cannot use `bits` with `id`",
-                    ));
+                    return Err((receiver.ident.span(), "error: cannot use `bits` with `id`"));
                 }
                 if receiver.id.is_some() && receiver.id_bytes.is_some() {
                     return Err((

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -30,8 +30,8 @@ struct DekuData {
     id_type: Option<syn::Ident>,
 
     /// enum only: bit size of the enum `id`
-    /// `id_bytes` is converted to `id_bits` if provided
-    id_bits: Option<usize>,
+    /// `id_bytes` is converted to `bits` if provided
+    bits: Option<usize>,
 }
 
 impl DekuData {
@@ -71,7 +71,7 @@ impl DekuData {
             .transpose()
             .map_err(|e| e.to_compile_error())?;
 
-        let id_bits = receiver.id_bytes.map(|b| b * 8).or(receiver.id_bits);
+        let bits = receiver.id_bytes.map(|b| b * 8).or(receiver.bits);
 
         Ok(Self {
             vis: receiver.vis,
@@ -83,7 +83,7 @@ impl DekuData {
             ctx_default,
             id: receiver.id,
             id_type: receiver.id_type,
-            id_bits,
+            bits,
         })
     }
 
@@ -112,8 +112,8 @@ impl DekuData {
                         receiver.id_bytes.span(),
                         "`id_bytes` only supported on enum",
                     ))
-                } else if receiver.id_bits.is_some() {
-                    Err((receiver.id_bits.span(), "`id_bits` only supported on enum"))
+                } else if receiver.bits.is_some() {
+                    Err((receiver.bits.span(), "`bits` only supported on enum"))
                 } else {
                     Ok(())
                 }
@@ -136,10 +136,10 @@ impl DekuData {
                 }
 
                 // Validate `id_*` used correctly
-                if receiver.id.is_some() && receiver.id_bits.is_some() {
+                if receiver.id.is_some() && receiver.bits.is_some() {
                     return Err((
                         receiver.ident.span(),
-                        "error: cannot use `id_bits` with `id`",
+                        "error: cannot use `bits` with `id`",
                     ));
                 }
                 if receiver.id.is_some() && receiver.id_bytes.is_some() {
@@ -149,11 +149,11 @@ impl DekuData {
                     ));
                 }
 
-                // Validate either `id_bits` or `id_bytes` is specified
-                if receiver.id_bits.is_some() && receiver.id_bytes.is_some() {
+                // Validate either `bits` or `id_bytes` is specified
+                if receiver.bits.is_some() && receiver.id_bytes.is_some() {
                     return Err((
-                        receiver.id_bits.span(),
-                        "conflicting: both `id_bits` and `id_bytes` specified on enum",
+                        receiver.bits.span(),
+                        "conflicting: both `bits` and `id_bytes` specified on enum",
                     ));
                 }
 
@@ -399,7 +399,7 @@ struct DekuReceiver {
 
     /// enum only: bit size of the enum `id`
     #[darling(default)]
-    id_bits: Option<usize>,
+    bits: Option<usize>,
 
     /// enum only: byte size of the enum `id`
     #[darling(default)]

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -132,7 +132,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let id = input.id.as_ref();
     let id_type = input.id_type.as_ref();
 
-    let id_args = gen_id_args(input.endian.as_ref(), input.id_bits)?;
+    let id_args = gen_id_args(input.endian.as_ref(), input.bits)?;
 
     let mut variant_matches = vec![];
     let mut has_default_match = false;

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -147,7 +147,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let id = input.id.as_ref();
     let id_type = input.id_type.as_ref();
 
-    let id_args = gen_id_args(input.endian.as_ref(), input.id_bits)?;
+    let id_args = gen_id_args(input.endian.as_ref(), input.bits)?;
 
     let mut variant_writes = vec![];
     let mut variant_updates = vec![];

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -160,7 +160,7 @@ fn gen_ctx_types_and_arg(
 }
 
 /// Generate argument for `id`:
-/// `#deku(endian = "big", id_bits = "1")` -> `Endian::Big, BitSize(1)`
+/// `#deku(endian = "big", bits = "1")` -> `Endian::Big, BitSize(1)`
 fn gen_id_args(endian: Option<&syn::LitStr>, bits: Option<usize>) -> syn::Result<TokenStream> {
     let endian = endian.map(gen_endian_from_str).transpose()?;
     let bits = bits.map(|n| quote! {deku::ctx::BitSize(#n)});
@@ -179,7 +179,7 @@ fn gen_id_args(endian: Option<&syn::LitStr>, bits: Option<usize>) -> syn::Result
 
 /// Generate argument for fields:
 ///
-/// `#deku(endian = "big", id_bits = "1", ctx = "a")` -> `Endian::Big, BitSize(1), a`
+/// `#deku(endian = "big", bits = "1", ctx = "a")` -> `Endian::Big, BitSize(1), a`
 fn gen_field_args(
     endian: Option<&syn::LitStr>,
     bits: Option<usize>,

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -21,7 +21,7 @@ A documentation-only module for #[deku] attributes
 | enum: [id](#id) | top-level, variant | enum or variant id value
 | enum: [id_pat](#id_pat) | variant | variant id match pattern
 | enum: [id_type](#id_type) | top-level | Set the type of the variant `id`
-| enum: [id_bits](#id_bits) | top-level | Set the bit-size of the variant `id`
+| enum: [bits](#bits) | top-level | Set the bit-size of the variant `id`
 | enum: [id_bytes](#id_bytes) | top-level | Set the byte-size of the variant `id`
 
 # endian
@@ -680,7 +680,7 @@ assert_eq!(data, variant_bytes);
 
 Specify the type of the enum variant id to consume, see [example](#id-variant)
 
-# id_bits
+# bits
 
 Set the bit size of the enum variant `id`
 
@@ -691,7 +691,7 @@ Example:
 # use deku::prelude::*;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(id_type = "u8", id_bits = "4")]
+#[deku(id_type = "u8", bits = "4")]
 enum DekuTest {
     #[deku(id = "0b1001")]
     VariantA( #[deku(bits = "4")] u8, u8),
@@ -714,7 +714,7 @@ assert_eq!(data, value);
 
 Set the byte size of the enum variant `id`
 
-**Note**: Cannot be used in combination with [id_bits](#id_bits)
+**Note**: Cannot be used in combination with [bits](#bits)
 
 Example:
 ```rust

--- a/tests/macro_read/bits_bytes_conflict.rs
+++ b/tests/macro_read/bits_bytes_conflict.rs
@@ -1,7 +1,7 @@
 use deku::prelude::*;
 
 #[derive(DekuRead)]
-#[deku(id_type = "u8", id_bits = "1", id_bytes = "2")]
+#[deku(id_type = "u8", bits = "1", id_bytes = "2")]
 enum Test1 {}
 
 #[derive(DekuRead)]

--- a/tests/macro_read/bits_bytes_conflict.stderr
+++ b/tests/macro_read/bits_bytes_conflict.stderr
@@ -1,4 +1,4 @@
-error: conflicting: both `id_bits` and `id_bytes` specified on enum
+error: conflicting: both `bits` and `id_bytes` specified on enum
  --> $DIR/bits_bytes_conflict.rs:3:10
   |
 3 | #[derive(DekuRead)]

--- a/tests/macro_read/enum_validation.rs
+++ b/tests/macro_read/enum_validation.rs
@@ -23,16 +23,16 @@ struct Test4 {
     a: u8
 }
 
-// test `id_bits` only allowed on enum
+// test `bits` only allowed on enum
 #[derive(DekuRead)]
-#[deku(id_bits = "1")]
+#[deku(bits = "1")]
 struct Test5 {
     a: u8
 }
 
 // test `id_bytes` only allowed on enum
 #[derive(DekuRead)]
-#[deku(id_bits = "1")]
+#[deku(bits = "1")]
 struct Test6 {
     a: u8
 }
@@ -44,9 +44,9 @@ struct Test7 {
     a: u8
 }
 
-// test `id_bits` cannot be used with `id`
+// test `bits` cannot be used with `id`
 #[derive(DekuRead)]
-#[deku(id = "test", id_bits = "4")]
+#[deku(id = "test", bits = "4")]
 enum Test8 {
     A
 }

--- a/tests/macro_read/enum_validation.stderr
+++ b/tests/macro_read/enum_validation.stderr
@@ -22,7 +22,7 @@ error: `id_type` only supported on enum
 21 | #[deku(id_type = "u8")]
    |                  ^^^^
 
-error: `id_bits` only supported on enum
+error: `bits` only supported on enum
   --> $DIR/enum_validation.rs:27:10
    |
 27 | #[derive(DekuRead)]
@@ -30,7 +30,7 @@ error: `id_bits` only supported on enum
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `id_bits` only supported on enum
+error: `bits` only supported on enum
   --> $DIR/enum_validation.rs:34:10
    |
 34 | #[derive(DekuRead)]
@@ -44,7 +44,7 @@ error: `id` only supported on enum
 42 | #[deku(id = "test")]
    |             ^^^^^^
 
-error: error: cannot use `id_bits` with `id`
+error: error: cannot use `bits` with `id`
   --> $DIR/enum_validation.rs:50:6
    |
 50 | enum Test8 {

--- a/tests/test_from_bytes.rs
+++ b/tests/test_from_bytes.rs
@@ -31,7 +31,7 @@ fn test_from_bytes_struct() {
 #[test]
 fn test_from_bytes_enum() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8", id_bits = "4")]
+    #[deku(id_type = "u8", bits = "4")]
     enum TestDeku {
         #[deku(id = "0b0110")]
         VariantA(#[deku(bits = "4")] u8),


### PR DESCRIPTION
- More direct change, with a full change of all mentions of `id_bits`
  to `bits`.

See #89