### PR TITLE
Avoid `use core::convert::TryInto` in empty update

### DIFF
--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -98,10 +98,13 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         }
     };
 
+    // avoid outputing `use core::convert::TryInto` if update() function is empty
+    let update_use = check_use_update(&field_updates);
+
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
             fn update(&mut self) -> Result<(), DekuError> {
-                use core::convert::TryInto;
+                #update_use
                 #(#field_updates)*
 
                 Ok(())
@@ -284,10 +287,14 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         Ok(())
     };
+
+    // avoid outputing `use core::convert::TryInto` if update() function is empty
+    let update_use = check_use_update(&variant_updates);
+
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
             fn update(&mut self) -> Result<(), DekuError> {
-                use core::convert::TryInto;
+                #update_use
 
                 match self {
                     #(#variant_updates),*
@@ -426,4 +433,13 @@ fn emit_field_write(
     };
 
     Ok(field_write)
+}
+
+/// avoid outputing `use core::convert::TryInto` if update() function is generated with empty Vec
+fn check_use_update<T>(vec: &[T]) -> TokenStream {
+    if !vec.is_empty() {
+        quote! {use core::convert::TryInto;}
+    } else {
+        quote! {}
+    }
 }

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -99,7 +99,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
     };
 
     // avoid outputing `use core::convert::TryInto` if update() function is empty
-    let update_use = check_use_update(&field_updates);
+    let update_use = check_update_use(&field_updates);
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
@@ -289,7 +289,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     };
 
     // avoid outputing `use core::convert::TryInto` if update() function is empty
-    let update_use = check_use_update(&variant_updates);
+    let update_use = check_update_use(&variant_updates);
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
@@ -436,7 +436,7 @@ fn emit_field_write(
 }
 
 /// avoid outputing `use core::convert::TryInto` if update() function is generated with empty Vec
-fn check_use_update<T>(vec: &[T]) -> TokenStream {
+fn check_update_use<T>(vec: &[T]) -> TokenStream {
     if !vec.is_empty() {
         quote! {use core::convert::TryInto;}
     } else {


### PR DESCRIPTION
This is rather small, but it removes the quotes! for:
`use core::convert::TryInto` if the update() function has no need for
it.