### PR TITLE
Add deku_id()

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -371,7 +371,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         &ctx_types
     };
     let deku_id = quote! {
-        impl #ident {
+        impl #imp DekuEnumExt<#lifetime, #deku_id_id_type> for #ident #wher {
             fn deku_id(&self) -> Result<#deku_id_id_type, DekuError> {
                 match self {
                     #(#deku_ids ,)*

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -1,7 +1,8 @@
 use crate::{
     macros::{
         gen_ctx_types_and_arg, gen_field_args, gen_id_args, gen_internal_field_ident,
-        gen_internal_field_idents, pad_bits, gen_type_from_ctx_id, token_contains_string, wrap_default_ctx,
+        gen_internal_field_idents, gen_type_from_ctx_id, pad_bits, token_contains_string,
+        wrap_default_ctx,
     },
     Id,
 };

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -370,24 +370,12 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     } else {
         &ctx_types
     };
-    let deku_id = if deku_ids.is_empty() {
-        quote! {
-            impl #ident {
-                fn deku_id(&self) -> Result<#deku_id_id_type, DekuError> {
-                    match self {
-                        _ => Err(DekuError::IdVariantNotFound),
-                    }
-                }
-            }
-        }
-    } else {
-        quote! {
-            impl #ident {
-                fn deku_id(&self) -> Result<#deku_id_id_type, DekuError> {
-                    match self {
-                        #(#deku_ids),*,
-                        _ => Err(DekuError::IdVariantNotFound),
-                    }
+    let deku_id = quote! {
+        impl #ident {
+            fn deku_id(&self) -> Result<#deku_id_id_type, DekuError> {
+                match self {
+                    #(#deku_ids ,)*
+                    _ => Err(DekuError::IdVariantNotFound),
                 }
             }
         }

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -364,8 +364,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     }
 
     // create `deku_id` function for retrieving at runtime the id value
-    let deku_id_id_type = if id_type.is_some() || input.ctx.is_none() {
-        id_type.unwrap()
+    let deku_id_id_type = if let Some(id_type) = id_type {
+        id_type
     } else {
         &ctx_types
     };

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -128,6 +128,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         });
     }
 
+    // println!("{}", tokens.to_string());
     Ok(tokens)
 }
 
@@ -392,6 +393,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     };
     tokens.extend(deku_id);
 
+    // println!("{}", tokens.to_string());
     Ok(tokens)
 }
 

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -363,7 +363,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         });
     }
 
-    // create `deku_id()` function for retrieving at runtime the id value
+    // Implement `DekuEnumExt`
     let deku_id_id_type = if let Some(id_type) = id_type {
         id_type
     } else {

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -1,7 +1,7 @@
 use crate::{
     macros::{
         gen_ctx_types_and_arg, gen_field_args, gen_id_args, gen_internal_field_ident,
-        gen_internal_field_idents, pad_bits, token_contains_string, wrap_default_ctx,
+        gen_internal_field_idents, pad_bits, gen_type_from_ctx_id, token_contains_string, wrap_default_ctx,
     },
     Id,
 };
@@ -327,7 +327,6 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             from_bytes_body,
         ));
     }
-
     let (ctx_types, ctx_arg) = gen_ctx_types_and_arg(input.ctx.as_ref())?;
 
     let read_body = quote! {
@@ -365,9 +364,10 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     // Implement `DekuEnumExt`
     let deku_id_id_type = if let Some(id_type) = id_type {
-        id_type
+        quote! {#id_type}
     } else {
-        &ctx_types
+        let r = gen_type_from_ctx_id(input.ctx.as_ref(), input.id.as_ref())?;
+        quote! {#r}
     };
     let deku_id = quote! {
         impl #imp DekuEnumExt<#lifetime, #deku_id_id_type> for #ident #wher {

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -160,6 +160,30 @@ fn gen_ctx_types_and_arg(
     }
 }
 
+/// Generate type from matching ident from `id` in `ctx`
+fn gen_type_from_ctx_id(
+    ctx: Option<&Punctuated<syn::FnArg, syn::token::Comma>>,
+    id: Option<&crate::Id>,
+) -> syn::Result<TokenStream> {
+    let id = syn::parse_str::<syn::Ident>(&id.unwrap().to_string()).unwrap();
+    if let Some(ctx) = ctx {
+        for c in ctx {
+            match c {
+                syn::FnArg::Typed(pat_type) => {
+                    if let syn::Pat::Ident(ident) = &*pat_type.pat {
+                        if id == ident.ident {
+                            let t = &pat_type.ty;
+                            return Ok(quote! {#t});
+                        }
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+    unreachable!()
+}
+
 /// Generate argument for `id`:
 /// `#deku(endian = "big", bits = "1")` -> `Endian::Big, Size::Bits(1)`
 fn gen_id_args(

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -161,6 +161,8 @@ fn gen_ctx_types_and_arg(
 }
 
 /// Generate type from matching ident from `id` in `ctx`
+///
+/// Given #[deku(ctx = "test: u16, my_id: u8", id = "my_id")], will return `u8`
 fn gen_type_from_ctx_id(
     ctx: Option<&Punctuated<syn::FnArg, syn::token::Comma>>,
     id: Option<&crate::Id>,

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -39,4 +39,7 @@ fn main() {
     let ret_out: Vec<u8> = deku_test.to_bytes().unwrap();
 
     assert_eq!(test_data, ret_out);
+
+    let id_first_byte = deku_test.deku_id();
+    assert_eq!(Ok(test_data[0]), id_first_byte);
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,8 @@ pub enum DekuError {
     Unexpected(String),
     /// Assertion error from `assert` or `assert_eq` attributes
     Assertion(String),
+    /// `id` attribute not found in `deku_id()`
+    IdVariantNotFound,
 }
 
 impl From<core::num::TryFromIntError> for DekuError {
@@ -74,6 +76,7 @@ impl core::fmt::Display for DekuError {
             DekuError::InvalidParam(ref err) => write!(f, "Invalid param error: {}", err),
             DekuError::Unexpected(ref err) => write!(f, "Unexpected error: {}", err),
             DekuError::Assertion(ref err) => write!(f, "Assertion error: {}", err),
+            DekuError::IdVariantNotFound => write!(f, "deku id for variant not found"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,7 @@ pub enum DekuError {
     Unexpected(String),
     /// Assertion error from `assert` or `assert_eq` attributes
     Assertion(String),
-    /// `id` attribute not found in `deku_id()`
+    /// Could not resolve `id` for variant
     IdVariantNotFound,
 }
 
@@ -76,7 +76,7 @@ impl core::fmt::Display for DekuError {
             DekuError::InvalidParam(ref err) => write!(f, "Invalid param error: {}", err),
             DekuError::Unexpected(ref err) => write!(f, "Unexpected error: {}", err),
             DekuError::Assertion(ref err) => write!(f, "Assertion error: {}", err),
-            DekuError::IdVariantNotFound => write!(f, "deku id for variant not found"),
+            DekuError::IdVariantNotFound => write!(f, "Could not resolve `id` for variant"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,3 +330,9 @@ pub trait DekuUpdate {
     /// Apply updates
     fn update(&mut self) -> Result<(), DekuError>;
 }
+
+/// "Extended Enum" trait: obtain additional enum information
+pub trait DekuEnumExt<'a, T> {
+    /// Obtain `id` of a given enum variant
+    fn deku_id(&self) -> Result<T, DekuError>;
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,7 +4,7 @@
 */
 pub use crate::{
     deku_derive, error::DekuError, error::NeedSize, DekuContainerRead, DekuContainerWrite,
-    DekuRead, DekuUpdate, DekuWrite,
+    DekuEnumExt, DekuRead, DekuUpdate, DekuWrite,
 };
 pub use bitvec::{
     order::BitOrder, order::Lsb0, order::Msb0, slice::BitSlice, vec::BitVec, view::BitView,

--- a/tests/test_deku_id.rs
+++ b/tests/test_deku_id.rs
@@ -12,8 +12,8 @@ fn test_regular() {
         Dogs { ball: u8 },
     }
 
-    assert_eq!(0x01, Request1::Cats { toy: 0 }.deku_id());
-    assert_eq!(0x10, Request1::Dogs { ball: 0 }.deku_id());
+    assert_eq!(Ok(0x01), Request1::Cats { toy: 0 }.deku_id());
+    assert_eq!(Ok(0x10), Request1::Dogs { ball: 0 }.deku_id());
 }
 
 #[test]
@@ -38,8 +38,8 @@ fn test_custom_type() {
         Dogs,
     }
 
-    assert_eq!(Request2::Cats, Request3::Cats.deku_id());
-    assert_eq!(Request2::Dogs, Request3::Dogs.deku_id());
+    assert_eq!(Ok(Request2::Cats), Request3::Cats.deku_id());
+    assert_eq!(Ok(Request2::Dogs), Request3::Dogs.deku_id());
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn test_ctx() {
         VarB,
     }
 
-    assert_eq!(1, EnumId::VarA(0).deku_id());
+    assert_eq!(Ok(1), EnumId::VarA(0).deku_id());
 
     #[derive(Copy, Clone, PartialEq, Debug, DekuRead, DekuWrite)]
     #[deku(type = "u8")]
@@ -87,8 +87,8 @@ fn test_ctx() {
         VarB,
     }
 
-    assert_eq!(Nice::True, EnumId2::VarA(0).deku_id());
-    assert_eq!(Nice::False, EnumId2::VarB.deku_id());
+    assert_eq!(Ok(Nice::True), EnumId2::VarA(0).deku_id());
+    assert_eq!(Ok(Nice::False), EnumId2::VarB.deku_id());
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test_ctx_and_type() {
         VariantA(u8),
     }
 
-    assert_eq!(1, TopLevelCtxEnum::VariantA(0).deku_id());
+    assert_eq!(Ok(1), TopLevelCtxEnum::VariantA(0).deku_id());
 }
 
 #[test]
@@ -114,5 +114,5 @@ fn test_advanced() {
         VarB,
     }
 
-    assert_eq!(b"123", &TestEnumArray::VarA.deku_id());
+    assert_eq!(b"123", TestEnumArray::VarA.deku_id().unwrap().as_ref());
 }

--- a/tests/test_deku_id.rs
+++ b/tests/test_deku_id.rs
@@ -63,7 +63,7 @@ fn test_ctx() {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(ctx = "my_id: Nice, other_id: u8", id = "my_id")]
+    #[deku(ctx = "my_id: Nice, _other_id: u8", id = "my_id")]
     enum EnumId2 {
         #[deku(id = "Nice::True")]
         VarA(u8),

--- a/tests/test_deku_id.rs
+++ b/tests/test_deku_id.rs
@@ -63,7 +63,7 @@ fn test_ctx() {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(ctx = "my_id: Nice", id = "my_id")]
+    #[deku(ctx = "my_id: Nice, other_id: u8", id = "my_id")]
     enum EnumId2 {
         #[deku(id = "Nice::True")]
         VarA(u8),

--- a/tests/test_deku_id.rs
+++ b/tests/test_deku_id.rs
@@ -1,0 +1,118 @@
+use deku::prelude::*;
+
+#[test]
+fn test_regular() {
+    #[derive(Debug, DekuRead, DekuWrite)]
+    #[deku(type = "u8")]
+    enum Request1 {
+        #[deku(id = "0x01")]
+        Cats { toy: u8 },
+
+        #[deku(id = "0x10")]
+        Dogs { ball: u8 },
+    }
+
+    assert_eq!(0x01, Request1::Cats { toy: 0 }.deku_id());
+    assert_eq!(0x10, Request1::Dogs { ball: 0 }.deku_id());
+}
+
+#[test]
+fn test_custom_type() {
+    #[derive(Debug, DekuRead, PartialEq, DekuWrite)]
+    #[deku(type = "u8")]
+    enum Request2 {
+        #[deku(id = "0x01")]
+        Cats,
+
+        #[deku(id = "0x10")]
+        Dogs,
+    }
+
+    #[derive(Debug, DekuRead, DekuWrite)]
+    #[deku(type = "Request2")]
+    enum Request3 {
+        #[deku(id = "Request2::Cats")]
+        Cats,
+
+        #[deku(id = "Request2::Dogs")]
+        Dogs,
+    }
+
+    assert_eq!(Request2::Cats, Request3::Cats.deku_id());
+    assert_eq!(Request2::Dogs, Request3::Dogs.deku_id());
+}
+
+#[test]
+fn test_ctx() {
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    struct StructEnumId {
+        my_id: u8,
+        data: u8,
+        #[deku(ctx = "*my_id")]
+        enum_from_id: EnumId,
+    }
+
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(ctx = "my_id: u8", id = "my_id")]
+    enum EnumId {
+        #[deku(id = "1")]
+        VarA(u8),
+        #[deku(id = "2")]
+        VarB,
+    }
+
+    assert_eq!(1, EnumId::VarA(0).deku_id());
+
+    #[derive(Copy, Clone, PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(type = "u8")]
+    enum Nice {
+        True = 0x00,
+        False = 0x01,
+    }
+
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    struct StructEnumId2 {
+        my_id: Nice,
+        data: u8,
+        #[deku(ctx = "*my_id")]
+        enum_from_id: EnumId2,
+    }
+
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(ctx = "my_id: Nice", id = "my_id")]
+    enum EnumId2 {
+        #[deku(id = "Nice::True")]
+        VarA(u8),
+        #[deku(id = "Nice::False")]
+        VarB,
+    }
+
+    assert_eq!(Nice::True, EnumId2::VarA(0).deku_id());
+    assert_eq!(Nice::False, EnumId2::VarB.deku_id());
+}
+
+#[test]
+fn test_ctx_and_type() {
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(type = "u8", ctx = "_a: u8, _b: u8")]
+    enum TopLevelCtxEnum {
+        #[deku(id = "1")]
+        VariantA(u8),
+    }
+
+    assert_eq!(1, TopLevelCtxEnum::VariantA(0).deku_id());
+}
+
+#[test]
+fn test_advanced() {
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(type = "[u8; 3]")]
+    enum TestEnumArray {
+        #[deku(id = b"123")]
+        VarA,
+        #[deku(id = "[1,1,1]")]
+        VarB,
+    }
+
+    assert_eq!(b"123", &TestEnumArray::VarA.deku_id());
+}

--- a/tests/test_deku_id.rs
+++ b/tests/test_deku_id.rs
@@ -100,3 +100,15 @@ fn test_litbytestr() {
 
     assert_eq!(b"123", TestEnumArray::VarA.deku_id().unwrap().as_ref());
 }
+
+#[test]
+#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: IdVariantNotFound")]
+fn test_no_id_discriminant() {
+    #[derive(Debug, DekuRead, PartialEq, DekuWrite)]
+    #[deku(type = "u8")]
+    enum Discriminant {
+        Cats = 0x01,
+        Dogs,
+    }
+    Discriminant::Dogs.deku_id().unwrap();
+}

--- a/tests/test_deku_id.rs
+++ b/tests/test_deku_id.rs
@@ -45,14 +45,6 @@ fn test_custom_type() {
 #[test]
 fn test_ctx() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    struct StructEnumId {
-        my_id: u8,
-        data: u8,
-        #[deku(ctx = "*my_id")]
-        enum_from_id: EnumId,
-    }
-
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     #[deku(ctx = "my_id: u8", id = "my_id")]
     enum EnumId {
         #[deku(id = "1")]
@@ -68,14 +60,6 @@ fn test_ctx() {
     enum Nice {
         True = 0x00,
         False = 0x01,
-    }
-
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    struct StructEnumId2 {
-        my_id: Nice,
-        data: u8,
-        #[deku(ctx = "*my_id")]
-        enum_from_id: EnumId2,
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
@@ -104,7 +88,7 @@ fn test_ctx_and_type() {
 }
 
 #[test]
-fn test_advanced() {
+fn test_litbytestr() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     #[deku(type = "[u8; 3]")]
     enum TestEnumArray {

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -86,16 +86,17 @@ fn test_enum_discriminant(input: &[u8], expected: TestEnumDiscriminant) {
     assert_eq!(input.to_vec(), ret_write);
 }
 
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+#[deku(type = "[u8; 3]")]
+enum TestEnumArray {
+    #[deku(id = b"123")]
+    VarA,
+    #[deku(id = "[1,1,1]")]
+    VarB,
+}
+
 #[test]
 fn test_enum_array_type() {
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(type = "[u8; 3]")]
-    enum TestEnumArray {
-        #[deku(id = b"123")]
-        VarA,
-        #[deku(id = "[1,1,1]")]
-        VarB,
-    }
 
     let input = b"123".as_ref();
 
@@ -104,4 +105,16 @@ fn test_enum_array_type() {
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(input.to_vec(), ret_write);
+}
+
+#[test]
+fn test_deku_id() {
+    let test_id = TestEnum::VarA(0).deku_id();
+    assert_eq!(1, test_id);
+
+    let test_id = TestEnum::VarB(0, 0).deku_id();
+    assert_eq!(2, test_id);
+
+    let test_id = TestEnumArray::VarA.deku_id();
+    assert_eq!(b"123", &test_id);
 }

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -85,3 +85,23 @@ fn test_enum_discriminant(input: &[u8], expected: TestEnumDiscriminant) {
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(input.to_vec(), ret_write);
 }
+
+#[test]
+fn test_enum_array_type() {
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(type = "[u8; 3]")]
+    enum TestEnumArray {
+        #[deku(id = b"123")]
+        VarA,
+        #[deku(id = "[1,1,1]")]
+        VarB,
+    }
+
+    let input = b"123".as_ref();
+
+    let ret_read = TestEnumArray::try_from(input).unwrap();
+    assert_eq!(TestEnumArray::VarA, ret_read);
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(input.to_vec(), ret_write);
+}

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -85,36 +85,3 @@ fn test_enum_discriminant(input: &[u8], expected: TestEnumDiscriminant) {
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(input.to_vec(), ret_write);
 }
-
-#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "[u8; 3]")]
-enum TestEnumArray {
-    #[deku(id = b"123")]
-    VarA,
-    #[deku(id = "[1,1,1]")]
-    VarB,
-}
-
-#[test]
-fn test_enum_array_type() {
-
-    let input = b"123".as_ref();
-
-    let ret_read = TestEnumArray::try_from(input).unwrap();
-    assert_eq!(TestEnumArray::VarA, ret_read);
-
-    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(input.to_vec(), ret_write);
-}
-
-#[test]
-fn test_deku_id() {
-    let test_id = TestEnum::VarA(0).deku_id();
-    assert_eq!(1, test_id);
-
-    let test_id = TestEnum::VarB(0, 0).deku_id();
-    assert_eq!(2, test_id);
-
-    let test_id = TestEnumArray::VarA.deku_id();
-    assert_eq!(b"123", &test_id);
-}


### PR DESCRIPTION
This creates a `deku_id()` function for enums that gives a user the ability for knowing the id of a enum variant at runtime. See https://github.com/sharksforarms/deku/issues/141

Any comments you have would be great! I'm still new to more advanced TokenStream _fun_.

- Having some issues with implementing the Generic part of the enum, and not sure how to implement that part of the code generation.
```
error[E0412]: cannot find type `T` in this scope
  --> src/lib.rs:89:15
   |
89 | enum TestEnum<T>
   |               ^ not found in this scope

error: aborting due to previous error
```
- Not sure on if you want this to be a trait function grouped with `DekuRead`?
- I have more testing I can throw in that enum test file