### PR TITLE
construct darling::ast::Fields with ::new

### DIFF
--- a/deku-derive/Cargo.toml
+++ b/deku-derive/Cargo.toml
@@ -17,7 +17,7 @@ syn = "1.0"
 # extra-traits gives us Debug
 # syn = {version = "1.0", features = ["extra-traits"]}
 proc-macro2 = "1.0"
-darling = "0.10"
+darling = "0.10.3"
 
 [dev-dependencies]
 rstest = "0.6"

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -54,14 +54,14 @@ impl DekuData {
             .map_err(|(span, msg)| syn::Error::new(span, msg).to_compile_error())?;
 
         let data = match receiver.data {
-            ast::Data::Struct(fields) => ast::Data::Struct(ast::Fields {
-                style: fields.style,
-                fields: fields
+            ast::Data::Struct(fields) => ast::Data::Struct(ast::Fields::new(
+                fields.style,
+                fields
                     .fields
                     .into_iter()
                     .map(FieldData::from_receiver)
                     .collect::<Result<Vec<_>, _>>()?,
-            }),
+            )),
             ast::Data::Enum(variants) => ast::Data::Enum(
                 variants
                     .into_iter()
@@ -369,15 +369,15 @@ impl VariantData {
         VariantData::validate(&receiver)
             .map_err(|(span, msg)| syn::Error::new(span, msg).to_compile_error())?;
 
-        let fields = ast::Fields {
-            style: receiver.fields.style,
-            fields: receiver
+        let fields = ast::Fields::new(
+            receiver.fields.style,
+            receiver
                 .fields
                 .fields
                 .into_iter()
                 .map(FieldData::from_receiver)
                 .collect::<Result<Vec<_>, _>>()?,
-        };
+        );
 
         Ok(Self {
             ident: receiver.ident,


### PR DESCRIPTION
Since darling [made a breaking change](https://github.com/TedDriggs/darling/pull/87) (allowed by the 0.x.y semantic version range without a major bump) deku-derive has been broken. This was merged in January but the update was only published 2 days ago on crates.io.

This patch only replaces `ast::Fields { .. }` with `ast::Fields::new(..)`.