### PR TITLE
DekuError: Derive Clone

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@
 use alloc::{format, string::String};
 
 /// Number of bits needed to retry parsing
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct NeedSize {
     bits: usize,
 }
@@ -28,7 +28,7 @@ impl NeedSize {
 }
 
 /// Deku errors
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum DekuError {
     /// Parsing error when reading


### PR DESCRIPTION
Would be nice to have, but not pushing for it (in case there are plans to propagate a `Box<dyn Error>` or something like that).