### PR TITLE
Change DekuWrite to accept a &mut BitVec instead of allocating

### DIFF
--- a/examples/custom_reader_and_writer.rs
+++ b/examples/custom_reader_and_writer.rs
@@ -42,7 +42,9 @@ fn bit_flipper_write(
     // flip the bits on value if field_a is 0x01
     let value = if field_a == 0x01 { !field_b } else { field_b };
 
-    value.write(bit_size)
+    let mut acc: BitVec<Msb0, u8> = BitVec::new();
+    value.write(&mut acc, bit_size)?;
+    Ok(acc)
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]

--- a/examples/custom_reader_and_writer.rs
+++ b/examples/custom_reader_and_writer.rs
@@ -28,8 +28,9 @@ fn bit_flipper_read(
 fn bit_flipper_write(
     field_a: u8,
     field_b: u8,
+    output: &mut BitVec<Msb0, u8>,
     bit_size: BitSize,
-) -> Result<BitVec<Msb0, u8>, DekuError> {
+) -> Result<(), DekuError> {
     // Access to previously written fields
     println!("field_a = 0x{:X}", field_a);
 
@@ -42,9 +43,7 @@ fn bit_flipper_write(
     // flip the bits on value if field_a is 0x01
     let value = if field_a == 0x01 { !field_b } else { field_b };
 
-    let mut acc: BitVec<Msb0, u8> = BitVec::new();
-    value.write(&mut acc, bit_size)?;
-    Ok(acc)
+    value.write(output, bit_size)
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
@@ -53,7 +52,7 @@ struct DekuTest {
 
     #[deku(
         reader = "bit_flipper_read(*field_a, rest, BitSize(8))",
-        writer = "bit_flipper_write(*field_a, *field_b, BitSize(8))"
+        writer = "bit_flipper_write(*field_a, *field_b, output, BitSize(8))"
     )]
     field_b: u8,
 }

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -389,7 +389,7 @@ Example:
 struct DekuTest {
     #[deku(
         reader = "DekuTest::read(rest)",
-        writer = "DekuTest::write(&self.field_a)"
+        writer = "DekuTest::write(output, &self.field_a)"
     )]
     field_a: String,
 }
@@ -404,9 +404,9 @@ impl DekuTest {
     }
 
     /// Parse from String to u8 and write
-    fn write(field_a: &str) -> Result<BitVec<Msb0, u8>, DekuError> {
+    fn write(output: &mut BitVec<Msb0, u8>, field_a: &str) -> Result<(), DekuError> {
         let value = field_a.parse::<u8>().unwrap();
-        value.write(())
+        value.write(output, ())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,7 +552,7 @@ impl<T: DekuWrite<Ctx>, Ctx: Copy> DekuWrite<Ctx> for Vec<T> {
     /// * **inner_ctx** - The context required by `T`.
     /// # Examples
     /// ```rust
-    /// # use deku::{ctx::Endian, DekuWrite, prelude::Lsb0};
+    /// # use deku::{ctx::Endian, DekuWrite, prelude::{Lsb0, Msb0}};
     /// # use bitvec::bitvec;
     /// let data = vec![1u8];
     /// let mut output = bitvec![Msb0, u8;];
@@ -597,7 +597,7 @@ impl<T: DekuWrite<Ctx>, Ctx: Copy> DekuWrite<Ctx> for Option<T> {
     /// * **inner_ctx** - The context required by `T`.
     /// # Examples
     /// ```rust
-    /// # use deku::{ctx::Endian, DekuWrite, prelude::Lsb0};
+    /// # use deku::{ctx::Endian, DekuWrite, prelude::{Lsb0, Msb0}};
     /// # use bitvec::bitvec;
     /// let data = Some(1u8);
     /// let mut output = bitvec![Msb0, u8;];

--- a/tests/test_macro.rs
+++ b/tests/test_macro.rs
@@ -1,3 +1,4 @@
+use bitvec::bitvec;
 use deku::prelude::*;
 use hexlit::hex;
 use rstest::rstest;
@@ -159,7 +160,7 @@ pub mod samples {
     pub struct SubTypeNeedCtx {
         #[deku(
             reader = "(|rest|{u8::read(rest,()).map(|(slice,c)|(slice,(a+b+c) as usize))})(rest)",
-            writer = "(|c|{u8::write(&(c-a-b), ())})(self.i as u8)"
+            writer = "(|c|{u8::write(&(c-a-b), output, ())})(self.i as u8)"
         )]
         pub(crate) i: usize,
     }
@@ -188,7 +189,7 @@ pub mod samples {
         VariantA(
             #[deku(
                 reader = "(|rest|{u8::read(rest,()).map(|(slice,c)|(slice,(a+b+c)))})(rest)",
-                writer = "(|c|{u8::write(&(c-a-b), ())})(field_0)"
+                writer = "(|c|{u8::write(&(c-a-b), output, ())})(field_0)"
             )]
             u8,
         ),
@@ -201,7 +202,7 @@ pub mod samples {
         VariantA(
             #[deku(
                 reader = "(|rest|{u8::read(rest,()).map(|(slice,c)|(slice,(a+b+c)))})(rest)",
-                writer = "(|c|{u8::write(&(c-a-b), ())})(field_0)"
+                writer = "(|c|{u8::write(&(c-a-b), output, ())})(field_0)"
             )]
             u8,
         ),


### PR DESCRIPTION
Resolves #59 

**Breaking change:**

- This breaks the interface required by the `DekuWrite` trait, since `DekuWrite::write` accepts a `&mut BitVec` instead of returning one. I think this is justified since it is an objectively better API and since this crate is not yet 1.0, some API churn should be expected.

- There are some differences at runtime regarding the layout of the output `BitVec`s, requiring changes to some test cases ([explained in comments below](https://github.com/sharksforarms/deku/pull/101#discussion_r494705816)).

Todo:

- [x] Update derive macros to output correct impls for the new API
- [x] Update integration/macro tests
- [x] Update doctests
- [x] Update examples