### PR TITLE
Support magic values prefixing types

### DIFF
--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -29,6 +29,9 @@ struct DekuData {
     /// default context passed to the field
     ctx_default: Option<Punctuated<syn::Expr, syn::token::Comma>>,
 
+    /// A magic value that must appear at the start of this struct's data
+    magic: Option<syn::LitByteStr>,
+
     /// enum only: `id` value
     id: Option<TokenStream>,
 
@@ -87,6 +90,7 @@ impl DekuData {
             endian: receiver.endian,
             ctx,
             ctx_default,
+            magic: receiver.magic,
             id: receiver.id,
             id_type: receiver.id_type,
             bits,
@@ -385,6 +389,10 @@ struct DekuReceiver {
     //       https://github.com/TedDriggs/darling/pull/98
     #[darling(default)]
     ctx_default: Option<syn::LitStr>,
+
+    /// A magic value that must appear at the start of this struct's data
+    #[darling(default)]
+    magic: Option<syn::LitByteStr>,
 
     /// enum only: `id` value
     #[darling(default, map = "option_as_tokenstream")]

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -29,7 +29,7 @@ struct DekuData {
     /// default context passed to the field
     ctx_default: Option<Punctuated<syn::Expr, syn::token::Comma>>,
 
-    /// A magic value that must appear at the start of this struct's data
+    /// A magic value that must appear at the start of this struct/enum's data
     magic: Option<syn::LitByteStr>,
 
     /// enum only: `id` value
@@ -390,7 +390,7 @@ struct DekuReceiver {
     #[darling(default)]
     ctx_default: Option<syn::LitStr>,
 
-    /// A magic value that must appear at the start of this struct's data
+    /// A magic value that must appear at the start of this struct/enum's data
     #[darling(default)]
     magic: Option<syn::LitByteStr>,
 

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -124,6 +124,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     let id_args = gen_id_args(input.endian.as_ref(), input.bits)?;
 
+    let magic_read = emit_magic_read(input)?;
+
     let mut variant_matches = vec![];
     let mut has_default_match = false;
 
@@ -226,6 +228,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 let mut rest = input.0.bits::<Msb0>();
                 rest = &rest[input.1..];
 
+                #magic_read
+
                 #variant_read
 
                 let pad = 8 * ((rest.len() + 7) / 8) - rest.len();
@@ -247,6 +251,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let read_body = quote! {
         use core::convert::TryFrom;
         let mut rest = input;
+
+        #magic_read
 
         #variant_read
 

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -283,11 +283,9 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     Ok(tokens)
 }
 
-fn emit_magic_read(
-    input: &DekuData
-) -> Result<TokenStream, syn::Error> {
+fn emit_magic_read(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let tokens = if let Some(magic) = &input.magic {
-        quote!{
+        quote! {
             let magic = #magic;
 
             for byte in magic {
@@ -300,7 +298,7 @@ fn emit_magic_read(
             }
         }
     } else {
-        quote!{}
+        quote! {}
     };
 
     Ok(tokens)

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -339,15 +339,13 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     Ok(tokens)
 }
 
-fn emit_magic_write(
-    input: &DekuData,
-) -> Result<TokenStream, syn::Error> {
+fn emit_magic_write(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let tokens = if let Some(magic) = &input.magic {
-        quote!{
+        quote! {
             #magic.write(output, ())?;
         }
     } else {
-        quote!{}
+        quote! {}
     };
 
     Ok(tokens)

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -105,7 +105,7 @@ assert_eq!(data, value);
 # magic
 
 Sets a "magic" value that must be present in the data at the start of
-a struct/enum when reading, and that is written out of the start of 
+a struct/enum when reading, and that is written out of the start of
 that type's data when writing, without needing to be explicitly stored
 in a field
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -115,16 +115,16 @@ Example:
 # use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(magic = b"deku")]
-pub struct MagicDeku {
+pub struct DekuTest {
     data: u8
 }
 
 let data: Vec<u8> = vec![0x64, 0x65, 0x6B, 0x75, 50];
 
-let value = MagicDeku::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data.as_ref()).unwrap();
 
 assert_eq!(
-    MagicDeku { data: 50 },
+    DekuTest { data: 50 },
     value
 );
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -106,8 +106,7 @@ assert_eq!(data, value);
 
 Sets a "magic" value that must be present in the data at the start of
 a struct/enum when reading, and that is written out of the start of
-that type's data when writing, without needing to be explicitly stored
-in a field
+that type's data when writing.
 
 Example:
 ```rust

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -6,6 +6,7 @@ A documentation-only module for #\[deku\] attributes
 | Attribute | Scope | Description
 |-----------|------------------|------------
 | [endian](#endian) | top-level, field | Set the endianness
+| [magic](#magic) | top-level | A magic value that must be present at the start of this struct/enum
 | [bits](#bits) | field | Set the bit-size of the field
 | [bytes](#bytes) | field | Set the byte-size of the field
 | [count](#count) | field | Set the field representing the element count of a container
@@ -94,6 +95,36 @@ assert_eq!(
        field_default: 0xCDAB,
        field_child: Child { field_a: 0xBEEF }
     },
+    value
+);
+
+let value: Vec<u8> = value.try_into().unwrap();
+assert_eq!(data, value);
+```
+
+# magic
+
+Sets a "magic" value that must be present in the data at the start of
+a struct/enum when reading, and that is written out of the start of 
+that type's data when writing, without needing to be explicitly stored
+in a field
+
+Example:
+```rust
+# use deku::prelude::*;
+# use std::convert::{TryInto, TryFrom};
+# #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+#[deku(magic = b"deku")]
+pub struct MagicDeku {
+    data: u8
+}
+
+let data: Vec<u8> = vec![0x64, 0x65, 0x6B, 0x75, 50];
+
+let value = MagicDeku::try_from(data.as_ref()).unwrap();
+
+assert_eq!(
+    MagicDeku { data: 50 },
     value
 );
 

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -1,7 +1,7 @@
 use deku::prelude::*;
 use hexlit::hex;
 use rstest::rstest;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 pub mod samples {
     use super::*;
@@ -48,7 +48,10 @@ fn test_magic_struct(input: &[u8]) {
     assert_eq!(
         samples::MagicDeku{},
         ret_read
-    )
+    );
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(ret_write, input)
 }
 
 #[rstest(input,
@@ -78,7 +81,10 @@ fn test_magic_enum(input: &[u8]) {
     assert_eq!(
         samples::EnumMagicDeku::Variant,
         ret_read
-    )
+    );
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(ret_write, input)
 }
 
 #[rstest(input,
@@ -96,5 +102,8 @@ fn test_nested_magic_struct(input: &[u8]) {
     assert_eq!(
         samples::NestedMagicDeku{nested: samples::MagicDeku{}},
         ret_read
-    )
+    );
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(ret_write, input)
 }

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -1,0 +1,100 @@
+use deku::prelude::*;
+use hexlit::hex;
+use rstest::rstest;
+use std::convert::TryFrom;
+
+pub mod samples {
+    use super::*;
+
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(magic = b"deku")]
+    pub struct MagicDeku {}
+
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(magic = b"deku", type = "u8")]
+    pub enum EnumMagicDeku {
+        #[deku(id = "0")]
+        Variant,
+    }
+
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(magic = b"UKED")]
+    pub struct NestedMagicDeku {
+        pub nested: MagicDeku
+    }
+}
+
+#[rstest(input,
+    case(&hex!("64656b75")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("64656bde")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("6465ad75")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("64be6b75")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("ef656b75")),
+
+    #[should_panic(expected = "Parse(\"not enough data: expected 8 bits got 0 bits\")")]
+    case(&hex!("64656b")),
+)]
+fn test_magic_struct(input: &[u8]) {
+    let ret_read = samples::MagicDeku::try_from(input).unwrap();
+
+    assert_eq!(
+        samples::MagicDeku{},
+        ret_read
+    )
+}
+
+#[rstest(input,
+    case(&hex!("64656b7500")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("64656bde00")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("6465ad7500")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("64be6b7500")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("ef656b7500")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("64656b00")),
+
+    #[should_panic(expected = "Parse(\"not enough data: expected 8 bits got 0 bits\")")]
+    case(&hex!("64656b")),
+)]
+fn test_magic_enum(input: &[u8]) {
+    let ret_read = samples::EnumMagicDeku::try_from(input).unwrap();
+
+    assert_eq!(
+        samples::EnumMagicDeku::Variant,
+        ret_read
+    )
+}
+
+#[rstest(input,
+    case(&hex!("554b454464656b75")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    case(&hex!("554b4544deadbeef")),
+
+    #[should_panic(expected = "Parse(\"Missing magic value [85, 75, 69, 68]\")")]
+    case(&hex!("deadbeef64656b75")),
+)]
+fn test_nested_magic_struct(input: &[u8]) {
+    let ret_read = samples::NestedMagicDeku::try_from(input).unwrap();
+
+    assert_eq!(
+        samples::NestedMagicDeku{nested: samples::MagicDeku{}},
+        ret_read
+    )
+}

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -3,27 +3,6 @@ use hexlit::hex;
 use rstest::rstest;
 use std::convert::{TryFrom, TryInto};
 
-pub mod samples {
-    use super::*;
-
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(magic = b"deku")]
-    pub struct MagicDeku {}
-
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(magic = b"deku", type = "u8")]
-    pub enum EnumMagicDeku {
-        #[deku(id = "0")]
-        Variant,
-    }
-
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(magic = b"UKED")]
-    pub struct NestedMagicDeku {
-        pub nested: MagicDeku,
-    }
-}
-
 #[rstest(input,
     case(&hex!("64656b75")),
 
@@ -43,9 +22,13 @@ pub mod samples {
     case(&hex!("64656b")),
 )]
 fn test_magic_struct(input: &[u8]) {
-    let ret_read = samples::MagicDeku::try_from(input).unwrap();
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(magic = b"deku")]
+    pub struct TestStruct {}
 
-    assert_eq!(samples::MagicDeku {}, ret_read);
+    let ret_read = TestStruct::try_from(input).unwrap();
+
+    assert_eq!(TestStruct {}, ret_read);
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(ret_write, input)
@@ -73,33 +56,18 @@ fn test_magic_struct(input: &[u8]) {
     case(&hex!("64656b")),
 )]
 fn test_magic_enum(input: &[u8]) {
-    let ret_read = samples::EnumMagicDeku::try_from(input).unwrap();
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(magic = b"deku", type = "u8")]
+    pub enum TestEnum {
+        #[deku(id = "0")]
+        Variant,
+    }
 
-    assert_eq!(samples::EnumMagicDeku::Variant, ret_read);
+    let ret_read = TestEnum::try_from(input).unwrap();
 
-    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(ret_write, input)
-}
-
-#[rstest(input,
-    case(&hex!("554b454464656b75")),
-
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
-    case(&hex!("554b4544deadbeef")),
-
-    #[should_panic(expected = "Parse(\"Missing magic value [85, 75, 69, 68]\")")]
-    case(&hex!("deadbeef64656b75")),
-)]
-fn test_nested_magic_struct(input: &[u8]) {
-    let ret_read = samples::NestedMagicDeku::try_from(input).unwrap();
-
-    assert_eq!(
-        samples::NestedMagicDeku {
-            nested: samples::MagicDeku {}
-        },
-        ret_read
-    );
+    assert_eq!(TestEnum::Variant, ret_read);
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(ret_write, input)
 }
+

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -20,7 +20,7 @@ pub mod samples {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     #[deku(magic = b"UKED")]
     pub struct NestedMagicDeku {
-        pub nested: MagicDeku
+        pub nested: MagicDeku,
     }
 }
 
@@ -45,10 +45,7 @@ pub mod samples {
 fn test_magic_struct(input: &[u8]) {
     let ret_read = samples::MagicDeku::try_from(input).unwrap();
 
-    assert_eq!(
-        samples::MagicDeku{},
-        ret_read
-    );
+    assert_eq!(samples::MagicDeku {}, ret_read);
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(ret_write, input)
@@ -78,10 +75,7 @@ fn test_magic_struct(input: &[u8]) {
 fn test_magic_enum(input: &[u8]) {
     let ret_read = samples::EnumMagicDeku::try_from(input).unwrap();
 
-    assert_eq!(
-        samples::EnumMagicDeku::Variant,
-        ret_read
-    );
+    assert_eq!(samples::EnumMagicDeku::Variant, ret_read);
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(ret_write, input)
@@ -100,7 +94,9 @@ fn test_nested_magic_struct(input: &[u8]) {
     let ret_read = samples::NestedMagicDeku::try_from(input).unwrap();
 
     assert_eq!(
-        samples::NestedMagicDeku{nested: samples::MagicDeku{}},
+        samples::NestedMagicDeku {
+            nested: samples::MagicDeku {}
+        },
         ret_read
     );
 

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -70,4 +70,3 @@ fn test_magic_enum(input: &[u8]) {
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(ret_write, input)
 }
-


### PR DESCRIPTION
This PR as-is is an initial implementation of #109, hacked-in with very little experience in this library or with developing proc-macros in general.

It currently supports reads only, and is very specific to my use-case, so will want to be expanded to support writes and to be more useful in general, and will also want tests implementing and documentation adding for the new attribute.