### PR TITLE
feat: Add `ctx_nested` attribute to top level

### DIFF
--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -100,7 +100,7 @@ fn cerror(span: proc_macro2::Span, msg: &str) -> TokenStream {
     syn::Error::new(span, msg).to_compile_error()
 }
 
-/// A post-processed version of `DekuReceiver`
+/// A post-processed version of [DekuReceiver](self::DekuReceiver)
 #[derive(Debug)]
 struct DekuData {
     vis: syn::Visibility,
@@ -116,6 +116,9 @@ struct DekuData {
 
     /// default context passed to the field
     ctx_default: Option<Punctuated<syn::Expr, syn::token::Comma>>,
+
+    /// additional context passed down to the fields
+    ctx_nested: Option<Punctuated<syn::Expr, syn::token::Comma>>,
 
     /// A magic value that must appear at the start of this struct/enum's data
     magic: Option<syn::LitByteStr>,
@@ -134,7 +137,7 @@ struct DekuData {
 }
 
 impl DekuData {
-    /// Map a `DekuReceiver` to `DekuData`
+    /// Map a [DekuReceiver](self::DekuReceiver) to [DekuData](self::DekuData)
     fn from_receiver(receiver: DekuReceiver) -> Result<Self, TokenStream> {
         let data = match receiver.data {
             ast::Data::Struct(fields) => ast::Data::Struct(ast::Fields::new(
@@ -161,6 +164,7 @@ impl DekuData {
             endian: receiver.endian,
             ctx: receiver.ctx,
             ctx_default: receiver.ctx_default,
+            ctx_nested: receiver.ctx_nested,
             magic: receiver.magic,
             id: receiver.id,
             id_type: receiver.id_type?,
@@ -265,7 +269,7 @@ impl DekuData {
     }
 }
 
-/// Common variables from `DekuData` for `emit_enum` read/write functions
+/// Common variables from [DekuData](self::DekuData) for `emit_enum` read/write functions
 #[derive(Debug)]
 struct DekuDataEnum<'a> {
     imp: syn::ImplGenerics<'a>,
@@ -311,7 +315,7 @@ impl<'a> TryFrom<&'a DekuData> for DekuDataEnum<'a> {
     }
 }
 
-/// Common variables from `DekuData` for `emit_struct` read/write functions
+/// Common variables from [DekuData](self::DekuData) for `emit_struct` read/write functions
 #[derive(Debug)]
 struct DekuDataStruct<'a> {
     imp: syn::ImplGenerics<'a>,
@@ -342,7 +346,7 @@ impl<'a> TryFrom<&'a DekuData> for DekuDataStruct<'a> {
     }
 }
 
-/// A post-processed version of `FieldReceiver`
+/// A post-processed version of [FieldReceiver](self::FieldReceiver)
 #[derive(Debug)]
 struct FieldData {
     ident: Option<syn::Ident>,
@@ -511,7 +515,7 @@ impl FieldData {
     }
 }
 
-/// A post-processed version of `VariantReceiver`
+/// A post-processed version of [VariantReceiver](self::VariantReceiver)
 #[derive(Debug)]
 struct VariantData {
     ident: syn::Ident,
@@ -600,6 +604,10 @@ struct DekuReceiver {
     /// default context passed to the field
     #[darling(default)]
     ctx_default: Option<syn::punctuated::Punctuated<syn::Expr, syn::token::Comma>>,
+
+    /// additional context passed down to the fields
+    #[darling(default)]
+    ctx_nested: Option<syn::punctuated::Punctuated<syn::Expr, syn::token::Comma>>,
 
     /// A magic value that must appear at the start of this struct/enum's data
     #[darling(default)]

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -561,6 +561,7 @@ fn emit_field_read(
             f.bits.as_ref(),
             f.bytes.as_ref(),
             f.ctx.as_ref(),
+            input.ctx_nested.as_ref(),
         )?;
 
         // The container limiting options are special, we need to generate `(limit, (other, ..))` for them.

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -525,6 +525,7 @@ fn emit_field_write(
             f.bits.as_ref(),
             f.bytes.as_ref(),
             f.ctx.as_ref(),
+            input.ctx_nested.as_ref(),
         )?;
 
         quote! { #object_prefix #field_ident.write(__deku_output, (#write_args)) }

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -235,18 +235,26 @@ fn gen_field_args(
     bits: Option<&Num>,
     bytes: Option<&Num>,
     ctx: Option<&Punctuated<syn::Expr, syn::token::Comma>>,
+    ctx_nested: Option<&Punctuated<syn::Expr, syn::token::Comma>>,
 ) -> syn::Result<TokenStream> {
     let crate_ = get_crate_name();
     let endian = endian.map(gen_endian_from_str).transpose()?;
     let bits = bits.map(|n| quote! {::#crate_::ctx::Size::Bits(#n)});
     let bytes = bytes.map(|n| quote! {::#crate_::ctx::Size::Bytes(#n)});
     let ctx = ctx.map(|c| quote! {#c});
+    let ctx_nested = ctx_nested.map(|c| quote! {#c});
 
     // FIXME: Should be `into_iter` here, see https://github.com/rust-lang/rust/issues/66145.
-    let field_args = [endian.as_ref(), bits.as_ref(), bytes.as_ref(), ctx.as_ref()]
-        .iter()
-        .filter_map(|i| *i)
-        .collect::<Vec<_>>();
+    let field_args = [
+        endian.as_ref(),
+        bits.as_ref(),
+        bytes.as_ref(),
+        ctx.as_ref(),
+        ctx_nested.as_ref(),
+    ]
+    .iter()
+    .filter_map(|i| *i)
+    .collect::<Vec<_>>();
 
     // Because `impl DekuRead<'_, (T1, T2)>` but `impl DekuRead<'_, T1>`(not tuple)
     match &field_args[..] {


### PR DESCRIPTION
This allows clients to pass context arguments down to all fields.

Example
```rust
use deku::prelude::*;

struct MyCtx {}

#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
#[deku(ctx = "ctx: MyCtx", ctx_nested = "ctx")]
pub struct Child {
    data: u32,
}

#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
#[deku(ctx = "ctx: MyCtx", ctx_nested = "ctx")]
pub struct Parent {
    child: Child,
}

impl<'a> DekuRead<'a, MyCtx> for u32 {
    fn read(
        input: &'a deku::bitvec::BitSlice<deku::bitvec::Msb0, u8>,
        ctx: MyCtx,
    ) -> Result<(&'a deku::bitvec::BitSlice<deku::bitvec::Msb0, u8>, Self), DekuError>
    where
        Self: Sized,
    {
        // Custom u32 reader
        todo!()
    }
}

impl DekuWrite<MyCtx> for u32 {
    fn write(
        &self,
        output: &mut deku::bitvec::BitVec<deku::bitvec::Msb0, u8>,
        ctx: MyCtx,
    ) -> Result<(), DekuError> {
        // Custom u32 writer
        todo!()
    }
}
```