### PR TITLE
Initial version of `as` attribute

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "alloc")]
 
-use alloc::{format, string::String, string::ToString};
+use alloc::{format, string::String};
 
 /// Number of bits needed to retry parsing
 #[derive(Debug, PartialEq)]
@@ -47,13 +47,13 @@ pub enum DekuError {
 
 impl From<core::num::TryFromIntError> for DekuError {
     fn from(e: core::num::TryFromIntError) -> DekuError {
-        DekuError::Parse(format!("error parsing int: {}", e.to_string()))
+        DekuError::Parse(format!("error parsing int: {}", e))
     }
 }
 
 impl From<core::array::TryFromSliceError> for DekuError {
     fn from(e: core::array::TryFromSliceError) -> DekuError {
-        DekuError::Parse(format!("error parsing from slice: {}", e.to_string()))
+        DekuError::Parse(format!("error parsing from slice: {}", e))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,3 +363,47 @@ where
         Ok(())
     }
 }
+
+pub trait DekuReadAs<'a, T, Ctx = ()> {
+    fn read_as(
+        input: &'a bitvec::BitSlice<bitvec::Msb0, u8>,
+        ctx: Ctx,
+    ) -> Result<(&'a bitvec::BitSlice<bitvec::Msb0, u8>, T), DekuError>;
+}
+
+pub trait DekuWriteAs<T: ?Sized, Ctx = ()> {
+    fn write_as(
+        source: &T,
+        output: &mut bitvec::BitVec<bitvec::Msb0, u8>,
+        ctx: Ctx,
+    ) -> Result<(), DekuError>;
+}
+
+pub struct Same {
+    _priv: (),
+}
+
+impl<'a, T, Ctx> DekuReadAs<'a, T, Ctx> for Same
+where
+    T: DekuRead<'a, Ctx>,
+{
+    fn read_as(
+        input: &'a bitvec::BitSlice<bitvec::Msb0, u8>,
+        ctx: Ctx,
+    ) -> Result<(&'a bitvec::BitSlice<bitvec::Msb0, u8>, T), DekuError> {
+        T::read(input, ctx)
+    }
+}
+
+impl<T, Ctx> DekuWriteAs<T, Ctx> for Same
+where
+    T: DekuWrite<Ctx> + ?Sized,
+{
+    fn write_as(
+        source: &T,
+        output: &mut bitvec::BitVec<bitvec::Msb0, u8>,
+        ctx: Ctx,
+    ) -> Result<(), DekuError> {
+        source.write(output, ctx)
+    }
+}

--- a/tests/test_as.rs
+++ b/tests/test_as.rs
@@ -1,0 +1,160 @@
+use deku::ctx::Size;
+use deku::prelude::*;
+use deku::{bitvec, DekuReadAs, DekuWriteAs, Same};
+use std::marker::PhantomData;
+
+#[derive(DekuRead, DekuWrite, PartialEq, Debug)]
+struct Foo {
+    #[deku(as = "VecWithLen<Same>", bytes = "4", ctx = "()")]
+    ints: Box<[u32]>,
+}
+
+#[test]
+fn test_roundtrip() {
+    let foo = Foo {
+        ints: Box::new([6, 1, 25, 9]),
+    };
+    let bytes = foo.to_bytes().unwrap();
+    let foo2 = Foo::from_bytes((&bytes, 0)).unwrap().1;
+    assert_eq!(foo2, foo);
+}
+
+#[test]
+fn test_vecwithlen() {
+    let foo = Foo {
+        ints: Box::new([6, 1, 25, 9]),
+    };
+    let bytes = foo.to_bytes().unwrap();
+    #[rustfmt::skip]
+    assert_eq!(
+        bytes,
+        [
+            4,  0, 0, 0,
+            6,  0, 0, 0,
+            1,  0, 0, 0,
+            25, 0, 0, 0,
+            9,  0, 0, 0
+        ]
+    );
+}
+
+struct VecWithLen<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<'a, Ctx: Copy, T, U: DekuReadAs<'a, T, Ctx>> DekuReadAs<'a, Box<[T]>, (Size, Ctx)>
+    for VecWithLen<U>
+{
+    fn read_as(
+        input: &'a bitvec::BitSlice<bitvec::Msb0, u8>,
+        ctx: (Size, Ctx),
+    ) -> Result<(&'a bitvec::BitSlice<bitvec::Msb0, u8>, Box<[T]>), DekuError> {
+        let (rest, vec) = Self::read_as(input, ctx)?;
+        Ok((rest, Vec::into_boxed_slice(vec)))
+    }
+}
+
+impl<'a, T, U: DekuReadAs<'a, T, ()>> DekuReadAs<'a, Box<[T]>> for VecWithLen<U> {
+    fn read_as(
+        input: &'a bitvec::BitSlice<bitvec::Msb0, u8>,
+        ctx: (),
+    ) -> Result<(&'a bitvec::BitSlice<bitvec::Msb0, u8>, Box<[T]>), DekuError> {
+        let (rest, vec) = Self::read_as(input, ctx)?;
+        Ok((rest, Vec::into_boxed_slice(vec)))
+    }
+}
+
+impl<'a, Ctx: Copy, T, U: DekuReadAs<'a, T, Ctx>> DekuReadAs<'a, Vec<T>, (Size, Ctx)>
+    for VecWithLen<U>
+{
+    fn read_as(
+        input: &'a bitvec::BitSlice<bitvec::Msb0, u8>,
+        (size, ctx): (Size, Ctx),
+    ) -> Result<(&'a bitvec::BitSlice<bitvec::Msb0, u8>, Vec<T>), DekuError> {
+        let mut rest = input;
+        let (r, len) = usize::read(rest, size)?;
+        rest = r;
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            let (r, elem) = U::read_as(rest, ctx)?;
+            out.push(elem);
+            rest = r
+        }
+        Ok((rest, out))
+    }
+}
+
+impl<'a, T, U: DekuReadAs<'a, T, ()>> DekuReadAs<'a, Vec<T>> for VecWithLen<U> {
+    fn read_as(
+        input: &'a bitvec::BitSlice<bitvec::Msb0, u8>,
+        _ctx: (),
+    ) -> Result<(&'a bitvec::BitSlice<bitvec::Msb0, u8>, Vec<T>), DekuError> {
+        Self::read_as(input, (Size::of::<usize>(), ()))
+    }
+}
+
+impl<Ctx: Copy, T, U: DekuWriteAs<T, Ctx>> DekuWriteAs<[T], (Size, Ctx)> for VecWithLen<U> {
+    fn write_as(
+        source: &[T],
+        output: &mut bitvec::BitVec<bitvec::Msb0, u8>,
+        (size, ctx): (Size, Ctx),
+    ) -> Result<(), DekuError> {
+        dbg!(&output);
+        source.len().write(output, size)?;
+        dbg!(&output);
+        for elem in source {
+            U::write_as(elem, output, ctx)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T, U: DekuWriteAs<T, ()>> DekuWriteAs<[T]> for VecWithLen<U> {
+    fn write_as(
+        source: &[T],
+        output: &mut bitvec::BitVec<bitvec::Msb0, u8>,
+        _ctx: (),
+    ) -> Result<(), DekuError> {
+        Self::write_as(source, output, (Size::of::<usize>(), ()))
+    }
+}
+
+impl<Ctx: Copy, T, U: DekuWriteAs<T, Ctx>> DekuWriteAs<Box<[T]>, (Size, Ctx)> for VecWithLen<U> {
+    fn write_as(
+        source: &Box<[T]>,
+        output: &mut bitvec::BitVec<bitvec::Msb0, u8>,
+        ctx: (Size, Ctx),
+    ) -> Result<(), DekuError> {
+        Self::write_as(&**source, output, ctx)
+    }
+}
+
+impl<T, U: DekuWriteAs<T, ()>> DekuWriteAs<Box<[T]>> for VecWithLen<U> {
+    fn write_as(
+        source: &Box<[T]>,
+        output: &mut bitvec::BitVec<bitvec::Msb0, u8>,
+        ctx: (),
+    ) -> Result<(), DekuError> {
+        Self::write_as(&**source, output, ctx)
+    }
+}
+
+impl<Ctx: Copy, T, U: DekuWriteAs<T, Ctx>> DekuWriteAs<Vec<T>, (Size, Ctx)> for VecWithLen<U> {
+    fn write_as(
+        source: &Vec<T>,
+        output: &mut bitvec::BitVec<bitvec::Msb0, u8>,
+        ctx: (Size, Ctx),
+    ) -> Result<(), DekuError> {
+        Self::write_as(&**source, output, ctx)
+    }
+}
+
+impl<T, U: DekuWriteAs<T, ()>> DekuWriteAs<Vec<T>> for VecWithLen<U> {
+    fn write_as(
+        source: &Vec<T>,
+        output: &mut bitvec::BitVec<bitvec::Msb0, u8>,
+        ctx: (),
+    ) -> Result<(), DekuError> {
+        Self::write_as(&**source, output, ctx)
+    }
+}


### PR DESCRIPTION
Resolves #225.

Here's an initial draft of the "as" attribute, let me know what you think. Note that as of tomorrow, I'll be going to summer camp, so I may not be able to work on this very much; sorry about that :sweat_smile: It should really just be docs though, unless you want this initial PR to contain types that implement `DekuRead/WriteAs` as well.