### PR TITLE
Use AsRef in `DekuContainerRead::from_bytes`

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -688,7 +688,8 @@ pub fn emit_from_bytes(
     quote! {
         impl #imp ::#crate_::DekuContainerRead<#lifetime> for #ident #wher {
             #[allow(non_snake_case)]
-            fn from_bytes(__deku_input: (&#lifetime [u8], usize)) -> Result<((&#lifetime [u8], usize), Self), ::#crate_::DekuError> {
+            fn from_bytes(__deku_input: (&#lifetime (impl std::convert::AsRef<[u8]> + ?Sized), usize)) -> Result<((&#lifetime [u8], usize), Self), ::#crate_::DekuError> {
+                let __deku_input = (__deku_input.0.as_ref(), __deku_input.1);
                 #body
             }
         }

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -688,8 +688,8 @@ pub fn emit_from_bytes(
     quote! {
         impl #imp ::#crate_::DekuContainerRead<#lifetime> for #ident #wher {
             #[allow(non_snake_case)]
-            fn from_bytes(__deku_input: (&#lifetime (impl std::convert::AsRef<[u8]> + ?Sized), usize)) -> Result<((&#lifetime [u8], usize), Self), ::#crate_::DekuError> {
-                let __deku_input = (__deku_input.0.as_ref(), __deku_input.1);
+            fn from_bytes(__deku_input: (&#lifetime (impl core::convert::AsRef<[u8]> + ?Sized), usize)) -> Result<((&#lifetime [u8], usize), Self), ::#crate_::DekuError> {
+                let __deku_input = (core::convert::AsRef::as_ref(__deku_input.0), __deku_input.1);
                 #body
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ pub trait DekuContainerRead<'a>: DekuRead<'a, ()> {
     /// * **input** - Input given as data and bit offset
     ///
     /// Returns the remaining bytes and bit offset after parsing in addition to Self.
-    fn from_bytes(input: (&'a [u8], usize)) -> Result<((&'a [u8], usize), Self), DekuError>
+    fn from_bytes(input: (&'a (impl AsRef<[u8]> + ?Sized), usize)) -> Result<((&'a [u8], usize), Self), DekuError>
     where
         Self: Sized;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,9 @@ pub trait DekuContainerRead<'a>: DekuRead<'a, ()> {
     /// * **input** - Input given as data and bit offset
     ///
     /// Returns the remaining bytes and bit offset after parsing in addition to Self.
-    fn from_bytes(input: (&'a (impl AsRef<[u8]> + ?Sized), usize)) -> Result<((&'a [u8], usize), Self), DekuError>
+    fn from_bytes(
+        input: (&'a (impl AsRef<[u8]> + ?Sized), usize),
+    ) -> Result<((&'a [u8], usize), Self), DekuError>
     where
         Self: Sized;
 }


### PR DESCRIPTION
Fix #48. Tests not updated. All failed tests are caused by the manual use of `as_ref`. e.g. https://github.com/sharksforarms/deku/blob/e46d9502593417cb92d18f0bc130dff1180abe50/src/lib.rs#L176
Note: This change will break all codes that calls `as_ref` in argument passing because of the type inference issue (can't resolve two generics in `AsRef` at the same time).