### PR TITLE
Implement the backend for reading a vector until a predicate or until a number of bits

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -359,7 +359,7 @@ fn emit_field_read(
             quote! {
                 {
                     use core::borrow::Borrow;
-                    DekuRead::read(rest, (deku::ctx::Count(usize::try_from(*((#field_count).borrow()))?), (#read_args)))
+                    DekuRead::read(rest, (usize::try_from(*((#field_count).borrow()))?.into(), (#read_args)))
                 }
             }
         } else {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -73,7 +73,7 @@ impl FromStr for Endian {
     }
 }
 
-/// A limit placed on a contaner's elements
+/// A limit placed on a container's elements
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Limit<T, Predicate: FnMut(&T) -> bool> {
     /// Read a specific count of elements

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -81,6 +81,9 @@ pub enum Limit<T, Predicate: FnMut(&T) -> bool> {
 
     /// Read until a given predicate holds true
     Until(Predicate, PhantomData<T>),
+
+    /// Read until a given quantity of bits have been read
+    Bits(BitSize),
 }
 
 impl<T> From<usize> for Limit<T, fn(&T) -> bool> {
@@ -92,6 +95,12 @@ impl<T> From<usize> for Limit<T, fn(&T) -> bool> {
 impl<T, Predicate: for<'a> FnMut(&'a T) -> bool> From<Predicate> for Limit<T, Predicate> {
     fn from(predicate: Predicate) -> Self {
         Limit::Until(predicate, PhantomData)
+    }
+}
+
+impl<T> From<BitSize> for Limit<T, fn(&T) -> bool> {
+    fn from(bits: BitSize) -> Self {
+        Limit::Bits(bits)
     }
 }
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -72,33 +72,24 @@ impl FromStr for Endian {
     }
 }
 
-/// The count of a container's elements
+/// A limit placed on a contaner's elements
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Count(pub usize);
+pub enum Limit {
+    /// Read a specific count of elements
+    Count(usize),
+}
 
-impl Into<usize> for Count {
+impl Into<usize> for Limit {
     fn into(self) -> usize {
-        self.0
+        match self {
+            Limit::Count(count) => count,
+        }
     }
 }
 
-impl From<usize> for Count {
+impl From<usize> for Limit {
     fn from(n: usize) -> Self {
-        Self(n)
-    }
-}
-
-impl Deref for Count {
-    type Target = usize;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Count {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        Limit::Count(n)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -915,6 +915,10 @@ mod tests {
         case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![Msb0, u8;]),
         #[should_panic(expected = "Parse(\"not enough data: expected 8 bits got 0 bits\")")]
         case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(8), 2.into(), vec![], bits![Msb0, u8;]),
+        #[should_panic(expected = "Parse(\"not enough data: expected 8 bits got 0 bits\")")]
+        case::not_enough_data_until([0xAA].as_ref(), Endian::Little, Some(8), (|_: &u8| false).into(), vec![], bits![Msb0, u8;]),
+        #[should_panic(expected = "Parse(\"not enough data: expected 8 bits got 0 bits\")")]
+        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (BitSize(16)).into(), vec![], bits![Msb0, u8;]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
         case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![Msb0, u8;]),
     )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,8 +522,8 @@ fn read_vec_with_predicate<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(usize, 
 impl<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool> DekuRead<(Limit<T, Predicate>, Ctx)>
     for Vec<T>
 {
-    /// Read the specified number of `T`s from input.
-    /// * `count` - the number of `T`s you want to read.
+    /// Read `T`s until the given limit
+    /// * `limit` - the limiting factor on the amount of `T`s to read
     /// * `inner_ctx` - The context required by `T`. It will be passed to every `T`s when constructing.
     /// # Examples
     /// ```rust
@@ -575,7 +575,7 @@ impl<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool> DekuRead<(Limit<
 }
 
 impl<T: DekuRead, Predicate: FnMut(&T) -> bool> DekuRead<Limit<T, Predicate>> for Vec<T> {
-    /// Read the specified number of `T`s from input for types which don't require context.
+    /// Read `T`s until the given limit from input for types which don't require context.
     fn read(
         input: &BitSlice<Msb0, u8>,
         limit: Limit<T, Predicate>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,12 +500,18 @@ macro_rules! ImplDekuTraits {
 
 fn read_vec_with_predicate<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(usize, &T) -> bool>(
     input: &BitSlice<Msb0, u8>,
-    vec: Vec<T>,
+    capacity: Option<usize>,
     ctx: Ctx,
     mut predicate: Predicate,
 ) -> Result<(&BitSlice<Msb0, u8>, Vec<T>), DekuError> {
-    let mut res = vec;
+    let mut res = if let Some(capacity) = capacity {
+        Vec::with_capacity(capacity)
+    } else {
+        Vec::new()
+    };
+
     let mut rest = input;
+
     loop {
         let (new_rest, val) = <T>::read(rest, ctx)?;
         res.push(val);
@@ -551,7 +557,7 @@ impl<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool> DekuRead<(Limit<
                 }
 
                 // Otherwise, read until we have read `count` elements
-                read_vec_with_predicate(input, Vec::with_capacity(count), inner_ctx, move |_, _| {
+                read_vec_with_predicate(input, Some(count), inner_ctx, move |_, _| {
                     count -= 1;
                     count == 0
                 })
@@ -559,14 +565,14 @@ impl<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool> DekuRead<(Limit<
 
             // Read until a given predicate returns true
             Limit::Until(mut predicate, _) => {
-                read_vec_with_predicate(input, Vec::new(), inner_ctx, move |_, value| {
+                read_vec_with_predicate(input, None, inner_ctx, move |_, value| {
                     predicate(value)
                 })
             }
 
             // Read until a given quanity of bits have been read
             Limit::Bits(bits) => {
-                read_vec_with_predicate(input, Vec::new(), inner_ctx, move |read_bits, _| {
+                read_vec_with_predicate(input, None, inner_ctx, move |read_bits, _| {
                     read_bits == bits.into()
                 })
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,8 @@ fn read_vec_with_predicate<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(usize, 
         res.push(val);
         rest = new_rest;
 
+        // This unwrap is safe as we are pushing to the vec immediately before it,
+        // so there will always be a last element
         if predicate(input.offset_from(rest) as usize, res.last().unwrap()) {
             break;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,9 +574,7 @@ impl<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool> DekuRead<(Limit<
 
             // Read until a given predicate returns true
             Limit::Until(mut predicate, _) => {
-                read_vec_with_predicate(input, None, inner_ctx, move |_, value| {
-                    predicate(value)
-                })
+                read_vec_with_predicate(input, None, inner_ctx, move |_, value| predicate(value))
             }
 
             // Read until a given quanity of bits have been read

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,6 +498,13 @@ macro_rules! ImplDekuTraits {
     };
 }
 
+/// Read `T`s into a vec until a given predicate returns true
+/// * `capacity` - an optional capacity to pre-allocate the vector with
+/// * `ctx` - The context required by `T`. It will be passed to every `T` when constructing.
+/// * `predicate` - the predicate that decides when to stop reading `T`s
+/// The predicate takes two parameters: the number of bits that have been read so far,
+/// and a borrow of the latest value to have been read. It should return `true` if reading
+/// should now stop, and `false` otherwise
 fn read_vec_with_predicate<T: DekuRead<Ctx>, Ctx: Copy, Predicate: FnMut(usize, &T) -> bool>(
     input: &BitSlice<Msb0, u8>,
     capacity: Option<usize>,


### PR DESCRIPTION
This PR implements a potential backend (i.e., the context types only, and no proc-macros to use them yet) for both #110 and #76. I've done it like this to make sure we're happy with how this is implemented before I go any further, as this is a rather important breaking change (and also because the latter of those issues has not yet reached a conclusion as to the attribute it would use).

We convert the `Count` context type into a `Limit` enum, allowing either a count (the original behaviour), a number of bits, or a general predicate.

Annoyingly, the `Limit` type is now quite ugly, due to the need to have type parameters for the `Until` variant - I cannot think of any particularly nice options here. The best alternative is probably to template `Limit` on `<T>` only, and then take a `&mut dyn FnMut` in the `Until` variant, but I'm open to any suggestions here. Potentialy however, this ugliness doesn't _really_ matter, as the type is mostly designed to be hidden behind the nice proc-macro attributes once those are actually implemented for the two new cases.