### PR TITLE
feat: Add `temp` attribute

### DIFF
--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -86,7 +86,7 @@ fn gen_struct_destruction<I: ToTokens, F: ToTokens>(
 
 /// Convert a field ident to internal ident:
 /// `a` -> `__deku_a`
-fn gen_internal_field_ident(ident: TokenStream) -> TokenStream {
+fn gen_internal_field_ident(ident: &TokenStream) -> TokenStream {
     // Concat token: https://github.com/rust-lang/rust/issues/29599
     let span = ident.span();
     let s = ident.to_string();
@@ -100,7 +100,7 @@ fn gen_internal_field_ident(ident: TokenStream) -> TokenStream {
 ///
 /// - Named: `{ a: __deku_a }`
 /// - Unnamed: `( __deku_a )`
-fn gen_internal_field_idents(named: bool, idents: Vec<TokenStream>) -> Vec<TokenStream> {
+fn gen_internal_field_idents(named: bool, idents: Vec<&TokenStream>) -> Vec<TokenStream> {
     if named {
         idents
             .into_iter()

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -14,6 +14,7 @@ A documentation-only module for #\[deku\] attributes
 | [bytes_read](#bytes_read) | field | Set the field representing the number of bytes to read into a container
 | [until](#until) | field | Set a predicate returning when to stop reading elements into a container
 | [update](#update) | field | Apply code over the field when `.update()` is called
+| [temp](#temp) | field | Read the field but exclude it from the struct/enum
 | [skip](#skip) | field | Skip the reading/writing of a field
 | [cond](#cond) | field | Conditional expression for the field
 | [default](#default) | field | Custom defaulting code when `skip` is true
@@ -358,6 +359,45 @@ assert_eq!(
 
 let value: Vec<u8> = value.try_into().unwrap();
 assert_eq!(vec![0x03, 0xAB, 0xCD, 0xFF], value);
+```
+
+# temp
+
+A temporary field
+
+Included in the reading of the struct/enum but not stored
+
+**Note**: Struct/enum must be derived with `#[deku_derive(...)]` to derive
+`DekuRead` and/or `DekuWrite`, not with `#[derive(...)]`. This is because the
+struct/enum needs to be modified at compile time.
+
+Example:
+```rust
+# use deku::prelude::*;
+# use std::convert::{TryInto, TryFrom};
+#[deku_derive(DekuRead, DekuWrite)]
+#[derive(Debug, PartialEq)]
+struct DekuTest {
+    #[deku(temp)]
+    num_items: u8,
+
+    #[deku(count = "num_items", endian = "big")]
+    items: Vec<u16>,
+}
+
+let data: Vec<u8> = vec![0x01, 0xBE, 0xEF];
+
+let value = DekuTest::try_from(data.as_ref()).unwrap();
+
+assert_eq!(
+    DekuTest {
+       items: vec![0xBEEF]
+    },
+    value
+);
+
+let value: Vec<u8> = value.try_into().unwrap();
+assert_eq!(vec![0xBE, 0xEF], value);
 ```
 
 # skip

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,7 +3,8 @@
 [What is a prelude?](std::prelude)
 */
 pub use crate::{
-    error::DekuError, DekuContainerRead, DekuContainerWrite, DekuRead, DekuUpdate, DekuWrite,
+    deku_derive, error::DekuError, DekuContainerRead, DekuContainerWrite, DekuRead, DekuUpdate,
+    DekuWrite,
 };
 pub use bitvec::{
     order::BitOrder, order::Lsb0, order::Msb0, slice::BitSlice, vec::BitVec, view::BitView,

--- a/tests/test_attributes/mod.rs
+++ b/tests/test_attributes/mod.rs
@@ -2,5 +2,6 @@ mod test_cond;
 mod test_ctx;
 mod test_map;
 mod test_skip;
+mod test_temp;
 mod test_update;
 mod test_vec_limits;

--- a/tests/test_attributes/test_temp.rs
+++ b/tests/test_attributes/test_temp.rs
@@ -1,0 +1,71 @@
+use deku::prelude::*;
+use std::convert::{TryFrom, TryInto};
+
+#[test]
+fn test_temp_field() {
+    #[deku_derive(DekuRead, DekuWrite)]
+    #[derive(PartialEq, Debug)]
+    struct TestStruct {
+        #[deku(temp)]
+        field_a: u8,
+        #[deku(count = "field_a")]
+        field_b: Vec<u8>,
+    }
+
+    let test_data: Vec<u8> = [0x01, 0x02].to_vec();
+
+    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    assert_eq!(
+        TestStruct {
+            field_b: vec![0x02]
+        },
+        ret_read
+    );
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(test_data[1..].to_vec(), ret_write);
+}
+
+#[test]
+fn test_temp_field_unnamed() {
+    #[deku_derive(DekuRead, DekuWrite)]
+    #[derive(PartialEq, Debug)]
+    struct TestStruct(#[deku(temp)] u8, #[deku(count = "field_0")] Vec<u8>);
+
+    let test_data: Vec<u8> = [0x01, 0x02].to_vec();
+
+    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    assert_eq!(TestStruct(vec![0x02]), ret_read);
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(test_data[1..].to_vec(), ret_write);
+}
+
+#[test]
+fn test_temp_enum_field() {
+    #[deku_derive(DekuRead, DekuWrite)]
+    #[derive(PartialEq, Debug)]
+    #[deku(type = "u8")]
+    enum TestEnum {
+        #[deku(id = "0xAB")]
+        VarA {
+            #[deku(temp)]
+            field_a: u8,
+            #[deku(count = "field_a")]
+            field_b: Vec<u8>,
+        },
+    };
+
+    let test_data: Vec<u8> = [0xAB, 0x01, 0x02].to_vec();
+
+    let ret_read = TestEnum::try_from(test_data.as_ref()).unwrap();
+    assert_eq!(
+        TestEnum::VarA {
+            field_b: vec![0x02]
+        },
+        ret_read
+    );
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(vec![0xAB, 0x02], ret_write);
+}

--- a/tests/test_compile/cases/temp_field.rs
+++ b/tests/test_compile/cases/temp_field.rs
@@ -1,0 +1,8 @@
+use deku::prelude::*;
+
+// wrong way to use temp
+#[derive(DekuRead, DekuWrite)]
+struct Test1 {
+    #[deku(temp)]
+    field_a: u8,
+}

--- a/tests/test_compile/cases/temp_field.stderr
+++ b/tests/test_compile/cases/temp_field.stderr
@@ -1,0 +1,19 @@
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> $DIR/temp_field.rs:1:1
+  |
+1 | / use deku::prelude::*;
+2 | |
+3 | | // wrong way to use temp
+4 | | #[derive(DekuRead, DekuWrite)]
+... |
+7 | |     field_a: u8,
+8 | | }
+  | |_^ consider adding a `main` function to `$DIR/tests/test_compile/cases/temp_field.rs`
+
+error[E0063]: missing field `field_a` in initializer of `Test1`
+ --> $DIR/temp_field.rs:4:10
+  |
+4 | #[derive(DekuRead, DekuWrite)]
+  |          ^^^^^^^^ missing `field_a`
+  |
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Related: https://github.com/sharksforarms/deku/issues/120

Example
```rust
use deku::prelude::*;
use std::convert::{TryFrom, TryInto};

// Note: new `deku_derive` vs `derive`, this is needed only for structs/enums which use `temp`
#[deku_derive(DekuRead, DekuWrite)]
#[derive(PartialEq, Debug)]
struct TestStruct {
    #[deku(temp)]
    field_a: u8,
    #[deku(count = "field_a")]
    field_b: Vec<u8>,
}

fn main() {
    let test_data: Vec<u8> = [0x01, 0x02].to_vec();

    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
    assert_eq!(
        TestStruct {
            field_b: vec![0x02]
        },
        ret_read
    );

    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
    assert_eq!(test_data[1..].to_vec(), ret_write);
}
```