### PR TITLE
feat: Use crate name in proc-macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ members = [
 ]
 
 [features]
-default = ["std", "bitvec/std"]
-std = ["alloc"]
+default = ["std"]
+std = ["deku_derive/std", "bitvec/std", "alloc"]
 alloc = ["bitvec/alloc"]
 
 [dependencies]
-deku_derive = { version = "^0.10.0", path = "deku-derive" }
+deku_derive = { version = "^0.10.0", path = "deku-derive", default-features = false}
 bitvec = { version = "0.21.0", default-features = false }
 
 [dev-dependencies]

--- a/deku-derive/Cargo.toml
+++ b/deku-derive/Cargo.toml
@@ -11,6 +11,9 @@ readme = "../README.md"
 [lib]
 proc-macro = true
 
+[features]
+std = ["proc-macro-crate"]
+
 [dependencies]
 quote = "1.0"
 syn = "1.0"
@@ -18,6 +21,7 @@ syn = "1.0"
 # syn = {version = "1.0", features = ["extra-traits"]}
 proc-macro2 = "1.0"
 darling = "0.11"
+proc-macro-crate = { version = "0.1.4", optional = true }
 
 [dev-dependencies]
 rstest = "0.6"

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -23,6 +23,7 @@ pub(crate) fn emit_deku_read(input: &DekuData) -> Result<TokenStream, syn::Error
 }
 
 fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
+    let crate_ = super::get_crate_name();
     let mut tokens = TokenStream::new();
 
     let lifetime = input
@@ -66,7 +67,8 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         let from_bytes_body = wrap_default_ctx(
             quote! {
                 use core::convert::TryFrom;
-                let __deku_input_bits = __deku_input.0.view_bits::<Msb0>();
+                use ::#crate_::bitvec::BitView;
+                let __deku_input_bits = __deku_input.0.view_bits::<::#crate_::bitvec::Msb0>();
 
                 let mut __deku_rest = __deku_input_bits;
                 __deku_rest = &__deku_rest[__deku_input.1..];
@@ -111,8 +113,8 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
     };
 
     tokens.extend(quote! {
-        impl #imp DekuRead<#lifetime, #ctx_types> for #ident #wher {
-            fn read(__deku_input_bits: &#lifetime BitSlice<Msb0, u8>, #ctx_arg) -> Result<(&#lifetime BitSlice<Msb0, u8>, Self), DekuError> {
+        impl #imp ::#crate_::DekuRead<#lifetime, #ctx_types> for #ident #wher {
+            fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<::#crate_::bitvec::Msb0, u8>, #ctx_arg) -> Result<(&#lifetime ::#crate_::bitvec::BitSlice<::#crate_::bitvec::Msb0, u8>, Self), ::#crate_::DekuError> {
                 #read_body
             }
         }
@@ -122,8 +124,8 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         let read_body = wrap_default_ctx(read_body, &input.ctx, &input.ctx_default);
 
         tokens.extend(quote! {
-            impl #imp DekuRead<#lifetime> for #ident #wher {
-                fn read(__deku_input_bits: &#lifetime BitSlice<Msb0, u8>, _: ()) -> Result<(&#lifetime BitSlice<Msb0, u8>, Self), DekuError> {
+            impl #imp ::#crate_::DekuRead<#lifetime> for #ident #wher {
+                fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<::#crate_::bitvec::Msb0, u8>, _: ()) -> Result<(&#lifetime ::#crate_::bitvec::BitSlice<::#crate_::bitvec::Msb0, u8>, Self), ::#crate_::DekuError> {
                     #read_body
                 }
             }
@@ -135,6 +137,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 }
 
 fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
+    let crate_ = super::get_crate_name();
     let mut tokens = TokenStream::new();
 
     let lifetime = input
@@ -262,7 +265,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     if !has_default_match {
         variant_matches.push(quote! {
             _ => {
-                return Err(DekuError::Parse(
+                return Err(::#crate_::DekuError::Parse(
                             format!(
                                 "Could not match enum variant id = {:?} on enum `{}`",
                                 __deku_variant_id,
@@ -301,7 +304,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         let from_bytes_body = wrap_default_ctx(
             quote! {
                 use core::convert::TryFrom;
-                let __deku_input_bits = __deku_input.0.view_bits::<Msb0>();
+                use ::#crate_::bitvec::BitView;
+                let __deku_input_bits = __deku_input.0.view_bits::<::#crate_::bitvec::Msb0>();
 
                 let mut __deku_rest = __deku_input_bits;
                 __deku_rest = &__deku_rest[__deku_input.1..];
@@ -344,8 +348,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         #[allow(non_snake_case)]
-        impl #imp DekuRead<#lifetime, #ctx_types> for #ident #wher {
-            fn read(__deku_input_bits: &#lifetime BitSlice<Msb0, u8>, #ctx_arg) -> Result<(&#lifetime BitSlice<Msb0, u8>, Self), DekuError> {
+        impl #imp ::#crate_::DekuRead<#lifetime, #ctx_types> for #ident #wher {
+            fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<::#crate_::bitvec::Msb0, u8>, #ctx_arg) -> Result<(&#lifetime ::#crate_::bitvec::BitSlice<::#crate_::bitvec::Msb0, u8>, Self), ::#crate_::DekuError> {
                 #read_body
             }
         }
@@ -356,8 +360,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         tokens.extend(quote! {
             #[allow(non_snake_case)]
-            impl #imp DekuRead<#lifetime> for #ident #wher {
-                fn read(__deku_input_bits: &#lifetime BitSlice<Msb0, u8>, _: ()) -> Result<(&#lifetime BitSlice<Msb0, u8>, Self), DekuError> {
+            impl #imp ::#crate_::DekuRead<#lifetime> for #ident #wher {
+                fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<::#crate_::bitvec::Msb0, u8>, _: ()) -> Result<(&#lifetime ::#crate_::bitvec::BitSlice<::#crate_::bitvec::Msb0, u8>, Self), ::#crate_::DekuError> {
                     #read_body
                 }
             }
@@ -393,6 +397,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 }
 
 fn emit_magic_read(input: &DekuData) -> TokenStream {
+    let crate_ = super::get_crate_name();
     if let Some(magic) = &input.magic {
         quote! {
             let __deku_magic = #magic;
@@ -400,7 +405,7 @@ fn emit_magic_read(input: &DekuData) -> TokenStream {
             for __deku_byte in __deku_magic {
                 let (__deku_new_rest, __deku_read_byte) = u8::read(__deku_rest, ())?;
                 if *__deku_byte != __deku_read_byte {
-                    return Err(DekuError::Parse(format!("Missing magic value {:?}", #magic)));
+                    return Err(::#crate_::DekuError::Parse(format!("Missing magic value {:?}", #magic)));
                 }
 
                 __deku_rest = __deku_new_rest;
@@ -466,11 +471,12 @@ fn emit_bit_byte_offsets(
 }
 
 fn emit_padding(bit_size: &TokenStream) -> TokenStream {
+    let crate_ = super::get_crate_name();
     quote! {
         {
             use core::convert::TryFrom;
             let __deku_pad = usize::try_from(#bit_size).map_err(|e|
-                DekuError::InvalidParam(format!(
+                ::#crate_::DekuError::InvalidParam(format!(
                     "Invalid padding param \"{}\": cannot convert to usize",
                     stringify!(#bit_size)
                 ))
@@ -480,7 +486,7 @@ fn emit_padding(bit_size: &TokenStream) -> TokenStream {
                 let (__deku_padded_bits, __deku_new_rest) = __deku_rest.split_at(__deku_pad);
                 __deku_rest = __deku_new_rest;
             } else {
-                return Err(DekuError::Incomplete(NeedSize::new(__deku_pad)));
+                return Err(::#crate_::DekuError::Incomplete(::#crate_::error::NeedSize::new(__deku_pad)));
             }
         }
     }
@@ -491,6 +497,7 @@ fn emit_field_read(
     i: usize,
     f: &FieldData,
 ) -> Result<(TokenStream, TokenStream), syn::Error> {
+    let crate_ = super::get_crate_name();
     let field_type = &f.ty;
 
     let field_endian = f.endian.as_ref().or_else(|| input.endian.as_ref());
@@ -520,7 +527,7 @@ fn emit_field_read(
         .map(|v| {
             quote! { (#v) }
         })
-        .or_else(|| Some(quote! { Result::<_, DekuError>::Ok }));
+        .or_else(|| Some(quote! { Result::<_, ::#crate_::DekuError>::Ok }));
 
     let field_ident = f.get_ident(i, true);
     let field_ident_str = field_ident.to_string();
@@ -530,7 +537,7 @@ fn emit_field_read(
         quote! {
             if (!(#v)) {
                 // assertion is false, raise error
-                return Err(DekuError::Assertion(format!(
+                return Err(::#crate_::DekuError::Assertion(format!(
                             "field '{}' failed assertion: {}",
                             #field_ident_str,
                             stringify!(#v)
@@ -545,7 +552,7 @@ fn emit_field_read(
         quote! {
             if (!(#internal_field_ident == (#v))) {
                 // assertion is false, raise error
-                return Err(DekuError::Assertion(format!(
+                return Err(::#crate_::DekuError::Assertion(format!(
                             "field '{}' failed assertion: {}",
                             #field_ident_str,
                             stringify!(#field_ident == #v)
@@ -577,29 +584,29 @@ fn emit_field_read(
             quote! {
                 {
                     use core::borrow::Borrow;
-                    DekuRead::read(__deku_rest, (deku::ctx::Limit::new_count(usize::try_from(*((#field_count).borrow()))?), (#read_args)))
+                    ::#crate_::DekuRead::read(__deku_rest, (::#crate_::ctx::Limit::new_count(usize::try_from(*((#field_count).borrow()))?), (#read_args)))
                 }
             }
         } else if let Some(field_bits) = &f.bits_read {
             quote! {
                 {
                     use core::borrow::Borrow;
-                    DekuRead::read(__deku_rest, (deku::ctx::Limit::new_size(deku::ctx::Size::Bits(usize::try_from(*((#field_bits).borrow()))?)), (#read_args)))
+                    ::#crate_::DekuRead::read(__deku_rest, (::#crate_::ctx::Limit::new_size(::#crate_::ctx::Size::Bits(usize::try_from(*((#field_bits).borrow()))?)), (#read_args)))
                 }
             }
         } else if let Some(field_bytes) = &f.bytes_read {
             quote! {
                 {
                     use core::borrow::Borrow;
-                    DekuRead::read(__deku_rest, (deku::ctx::Limit::new_size(deku::ctx::Size::Bytes(usize::try_from(*((#field_bytes).borrow()))?)), (#read_args)))
+                    ::#crate_::DekuRead::read(__deku_rest, (::#crate_::ctx::Limit::new_size(::#crate_::ctx::Size::Bytes(usize::try_from(*((#field_bytes).borrow()))?)), (#read_args)))
                 }
             }
         } else if let Some(field_until) = &f.until {
             // We wrap the input into another closure here to enforce that it is actually a callable
             // Otherwise, an incorrectly passed-in integer could unexpectedly convert into a `Count` limit
-            quote! {DekuRead::read(__deku_rest, (deku::ctx::Limit::new_until(#field_until), (#read_args)))}
+            quote! {::#crate_::DekuRead::read(__deku_rest, (::#crate_::ctx::Limit::new_until(#field_until), (#read_args)))}
         } else {
-            quote! {DekuRead::read(__deku_rest, (#read_args))}
+            quote! {::#crate_::DekuRead::read(__deku_rest, (#read_args))}
         }
     };
 
@@ -687,10 +694,11 @@ pub fn emit_from_bytes(
     wher: Option<&syn::WhereClause>,
     body: TokenStream,
 ) -> TokenStream {
+    let crate_ = super::get_crate_name();
     quote! {
-        impl #imp DekuContainerRead<#lifetime> for #ident #wher {
+        impl #imp ::#crate_::DekuContainerRead<#lifetime> for #ident #wher {
             #[allow(non_snake_case)]
-            fn from_bytes(__deku_input: (&#lifetime [u8], usize)) -> Result<((&#lifetime [u8], usize), Self), DekuError> {
+            fn from_bytes(__deku_input: (&#lifetime [u8], usize)) -> Result<((&#lifetime [u8], usize), Self), ::#crate_::DekuError> {
                 #body
             }
         }
@@ -704,14 +712,15 @@ pub fn emit_try_from(
     ident: &TokenStream,
     wher: Option<&syn::WhereClause>,
 ) -> TokenStream {
+    let crate_ = super::get_crate_name();
     quote! {
         impl #imp core::convert::TryFrom<&#lifetime [u8]> for #ident #wher {
-            type Error = DekuError;
+            type Error = ::#crate_::DekuError;
 
             fn try_from(input: &#lifetime [u8]) -> Result<Self, Self::Error> {
                 let (rest, res) = Self::from_bytes((input, 0))?;
                 if !rest.0.is_empty() {
-                    return Err(DekuError::Parse(format!("Too much data")));
+                    return Err(::#crate_::DekuError::Parse(format!("Too much data")));
                 }
                 Ok(res)
             }

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -18,6 +18,7 @@ pub(crate) fn emit_deku_write(input: &DekuData) -> Result<TokenStream, syn::Erro
 }
 
 fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
+    let crate_ = super::get_crate_name();
     let mut tokens = TokenStream::new();
 
     let (imp, ty, wher) = input.generics.split_for_impl();
@@ -49,7 +50,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             quote! {
                 match *self {
                     #destructured => {
-                        let mut __deku_acc: BitVec<Msb0, u8> = BitVec::new();
+                        let mut __deku_acc: ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8> = ::#crate_::bitvec::BitVec::new();
                         let __deku_output = &mut __deku_acc;
 
                         #magic_write
@@ -64,8 +65,8 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         );
 
         tokens.extend(quote! {
-            impl #imp core::convert::TryFrom<#ident> for BitVec<Msb0, u8> #wher {
-                type Error = DekuError;
+            impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8> #wher {
+                type Error = ::#crate_::DekuError;
 
                 fn try_from(input: #ident) -> Result<Self, Self::Error> {
                     input.to_bits()
@@ -73,7 +74,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             }
 
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
-                type Error = DekuError;
+                type Error = ::#crate_::DekuError;
 
                 fn try_from(input: #ident) -> Result<Self, Self::Error> {
                     input.to_bytes()
@@ -81,13 +82,13 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             }
 
             impl #imp DekuContainerWrite for #ident #wher {
-                fn to_bytes(&self) -> Result<Vec<u8>, DekuError> {
-                    let mut acc: BitVec<Msb0, u8> = self.to_bits()?;
+                fn to_bytes(&self) -> Result<Vec<u8>, ::#crate_::DekuError> {
+                    let mut acc: ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8> = self.to_bits()?;
                     Ok(acc.into_vec())
                 }
 
                 #[allow(unused_variables)]
-                fn to_bits(&self) -> Result<BitVec<Msb0, u8>, DekuError> {
+                fn to_bits(&self) -> Result<::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8>, ::#crate_::DekuError> {
                     #to_bits_body
                 }
             }
@@ -112,7 +113,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
-            fn update(&mut self) -> Result<(), DekuError> {
+            fn update(&mut self) -> Result<(), ::#crate_::DekuError> {
                 #update_use
                 #(#field_updates)*
 
@@ -122,7 +123,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         impl #imp DekuWrite<#ctx_types> for #ident #wher {
             #[allow(unused_variables)]
-            fn write(&self, __deku_output: &mut BitVec<Msb0, u8>, #ctx_arg) -> Result<(), DekuError> {
+            fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8>, #ctx_arg) -> Result<(), ::#crate_::DekuError> {
                 #write_body
             }
         }
@@ -134,7 +135,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             impl #imp DekuWrite for #ident #wher {
                 #[allow(unused_variables)]
-                fn write(&self, __deku_output: &mut BitVec<Msb0, u8>, _: ()) -> Result<(), DekuError> {
+                fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8>, _: ()) -> Result<(), ::#crate_::DekuError> {
                     #write_body
                 }
             }
@@ -146,6 +147,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 }
 
 fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
+    let crate_ = super::get_crate_name();
     let mut tokens = TokenStream::new();
 
     let (imp, ty, wher) = input.generics.split_for_impl();
@@ -266,7 +268,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     if input.ctx.is_none() || (input.ctx.is_some() && input.ctx_default.is_some()) {
         let to_bits_body = wrap_default_ctx(
             quote! {
-                let mut __deku_acc: BitVec<Msb0, u8> = BitVec::new();
+                let mut __deku_acc: ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8> = ::#crate_::bitvec::BitVec::new();
                 let __deku_output = &mut __deku_acc;
 
                 #magic_write
@@ -282,8 +284,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         );
 
         tokens.extend(quote! {
-            impl #imp core::convert::TryFrom<#ident> for BitVec<Msb0, u8> #wher {
-                type Error = DekuError;
+            impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8> #wher {
+                type Error = ::#crate_::DekuError;
 
                 fn try_from(input: #ident) -> Result<Self, Self::Error> {
                     input.to_bits()
@@ -291,7 +293,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             }
 
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
-                type Error = DekuError;
+                type Error = ::#crate_::DekuError;
 
                 fn try_from(input: #ident) -> Result<Self, Self::Error> {
                     input.to_bytes()
@@ -299,13 +301,13 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             }
 
             impl #imp DekuContainerWrite for #ident #wher {
-                fn to_bytes(&self) -> Result<Vec<u8>, DekuError> {
-                    let mut acc: BitVec<Msb0, u8> = self.to_bits()?;
+                fn to_bytes(&self) -> Result<Vec<u8>, ::#crate_::DekuError> {
+                    let mut acc: ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8> = self.to_bits()?;
                     Ok(acc.into_vec())
                 }
 
                 #[allow(unused_variables)]
-                fn to_bits(&self) -> Result<BitVec<Msb0, u8>, DekuError> {
+                fn to_bits(&self) -> Result<::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8>, ::#crate_::DekuError> {
                     #to_bits_body
                 }
             }
@@ -329,7 +331,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
-            fn update(&mut self) -> Result<(), DekuError> {
+            fn update(&mut self) -> Result<(), ::#crate_::DekuError> {
                 #update_use
 
                 match self {
@@ -342,7 +344,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         impl #imp DekuWrite<#ctx_types> for #ident #wher {
             #[allow(unused_variables)]
-            fn write(&self, __deku_output: &mut BitVec<Msb0, u8>, #ctx_arg) -> Result<(), DekuError> {
+            fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8>, #ctx_arg) -> Result<(), ::#crate_::DekuError> {
                 #write_body
             }
         }
@@ -354,7 +356,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             impl #imp DekuWrite for #ident #wher {
                 #[allow(unused_variables)]
-                fn write(&self, __deku_output: &mut BitVec<Msb0, u8>, _: ()) -> Result<(), DekuError> {
+                fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<::#crate_::bitvec::Msb0, u8>, _: ()) -> Result<(), ::#crate_::DekuError> {
                     #write_body
                 }
             }
@@ -455,11 +457,12 @@ fn emit_bit_byte_offsets(
 }
 
 fn emit_padding(bit_size: &TokenStream) -> TokenStream {
+    let crate_ = super::get_crate_name();
     quote! {
         {
             use core::convert::TryFrom;
             let __deku_pad = usize::try_from(#bit_size).map_err(|e|
-                DekuError::InvalidParam(format!(
+                ::#crate_::DekuError::InvalidParam(format!(
                     "Invalid padding param \"{}\": cannot convert to usize",
                     stringify!(#bit_size)
                 ))
@@ -476,6 +479,7 @@ fn emit_field_write(
     f: &FieldData,
     object_prefix: &Option<TokenStream>,
 ) -> Result<TokenStream, syn::Error> {
+    let crate_ = super::get_crate_name();
     let field_endian = f.endian.as_ref().or_else(|| input.endian.as_ref());
 
     // fields to check usage of bit/byte offset
@@ -497,7 +501,7 @@ fn emit_field_write(
         quote! {
             if (!(#v)) {
                 // assertion is false, raise error
-                return Err(DekuError::Assertion(format!(
+                return Err(::#crate_::DekuError::Assertion(format!(
                             "field '{}' failed assertion: {}",
                             #field_ident_str,
                             stringify!(#v)
@@ -512,7 +516,7 @@ fn emit_field_write(
         quote! {
             if (!(*(#field_ident) == (#v))) {
                 // assertion is false, raise error
-                return Err(DekuError::Assertion(format!(
+                return Err(::#crate_::DekuError::Assertion(format!(
                             "field '{}' failed assertion: {}",
                             #field_ident_str,
                             stringify!(#field_ident == #v)

--- a/examples/custom_reader_and_writer.rs
+++ b/examples/custom_reader_and_writer.rs
@@ -1,3 +1,4 @@
+use deku::bitvec::{BitSlice, BitVec, Msb0};
 use deku::ctx::Size;
 use deku::prelude::*;
 use std::convert::TryInto;

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -733,8 +733,10 @@ Specify custom reader or writer tokens for reading a field or variant
 
 Example:
 ```rust
-# use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
+use std::convert::{TryInto, TryFrom};
+use deku::bitvec::{BitSlice, BitVec, Msb0};
+use deku::prelude::*;
+
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -8,7 +8,7 @@ impl<'a, T: DekuRead<'a, Ctx>, Ctx: Copy> DekuRead<'a, Ctx> for Option<T> {
     /// ```rust
     /// # use deku::ctx::*;
     /// # use deku::DekuRead;
-    /// # use bitvec::view::BitView;
+    /// # use deku::bitvec::BitView;
     /// let input = vec![1u8, 2, 3, 4];
     /// let (rest, v) = Option::<u32>::read(input.view_bits(), Endian::Little).unwrap();
     /// assert!(rest.is_empty());
@@ -31,12 +31,12 @@ impl<T: DekuWrite<Ctx>, Ctx: Copy> DekuWrite<Ctx> for Option<T> {
     /// * **inner_ctx** - The context required by `T`.
     /// # Examples
     /// ```rust
-    /// # use deku::{ctx::Endian, DekuWrite, prelude::{Lsb0, Msb0}};
-    /// # use bitvec::bitvec;
+    /// # use deku::{ctx::Endian, DekuWrite};
+    /// # use deku::bitvec::{bitvec, Msb0};
     /// let data = Some(1u8);
     /// let mut output = bitvec![Msb0, u8;];
     /// data.write(&mut output, Endian::Big).unwrap();
-    /// assert_eq!(output, bitvec![0, 0, 0, 0, 0, 0, 0, 1])
+    /// assert_eq!(output, bitvec![Msb0, u8; 0, 0, 0, 0, 0, 0, 0, 1])
     /// ```
     fn write(&self, output: &mut BitVec<Msb0, u8>, inner_ctx: Ctx) -> Result<(), DekuError> {
         self.as_ref().map_or(Ok(()), |v| v.write(output, inner_ctx))

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -55,7 +55,7 @@ impl<'a, T: DekuRead<'a, Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool>
     /// ```rust
     /// # use deku::ctx::*;
     /// # use deku::DekuRead;
-    /// # use bitvec::view::BitView;
+    /// # use deku::bitvec::BitView;
     /// let input = vec![1u8, 2, 3, 4];
     /// let (rest, v) = Vec::<u32>::read(input.view_bits(), (1.into(), Endian::Little)).unwrap();
     /// assert!(rest.is_empty());
@@ -119,12 +119,12 @@ impl<T: DekuWrite<Ctx>, Ctx: Copy> DekuWrite<Ctx> for Vec<T> {
     /// * **inner_ctx** - The context required by `T`.
     /// # Examples
     /// ```rust
-    /// # use deku::{ctx::Endian, DekuWrite, prelude::{Lsb0, Msb0}};
-    /// # use bitvec::bitvec;
+    /// # use deku::{ctx::Endian, DekuWrite};
+    /// # use deku::bitvec::{Msb0, bitvec};
     /// let data = vec![1u8];
     /// let mut output = bitvec![Msb0, u8;];
     /// data.write(&mut output, Endian::Big).unwrap();
-    /// assert_eq!(output, bitvec![0, 0, 0, 0, 0, 0, 0, 1])
+    /// assert_eq!(output, bitvec![Msb0, u8; 0, 0, 0, 0, 0, 0, 0, 1])
     /// ```
     fn write(&self, output: &mut BitVec<Msb0, u8>, inner_ctx: Ctx) -> Result<(), DekuError> {
         for v in self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,10 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-use bitvec::prelude::*;
+/// re-export of bitvec
+pub mod bitvec {
+    pub use bitvec::prelude::*;
+}
 
 pub use deku_derive::*;
 
@@ -287,9 +290,9 @@ pub trait DekuRead<'a, Ctx = ()> {
     /// * **ctx** - A context required by context-sensitive reading. A unit type `()` means no context
     /// needed.
     fn read(
-        input: &'a BitSlice<Msb0, u8>,
+        input: &'a bitvec::BitSlice<bitvec::Msb0, u8>,
         ctx: Ctx,
-    ) -> Result<(&'a BitSlice<Msb0, u8>, Self), DekuError>
+    ) -> Result<(&'a bitvec::BitSlice<bitvec::Msb0, u8>, Self), DekuError>
     where
         Self: Sized;
 }
@@ -312,7 +315,11 @@ pub trait DekuWrite<Ctx = ()> {
     /// * **output** - Sink to store resulting bits
     /// * **ctx** - A context required by context-sensitive reading. A unit type `()` means no context
     /// needed.
-    fn write(&self, output: &mut BitVec<Msb0, u8>, ctx: Ctx) -> Result<(), DekuError>;
+    fn write(
+        &self,
+        output: &mut bitvec::BitVec<bitvec::Msb0, u8>,
+        ctx: Ctx,
+    ) -> Result<(), DekuError>;
 }
 
 /// "Writer" trait: implemented on DekuWrite struct and enum containers. A `container` is a type which
@@ -322,7 +329,7 @@ pub trait DekuContainerWrite: DekuWrite<()> {
     fn to_bytes(&self) -> Result<Vec<u8>, DekuError>;
 
     /// Write struct/enum to BitVec
-    fn to_bits(&self) -> Result<BitVec<Msb0, u8>, DekuError>;
+    fn to_bits(&self) -> Result<bitvec::BitVec<bitvec::Msb0, u8>, DekuError>;
 }
 
 /// "Updater" trait: apply mutations to a type

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,3 @@ pub use crate::{
     deku_derive, error::DekuError, error::NeedSize, DekuContainerRead, DekuContainerWrite,
     DekuEnumExt, DekuRead, DekuUpdate, DekuWrite,
 };
-pub use bitvec::{
-    order::BitOrder, order::Lsb0, order::Msb0, slice::BitSlice, vec::BitVec, view::BitView,
-};

--- a/tests/test_attributes/test_ctx.rs
+++ b/tests/test_attributes/test_ctx.rs
@@ -1,4 +1,5 @@
 use bitvec::bitvec;
+use deku::bitvec::{BitView, Msb0};
 use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
 

--- a/tests/test_compile/cases/internal_variables.rs
+++ b/tests/test_compile/cases/internal_variables.rs
@@ -1,4 +1,5 @@
 use deku::prelude::*;
+use deku::bitvec::{BitVec, BitSlice, Msb0};
 
 #[derive(DekuRead, DekuWrite)]
 struct TestCount {

--- a/tests/test_compile/cases/internal_variables.stderr
+++ b/tests/test_compile/cases/internal_variables.stderr
@@ -1,5 +1,5 @@
 error: Unexpected meta-item format `attribute cannot contain `__deku_` these are internal variables. Please use the `deku::` instead.`
-  --> $DIR/internal_variables.rs:92:19
+  --> $DIR/internal_variables.rs:93:19
    |
-92 |     #[deku(cond = "__deku_bit_offset == *field_a as usize")]
+93 |     #[deku(cond = "__deku_bit_offset == *field_a as usize")]
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
- This is better proc-macro hygiene and allows clients to import and
  rename the crate in Cargo.toml (only works on std)
- Re-export bitvec and don't clobber the namespace. This is beneficial
  if bitvec is also used in the same crate deku is used in.

Fixes: https://github.com/sharksforarms/deku/issues/180