### PR TITLE
deps: Bump hexlit to 0.5.0 and fix broken test on latest stable.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ deku_derive = { version = "^0.11.0", path = "deku-derive", default-features = fa
 bitvec = { version = "0.21.0", default-features = false }
 
 [dev-dependencies]
-hexlit = "0.4.0"
 rstest = "0.7"
+hexlit = "0.5.0"
 criterion = "0.3"
 alloc_counter = "0.0.4"
 trybuild = "1.0"

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -44,11 +44,11 @@ mod tests {
 
     #[test]
     fn test_simple() {
-        let input = hex!("aabbbbcc0102ddffffffaa").as_ref();
+        let input = hex!("aabbbbcc0102ddffffffaa");
 
         assert_eq!(
             count_alloc(|| {
-                let _ = TestDeku::try_from(input).unwrap();
+                let _ = TestDeku::try_from(input.as_ref()).unwrap();
             })
             .0,
             (3, 0, 3)


### PR DESCRIPTION
This PR bumps hexlit to 0.5.0 which offers some small speed and size improvements due to min_const_generics now being stablized. It also fixes a test that used a temporary value which could be dropped while borrowed which is a hard error on the latest stable (1.51).