### PR TITLE
add optional `const_generics` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
 default = ["std"]
 std = ["deku_derive/std", "bitvec/std", "alloc"]
 alloc = ["bitvec/alloc"]
+const_generics = []
 
 [dependencies]
 deku_derive = { version = "^0.11.0", path = "deku-derive", default-features = false}

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -89,74 +89,140 @@ where
     }
 }
 
-macro_rules! ImplDekuSliceTraits {
-    ($typ:ty; $($count:expr),+ $(,)?) => {
+#[cfg(not(feature = "const_generics"))]
+mod pre_const_generics_impl {
+    use super::*;
 
-        impl<Ctx: Copy> DekuWrite<Ctx> for &[$typ]
-        where
-            $typ: DekuWrite<Ctx>,
-        {
-            fn write(&self, output: &mut BitVec<Msb0, u8>, ctx: Ctx) -> Result<(), DekuError> {
-                for v in *self {
-                    v.write(output, ctx)?;
-                }
-                Ok(())
-            }
-        }
+    macro_rules! ImplDekuSliceTraits {
+        ($typ:ty; $($count:expr),+ $(,)?) => {
 
-        $(
-            impl<'a, Ctx: Copy> DekuRead<'a, Ctx> for [$typ; $count]
-            where
-                $typ: DekuRead<'a, Ctx>,
-            {
-                fn read(
-                    input: &'a BitSlice<Msb0, u8>,
-                    ctx: Ctx,
-                ) -> Result<(&'a BitSlice<Msb0, u8>, Self), DekuError>
-                where
-                    Self: Sized,
-                {
-                    let mut slice: [$typ; $count] = Default::default();
-                    let mut rest = input;
-                    for i in 0..$count {
-                        let (new_rest, value) = <$typ>::read(rest, ctx)?;
-                        slice[i] = value;
-                        rest = new_rest;
-                    }
-
-                    Ok((rest, slice))
-                }
-            }
-
-            impl<Ctx: Copy> DekuWrite<Ctx> for [$typ; $count]
+            impl<Ctx: Copy> DekuWrite<Ctx> for &[$typ]
             where
                 $typ: DekuWrite<Ctx>,
             {
                 fn write(&self, output: &mut BitVec<Msb0, u8>, ctx: Ctx) -> Result<(), DekuError> {
-                    for v in self {
+                    for v in *self {
                         v.write(output, ctx)?;
                     }
                     Ok(())
                 }
             }
-        )+
-    };
+
+            $(
+                impl<'a, Ctx: Copy> DekuRead<'a, Ctx> for [$typ; $count]
+                where
+                    $typ: DekuRead<'a, Ctx>,
+                {
+                    fn read(
+                        input: &'a BitSlice<Msb0, u8>,
+                        ctx: Ctx,
+                    ) -> Result<(&'a BitSlice<Msb0, u8>, Self), DekuError>
+                    where
+                        Self: Sized,
+                    {
+                        let mut slice: [$typ; $count] = Default::default();
+                        let mut rest = input;
+                        for i in 0..$count {
+                            let (new_rest, value) = <$typ>::read(rest, ctx)?;
+                            slice[i] = value;
+                            rest = new_rest;
+                        }
+
+                        Ok((rest, slice))
+                    }
+                }
+
+                impl<Ctx: Copy> DekuWrite<Ctx> for [$typ; $count]
+                where
+                    $typ: DekuWrite<Ctx>,
+                {
+                    fn write(&self, output: &mut BitVec<Msb0, u8>, ctx: Ctx) -> Result<(), DekuError> {
+                        for v in self {
+                            v.write(output, ctx)?;
+                        }
+                        Ok(())
+                    }
+                }
+            )+
+        };
+    }
+
+    ImplDekuSliceTraits!(i8; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(i16; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(i32; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(i64; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(i128; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(isize; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(u8; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(u16; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(u32; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(u64; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(u128; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(usize; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(f32; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+    ImplDekuSliceTraits!(f64; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
 }
 
-ImplDekuSliceTraits!(i8; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(i16; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(i32; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(i64; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(i128; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(isize; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(u8; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(u16; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(u32; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(u64; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(u128; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(usize; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(f32; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-ImplDekuSliceTraits!(f64; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+#[cfg(feature = "const_generics")]
+mod const_generics_impl {
+    use super::*;
+
+    macro_rules! ImplDekuSliceTraits {
+        ($($typ:ty),+ $(,)?) => {
+            $(
+                impl<Ctx: Copy> DekuWrite<Ctx> for &[$typ]
+                where
+                    $typ: DekuWrite<Ctx>,
+                {
+                    fn write(&self, output: &mut BitVec<Msb0, u8>, ctx: Ctx) -> Result<(), DekuError> {
+                        for v in *self {
+                            v.write(output, ctx)?;
+                        }
+                        Ok(())
+                    }
+                }
+
+
+                impl<'a, Ctx: Copy, const N: usize> DekuRead<'a, Ctx> for [$typ; N]
+                where
+                    $typ: DekuRead<'a, Ctx>,
+                {
+                    fn read(
+                        input: &'a BitSlice<Msb0, u8>,
+                        ctx: Ctx,
+                    ) -> Result<(&'a BitSlice<Msb0, u8>, Self), DekuError>
+                    where
+                        Self: Sized,
+                    {
+                        let mut slice: [$typ; N] = [<$typ>::default(); N];
+                        let mut rest = input;
+                        for i in 0..N {
+                            let (new_rest, value) = <$typ>::read(rest, ctx)?;
+                            slice[i] = value;
+                            rest = new_rest;
+                        }
+
+                        Ok((rest, slice))
+                    }
+                }
+
+                impl<Ctx: Copy, const N: usize> DekuWrite<Ctx> for [$typ; N]
+                where
+                    $typ: DekuWrite<Ctx>,
+                {
+                    fn write(&self, output: &mut BitVec<Msb0, u8>, ctx: Ctx) -> Result<(), DekuError> {
+                        for v in self {
+                            v.write(output, ctx)?;
+                        }
+                        Ok(())
+                    }
+                }
+            )+
+        };
+    }
+
+    ImplDekuSliceTraits!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64);
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Adds a `const_generics` feature that uses `min_const_generics` which will be stabilized on March 25, 2021 as part of Rust 1.51 (and is currently available in beta) to allow for reading/writing arrays with >32 elements when enabled.