### PR TITLE
Add docs on the return type for DekuRead

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ pub use crate::error::DekuError;
 
 /// "Reader" trait: read bits and construct type
 pub trait DekuRead<'a, Ctx = ()> {
-    /// Read bits and construct type
+    /// Read bits and construct type. Returns the remaining bits after parsing in addition to Self.
     /// * **input** - Input as bits
     /// * **ctx** - A context required by context-sensitive reading. A unit type `()` means no context
     /// needed.


### PR DESCRIPTION
When trying to write my own implementation of DekuRead, instead of `#[derive]`ing it,
I was a little confused about the function signature of `DekuRead::read`.
Adding the return type to the documentation makes it easier for folks to write
their own implementations in cases where the provided tooling
(which is very good and extensive, btw) doesn't suffice.

FWIW my specific use-case involves a bitfield that's of variable length, and I couldn't think
of a simple way to use the `#[deku]` attributes to make it work in an elegant way.
