### PR TITLE
Fix CI failure for Codecov/tarpaulin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:develop-nightly
+      image: xd009642/tarpaulin:develop
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
@@ -114,7 +114,7 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Run tarpaulin for code coverage on stable rust instead of nightly.

Nightly rust has our test cases failing due to the changed debug
printing of strings with single quotes "'" so our test cases using
should_panic(expected = <error message>) are failing.