### PR TITLE
deps: Bumped hexlit to 0.4.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ deku_derive = { version = "^0.9.0", path = "deku-derive" }
 bitvec = { version = "0.19.4", default-features = false }
 
 [dev-dependencies]
-hexlit = "0.3.0"
+hexlit = "0.4.0"
 rstest = "0.6"
 criterion = "0.3"
 alloc_counter = "0.0.4"


### PR DESCRIPTION
This PR bumps hexlit from 0.3.0 to 0.4.0, which has faster macro-expansion and less generated code.