### PR TITLE
Add logging feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
 default = ["std", "const_generics"]
 std = ["deku_derive/std", "bitvec/std", "alloc"]
 alloc = ["bitvec/alloc"]
+logging = ["deku_derive/log"]
 const_generics = []
 
 [dependencies]

--- a/deku-derive/Cargo.toml
+++ b/deku-derive/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 
 [features]
 std = ["proc-macro-crate"]
+logging = ["log"]
 
 [dependencies]
 quote = "1.0"
@@ -22,6 +23,7 @@ syn = "1.0"
 proc-macro2 = "1.0"
 darling = "0.14"
 proc-macro-crate = { version = "1.0.0", optional = true }
+log = { version = "0.4.17", optional = true }
 
 [dev-dependencies]
 rstest = "0.13"

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -559,6 +559,14 @@ fn emit_field_read(
         }
     });
 
+    let trace_field_log = if cfg!(feature = "log") {
+        quote! {
+            log::trace!("Reading: {}::{} from {}", #ident, #field_ident_str, __deku_rest);
+        }
+    } else {
+        quote! {}
+    };
+
     let field_read_func = if field_reader.is_some() {
         quote! { #field_reader }
     } else {
@@ -668,6 +676,7 @@ fn emit_field_read(
         #bit_offset
         #byte_offset
 
+        #trace_field_log
         let #internal_field_ident = {
             #field_read_tokens
         };


### PR DESCRIPTION
* Improve ease of debugging an incorrect parser implementation by adding
  context to the Err values from deku parsers by adding logging from the
  log crate.
* This is feature-gated under the new "logging" feature.

From the following sample program, you can easily see the improved error
message and debugging since we known the field that was incorrect
parsed. Much easier than gdb.
```
[dependencies]
deku = { path = "../deku", features = ["logging"]}
log = "0.4.17"
env_logger = "0.9.0"
```
```
use deku::prelude::*;

pub struct TestStruct {
    pub a: u16,
    pub b: u16,
}

fn main() {
    env_logger::init();
    TestStruct::from_bytes((&[0x01, 0x02, 0x03], 0)).unwrap();
    println!("Hello, world!");
}
```
```
> RUST_LOG=trace cargo r
    Finished dev [unoptimized + debuginfo] target(s) in 0.27s
     Running `target/debug/deku-testing`
[2022-07-04T16:11:54Z TRACE deku_testing] Reading: TestStruct::a from [00000001, 00000010, 00000011]
[2022-07-04T16:11:54Z TRACE deku_testing] Reading: TestStruct::b from [00000011]
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Incomplete(NeedSize { bits: 16 })', src/main.rs:11:54
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This could be expanded in the future to enums and/or other internal deku
structs.

Even cooler would be something like this:
```text
                                                                      |-----------------|
[2022-07-04T16:08:16Z TRACE deku_testing] Reading: TestStruct::a from [00000001, 00000010, 00000011]
```

See #168