### PR TITLE
Check container size vs bits/bytes size at compile

### DIFF
--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -591,10 +591,26 @@ mod tests {
             #[deku(id = "3")]
             C { field_n: u8 },
         }"#),
+        case::valid_bits(r#"struct Test(#[deku(bits=8)] u8);"#),
 
-        // TODO: these tests should error/warn eventually?
-        // error: trying to store 9 bits in 8 bit type
+        // error: invalid bit container size for deku bits/bytes attribute
+        #[should_panic(expected="field `field_0` of type `u8` with bit size: 8, not big enough for bits = 9")]
         case::invalid_storage(r#"struct Test(#[deku(bits=9)] u8);"#),
+        #[should_panic(expected="field `field_a` of type `u16` with bit size: 16, not big enough for bits = 24")]
+        case::invalid_storage(r#"
+        struct Invalid {
+            #[deku(bytes = 3)]
+            pub field_a: u16
+        }
+        "#),
+        #[should_panic(expected="field `ganondorf` of type `u8` with bit size: 8, not big enough for bits = 120")]
+        case::invalid_storage(r#"
+        struct Invalid {
+            #[deku(bits = 120)]
+            pub ganondorf: u8
+        }
+        "#),
+        // TODO
         // warn: trying to set endian on a type which wouldn't make a difference
         case::invalid_endian(r#"struct Test(#[endian=big] u8);"#),
     )]

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -616,6 +616,13 @@ mod tests {
             pub ganondorf: u8
         }
         "#),
+        #[should_panic(expected="field `ganondorf` of type `u8` with bit size: 8, not big enough for bits = 9")]
+        case::invalid_storage(r#"
+        struct Invalid {
+            #[deku(ctx = "deku::ctx::BitSize(9)")]
+            pub ganondorf: u8
+        }
+        "#),
         // TODO
         // warn: trying to set endian on a type which wouldn't make a difference
         case::invalid_endian(r#"struct Test(#[endian=big] u8);"#),

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -578,6 +578,12 @@ mod tests {
             #[deku(skip, default = "5")]
             field_e: u32,
         }"#),
+        case::valid_ctx_bitsize(r#"
+        struct Invalid {
+            #[deku(ctx = "deku::ctx::BitSize(7)")]
+            pub hey_listen: u8
+        }
+        "#),
 
         // Valid Enum
         case::enum_empty(r#"#[deku(type = "u8")] enum Test {}"#),

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -485,7 +485,7 @@ fn check_bitsize_ctx(
             if let syn::Expr::Path(path) = &*call.func {
                 for path in path.path.segments.iter() {
                     // If we find a BitSize ident, parse the following argument
-                    if path.ident.to_string() == "BitSize" {
+                    if path.ident == "BitSize" {
                         // check call.args token
                         let args = call.args.first().unwrap();
                         if let syn::Expr::Lit(lit) = args {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -781,8 +781,6 @@ mod tests {
         case::not_enough_data([].as_ref(), Endian::Little, Some(32), 0xFF, bits![Msb0, u8;]),
         #[should_panic(expected = "Parse(\"not enough data: expected 32 bits got 16 bits\")")]
         case::not_enough_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(32), 0xFF, bits![Msb0, u8;]),
-        #[should_panic(expected = "Parse(\"too much data: container of 32 bits cannot hold 64 bits\")")]
-        case::too_much_data([0xAA, 0xBB, 0xCC, 0xDD, 0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(64), 0xFF, bits![Msb0, u8;]),
     )]
     fn test_bit_read(
         input: &[u8],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,13 +288,6 @@ macro_rules! ImplDekuTraits {
 
                 let input_is_le = endian.is_le();
 
-                if bit_size > max_type_bits {
-                    return Err(DekuError::Parse(format!(
-                        "too much data: container of {} bits cannot hold {} bits",
-                        max_type_bits, bit_size
-                    )));
-                }
-
                 if input.len() < bit_size {
                     return Err(DekuError::Parse(format!(
                         "not enough data: expected {} bits got {} bits",
@@ -864,14 +857,8 @@ mod tests {
         case::count_1([0xAA, 0xBB].as_ref(), Endian::Little, Some(8), 1, vec![0xAA], bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1, 1]),
         case::count_2([0xAA, 0xBB, 0xCC].as_ref(), Endian::Little, Some(8), 2, vec![0xAA, 0xBB], bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0]),
         case::bits_6([0b0110_1001, 0b1110_1001].as_ref(), Endian::Little, Some(6), 2, vec![0b00_011010, 0b00_011110], bits![Msb0, u8; 1, 0, 0, 1]),
-        #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::not_enough_data([].as_ref(), Endian::Little, Some(9), 1, vec![], bits![Msb0, u8;]),
-        #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(9), 1, vec![], bits![Msb0, u8;]),
         #[should_panic(expected = "Parse(\"not enough data: expected 8 bits got 0 bits\")")]
         case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(8), 2, vec![], bits![Msb0, u8;]),
-        #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1, vec![], bits![Msb0, u8;]),
     )]
     fn test_vec_read(
         input: &[u8],


### PR DESCRIPTION
- Add panic if bits is larger than the container size.
- Add Tests for new feature.
- Removed code in runtime for checking container size, since it is
  asserted at compile time now.

Any comments/questions welcome!