### PR TITLE
Specialize bytes

### DIFF
--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -2,6 +2,14 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use deku::prelude::*;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+struct DekuBits {
+    #[deku(bits = "1")]
+    data_01: u8,
+    #[deku(bits = "7")]
+    data_02: u8,
+}
+
+#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuByte {
     data: u8,
 }
@@ -18,6 +26,14 @@ struct DekuVec {
     count: u8,
     #[deku(count = "count")]
     data: Vec<u8>,
+}
+
+fn deku_read_bits(input: &[u8]) {
+    let (_rest, _v) = DekuBits::from_bytes((input, 0)).unwrap();
+}
+
+fn deku_write_bits(input: &DekuBits) {
+    let _v = input.to_bytes().unwrap();
 }
 
 fn deku_read_byte(input: &[u8]) {
@@ -50,6 +66,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
     c.bench_function("deku_write_byte", |b| {
         b.iter(|| deku_write_byte(black_box(&DekuByte { data: 0x01 })))
+    });
+    c.bench_function("deku_read_bits", |b| {
+        b.iter(|| deku_read_bits(black_box([0xf1].as_ref())))
+    });
+    c.bench_function("deku_write_bits", |b| {
+        b.iter(|| deku_write_bits(black_box(&DekuBits { data_01: 0x0f, data_02: 0x01 })))
     });
 
     c.bench_function("deku_read_enum", |b| {

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -597,27 +597,27 @@ fn emit_field_read(
             quote! {
                 {
                     use core::borrow::Borrow;
-                    #type_as_deku_read::read(__deku_rest, (::#crate_::ctx::Limit::new_count(usize::try_from(*((#field_count).borrow()))?), (#read_args)))
+                    #type_as_deku_read::::read(__deku_rest, (::#crate_::ctx::Limit::new_count(usize::try_from(*((#field_count).borrow()))?), (#read_args)))
                 }
             }
         } else if let Some(field_bits) = &f.bits_read {
             quote! {
                 {
                     use core::borrow::Borrow;
-                    #type_as_deku_read::read(__deku_rest, (::#crate_::ctx::Limit::new_size(::#crate_::ctx::Size::Bits(usize::try_from(*((#field_bits).borrow()))?)), (#read_args)))
+                    #type_as_deku_read::::read(__deku_rest, (::#crate_::ctx::Limit::new_bit_size(::#crate_::ctx::BitSize(usize::try_from(*((#field_bits).borrow()))?)), (#read_args)))
                 }
             }
         } else if let Some(field_bytes) = &f.bytes_read {
             quote! {
                 {
                     use core::borrow::Borrow;
-                    #type_as_deku_read::read(__deku_rest, (::#crate_::ctx::Limit::new_size(::#crate_::ctx::Size::Bytes(usize::try_from(*((#field_bytes).borrow()))?)), (#read_args)))
+                    #type_as_deku_read::::read(__deku_rest, (::#crate_::ctx::Limit::new_byte_size(::#crate_::ctx::ByteSize(usize::try_from(*((#field_bytes).borrow()))?)), (#read_args)))
                 }
             }
         } else if let Some(field_until) = &f.until {
             // We wrap the input into another closure here to enforce that it is actually a callable
             // Otherwise, an incorrectly passed-in integer could unexpectedly convert into a `Count` limit
-            quote! {#type_as_deku_read::read(__deku_rest, (::#crate_::ctx::Limit::new_until(#field_until), (#read_args)))}
+            quote! {#type_as_deku_read::::read(__deku_rest, (::#crate_::ctx::Limit::new_until(#field_until), (#read_args)))}
         } else {
             quote! {#type_as_deku_read::read(__deku_rest, (#read_args))}
         }

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -597,27 +597,27 @@ fn emit_field_read(
             quote! {
                 {
                     use core::borrow::Borrow;
-                    #type_as_deku_read::::read(__deku_rest, (::#crate_::ctx::Limit::new_count(usize::try_from(*((#field_count).borrow()))?), (#read_args)))
+                    #type_as_deku_read::read(__deku_rest, (::#crate_::ctx::Limit::new_count(usize::try_from(*((#field_count).borrow()))?), (#read_args)))
                 }
             }
         } else if let Some(field_bits) = &f.bits_read {
             quote! {
                 {
                     use core::borrow::Borrow;
-                    #type_as_deku_read::::read(__deku_rest, (::#crate_::ctx::Limit::new_bit_size(::#crate_::ctx::BitSize(usize::try_from(*((#field_bits).borrow()))?)), (#read_args)))
+                    #type_as_deku_read::read(__deku_rest, (::#crate_::ctx::Limit::new_bit_size(::#crate_::ctx::BitSize(usize::try_from(*((#field_bits).borrow()))?)), (#read_args)))
                 }
             }
         } else if let Some(field_bytes) = &f.bytes_read {
             quote! {
                 {
                     use core::borrow::Borrow;
-                    #type_as_deku_read::::read(__deku_rest, (::#crate_::ctx::Limit::new_byte_size(::#crate_::ctx::ByteSize(usize::try_from(*((#field_bytes).borrow()))?)), (#read_args)))
+                    #type_as_deku_read::read(__deku_rest, (::#crate_::ctx::Limit::new_byte_size(::#crate_::ctx::ByteSize(usize::try_from(*((#field_bytes).borrow()))?)), (#read_args)))
                 }
             }
         } else if let Some(field_until) = &f.until {
             // We wrap the input into another closure here to enforce that it is actually a callable
             // Otherwise, an incorrectly passed-in integer could unexpectedly convert into a `Count` limit
-            quote! {#type_as_deku_read::::read(__deku_rest, (::#crate_::ctx::Limit::new_until(#field_until), (#read_args)))}
+            quote! {#type_as_deku_read::read(__deku_rest, (::#crate_::ctx::Limit::new_until(#field_until), (#read_args)))}
         } else {
             quote! {#type_as_deku_read::read(__deku_rest, (#read_args))}
         }

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -204,7 +204,8 @@ fn gen_type_from_ctx_id(
 }
 
 /// Generate argument for `id`:
-/// `#deku(endian = "big", bits = "1")` -> `Endian::Big, Size::Bits(1)`
+/// `#deku(endian = "big", bits = "1")` -> `Endian::Big, BitSize(1)`
+/// `#deku(endian = "big", bytes = "1")` -> `Endian::Big, ByteSize(1)`
 pub(crate) fn gen_id_args(
     endian: Option<&syn::LitStr>,
     bits: Option<&Num>,
@@ -212,8 +213,8 @@ pub(crate) fn gen_id_args(
 ) -> syn::Result<TokenStream> {
     let crate_ = get_crate_name();
     let endian = endian.map(gen_endian_from_str).transpose()?;
-    let bits = bits.map(|n| quote! {::#crate_::ctx::Size::Bits(#n)});
-    let bytes = bytes.map(|n| quote! {::#crate_::ctx::Size::Bytes(#n)});
+    let bits = bits.map(|n| quote! {::#crate_::ctx::BitSize(#n)});
+    let bytes = bytes.map(|n| quote! {::#crate_::ctx::ByteSize(#n)});
 
     // FIXME: Should be `into_iter` here, see https://github.com/rust-lang/rust/issues/66145.
     let id_args = [endian.as_ref(), bits.as_ref(), bytes.as_ref()]
@@ -229,7 +230,8 @@ pub(crate) fn gen_id_args(
 
 /// Generate argument for fields:
 ///
-/// `#deku(endian = "big", bits = "1", ctx = "a")` -> `Endian::Big, Size::Bits(1), a`
+/// `#deku(endian = "big", bits = "1", ctx = "a")` -> `Endian::Big, BitSize(1), a`
+/// `#deku(endian = "big", bytes = "1", ctx = "a")` -> `Endian::Big, ByteSize(1), a`
 fn gen_field_args(
     endian: Option<&syn::LitStr>,
     bits: Option<&Num>,
@@ -238,8 +240,8 @@ fn gen_field_args(
 ) -> syn::Result<TokenStream> {
     let crate_ = get_crate_name();
     let endian = endian.map(gen_endian_from_str).transpose()?;
-    let bits = bits.map(|n| quote! {::#crate_::ctx::Size::Bits(#n)});
-    let bytes = bytes.map(|n| quote! {::#crate_::ctx::Size::Bytes(#n)});
+    let bits = bits.map(|n| quote! {::#crate_::ctx::BitSize(#n)});
+    let bytes = bytes.map(|n| quote! {::#crate_::ctx::ByteSize(#n)});
     let ctx = ctx.map(|c| quote! {#c});
 
     // FIXME: Should be `into_iter` here, see https://github.com/rust-lang/rust/issues/66145.

--- a/examples/custom_reader_and_writer.rs
+++ b/examples/custom_reader_and_writer.rs
@@ -1,12 +1,12 @@
 use deku::bitvec::{BitSlice, BitVec, Msb0};
-use deku::ctx::Size;
+use deku::ctx::BitSize;
 use deku::prelude::*;
 use std::convert::TryInto;
 
 fn bit_flipper_read(
     field_a: u8,
     rest: &BitSlice<Msb0, u8>,
-    bit_size: Size,
+    bit_size: BitSize,
 ) -> Result<(&BitSlice<Msb0, u8>, u8), DekuError> {
     // Access to previously read fields
     println!("field_a = 0x{:X}", field_a);
@@ -30,7 +30,7 @@ fn bit_flipper_write(
     field_a: u8,
     field_b: u8,
     output: &mut BitVec<Msb0, u8>,
-    bit_size: Size,
+    bit_size: BitSize,
 ) -> Result<(), DekuError> {
     // Access to previously written fields
     println!("field_a = 0x{:X}", field_a);
@@ -52,8 +52,8 @@ struct DekuTest {
     field_a: u8,
 
     #[deku(
-        reader = "bit_flipper_read(*field_a, deku::rest, Size::Bits(8))",
-        writer = "bit_flipper_write(*field_a, *field_b, deku::output, Size::Bits(8))"
+        reader = "bit_flipper_read(*field_a, deku::rest, BitSize(8))",
+        writer = "bit_flipper_write(*field_a, *field_b, deku::output, BitSize(8))"
     )]
     field_b: u8,
 }

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -855,7 +855,7 @@ struct Type1 {
 // is equivalent to
 
 struct Type1 {
-    #[deku(ctx = "Endian::Big, Size::Bits(1)")]
+    #[deku(ctx = "Endian::Big, BitSize(1)")]
     field: u8,
 }
 ```
@@ -874,7 +874,7 @@ struct Type1 {
 struct Type1 {
     #[deku(ctx = "Endian::Big")]
     field_a: u16,
-    #[deku(ctx = "Endian::Big, Size::Bits(5), *field_a")] // endian is prepended
+    #[deku(ctx = "Endian::Big, BitSize(5), *field_a")] // endian is prepended
     field_b: SubType,
 }
 ```

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -72,8 +72,11 @@ impl FromStr for Endian {
     }
 }
 
+#[allow(clippy::derive_partial_eq_without_eq)]
+// derive_partial_eq_without_eq false positive in struct using traits
+// For details: https://github.com/rust-lang/rust-clippy/issues/9413
 /// A limit placed on a container's elements
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum Limit<T, Predicate: FnMut(&T) -> bool> {
     /// Read a specific count of elements
     Count(usize),

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@
 use alloc::{format, string::String};
 
 /// Number of bits needed to retry parsing
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NeedSize {
     bits: usize,
 }
@@ -28,7 +28,7 @@ impl NeedSize {
 }
 
 /// Deku errors
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DekuError {
     /// Parsing error when reading

--- a/src/impls/bool.rs
+++ b/src/impls/bool.rs
@@ -72,7 +72,7 @@ mod tests {
         let input = &[0b01_000000];
         let bit_slice = input.view_bits::<Msb0>();
 
-        let (rest, res_read) = bool::read(bit_slice, crate::ctx::Size::Bits(2)).unwrap();
+        let (rest, res_read) = bool::read(bit_slice, crate::ctx::BitSize(2)).unwrap();
         assert_eq!(true, res_read);
         assert_eq!(6, rest.len());
 

--- a/src/impls/boxed.rs
+++ b/src/impls/boxed.rs
@@ -96,8 +96,8 @@ mod tests {
         case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD].into_boxed_slice(), bits![Msb0, u8;], vec![0xAA, 0xBB, 0xCC, 0xDD]),
         case::predicate_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), (|v: &u16| *v == 0xBBAA).into(), vec![0xBBAA].into_boxed_slice(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
         case::predicate_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), (|v: &u16| *v == 0xAABB).into(), vec![0xAABB].into_boxed_slice(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), Size::Bits(16).into(), vec![0xBBAA].into_boxed_slice(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), Size::Bits(16).into(), vec![0xAABB].into_boxed_slice(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
+        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), BitSize(16).into(), vec![0xBBAA].into_boxed_slice(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
+        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), BitSize(16).into(), vec![0xAABB].into_boxed_slice(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
     )]
     fn test_boxed_slice<Predicate: FnMut(&u16) -> bool>(
         input: &[u8],
@@ -114,13 +114,13 @@ mod tests {
         let bit_size = bit_size.unwrap();
 
         let (rest, res_read) =
-            <Box<[u16]>>::read(bit_slice, (limit, (endian, Size::Bits(bit_size)))).unwrap();
+            <Box<[u16]>>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap();
         assert_eq!(expected, res_read);
         assert_eq!(expected_rest, rest);
 
         let mut res_write = bitvec![Msb0, u8;];
         res_read
-            .write(&mut res_write, (endian, Size::Bits(bit_size)))
+            .write(&mut res_write, (endian, BitSize(bit_size)))
             .unwrap();
         assert_eq!(expected_write, res_write.into_vec());
 

--- a/src/impls/hashset.rs
+++ b/src/impls/hashset.rs
@@ -91,8 +91,16 @@ impl<
             }
 
             // Read until a given quantity of bits have been read
-            Limit::Size(size) => {
-                let bit_size = size.bit_size();
+            Limit::BitSize(size) => {
+                let bit_size = size.0;
+                read_hashset_with_predicate(input, None, inner_ctx, move |read_bits, _| {
+                    read_bits == bit_size
+                })
+            }
+
+            // Read until a given quantity of bits have been read
+            Limit::ByteSize(size) => {
+                let bit_size = size.0 * 8;
                 read_hashset_with_predicate(input, None, inner_ctx, move |read_bits, _| {
                     read_bits == bit_size
                 })
@@ -151,7 +159,7 @@ mod tests {
         case::count_1([0xAA, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), vec![0xAA].into_iter().collect(), bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1, 1]),
         case::count_2([0xAA, 0xBB, 0xCC].as_ref(), Endian::Little, Some(8), 2.into(), vec![0xAA, 0xBB].into_iter().collect(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0]),
         case::until_null([0xAA, 0, 0xBB].as_ref(), Endian::Little, None, (|v: &u8| *v == 0u8).into(), vec![0xAA, 0].into_iter().collect(), bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::until_bits([0xAA, 0xBB].as_ref(), Endian::Little, None, Size::Bits(8).into(), vec![0xAA].into_iter().collect(), bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1, 1]),
+        case::until_bits([0xAA, 0xBB].as_ref(), Endian::Little, None, BitSize(8).into(), vec![0xAA].into_iter().collect(), bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1, 1]),
         case::bits_6([0b0110_1001, 0b1110_1001].as_ref(), Endian::Little, Some(6), 2.into(), vec![0b00_011010, 0b00_011110].into_iter().collect(), bits![Msb0, u8; 1, 0, 0, 1]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
         case::not_enough_data([].as_ref(), Endian::Little, Some(9), 1.into(), FxHashSet::default(), bits![Msb0, u8;]),
@@ -162,7 +170,7 @@ mod tests {
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
         case::not_enough_data_until([0xAA].as_ref(), Endian::Little, Some(8), (|_: &u8| false).into(), FxHashSet::default(), bits![Msb0, u8;]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (Size::Bits(16)).into(), FxHashSet::default(), bits![Msb0, u8;]),
+        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (BitSize(16)).into(), FxHashSet::default(), bits![Msb0, u8;]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
         case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), FxHashSet::default(), bits![Msb0, u8;]),
     )]
@@ -178,7 +186,7 @@ mod tests {
 
         let (rest, res_read) = match bit_size {
             Some(bit_size) => {
-                FxHashSet::<u8>::read(bit_slice, (limit, (endian, Size::Bits(bit_size)))).unwrap()
+                FxHashSet::<u8>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap()
             }
             None => FxHashSet::<u8>::read(bit_slice, (limit, (endian))).unwrap(),
         };
@@ -202,8 +210,8 @@ mod tests {
         case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD].into_iter().collect(), bits![Msb0, u8;], vec![0xCC, 0xDD, 0xAA, 0xBB]),
         case::predicate_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), (|v: &u16| *v == 0xBBAA).into(), vec![0xBBAA].into_iter().collect(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
         case::predicate_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), (|v: &u16| *v == 0xAABB).into(), vec![0xAABB].into_iter().collect(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), Size::Bits(16).into(), vec![0xBBAA].into_iter().collect(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), Size::Bits(16).into(), vec![0xAABB].into_iter().collect(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
+        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), BitSize(16).into(), vec![0xBBAA].into_iter().collect(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
+        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), BitSize(16).into(), vec![0xAABB].into_iter().collect(), bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
     )]
     fn test_hashset_read_write<Predicate: FnMut(&u16) -> bool>(
         input: &[u8],
@@ -220,13 +228,13 @@ mod tests {
         let bit_size = bit_size.unwrap();
 
         let (rest, res_read) =
-            FxHashSet::<u16>::read(bit_slice, (limit, (endian, Size::Bits(bit_size)))).unwrap();
+            FxHashSet::<u16>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap();
         assert_eq!(expected, res_read);
         assert_eq!(expected_rest, rest);
 
         let mut res_write = bitvec![Msb0, u8;];
         res_read
-            .write(&mut res_write, (endian, Size::Bits(bit_size)))
+            .write(&mut res_write, (endian, BitSize(bit_size)))
             .unwrap();
         assert_eq!(expected_write, res_write.into_vec());
     }

--- a/src/impls/nonzero.rs
+++ b/src/impls/nonzero.rs
@@ -41,9 +41,9 @@ macro_rules! ImplDekuTraitsCtx {
 macro_rules! ImplDekuTraits {
     ($typ:ty, $readtype:ty) => {
         ImplDekuTraitsCtx!($typ, $readtype, (), ());
-        ImplDekuTraitsCtx!($typ, $readtype, (endian, size), (Endian, Size));
+        ImplDekuTraitsCtx!($typ, $readtype, (endian, bitsize), (Endian, BitSize));
+        ImplDekuTraitsCtx!($typ, $readtype, (endian, bytesize), (Endian, ByteSize));
         ImplDekuTraitsCtx!($typ, $readtype, endian, Endian);
-        ImplDekuTraitsCtx!($typ, $readtype, size, Size);
     };
 }
 

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -318,9 +318,9 @@ macro_rules! ForwardDekuRead {
 
                 // Since we don't have a #[bits] or [bytes], check if we can use bytes for perf
                 if (bit_size.0 % 8) == 0 {
-                    <$typ>::read(input, (endian, bit_size))
-                } else {
                     <$typ>::read(input, (endian, ByteSize(bit_size.0 / 8)))
+                } else {
+                    <$typ>::read(input, (endian, bit_size))
                 }
             }
         }

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -5,8 +5,122 @@ use core::convert::TryInto;
 #[cfg(feature = "alloc")]
 use alloc::format;
 
+// TODO: duplicate code, separate macros for bits vs bytes? we only want to specialize reading a byte u8...
+impl DekuRead<'_, (Endian, BitSize)> for u8 {
+    fn read(
+        input: &BitSlice<Msb0, u8>,
+        (endian, size): (Endian, BitSize),
+        ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
+        let max_type_bits: usize = BitSize::of::<u8>().0;
+        let bit_size: usize = size.0;
+
+        let input_is_le = endian.is_le();
+
+        if bit_size > max_type_bits {
+            return Err(DekuError::Parse(format!(
+                        "too much data: container of {} bits cannot hold {} bits",
+                        max_type_bits, bit_size
+                        )));
+        }
+
+        if input.len() < bit_size {
+            return Err(DekuError::Incomplete(crate::error::NeedSize::new(bit_size)));
+        }
+
+        let (bit_slice, rest) = input.split_at(bit_size);
+
+        let pad = 8 * ((bit_slice.len() + 7) / 8) - bit_slice.len();
+
+        let value = if pad == 0
+            && bit_slice.len() == max_type_bits
+            && bit_slice.as_raw_slice().len() * 8 == max_type_bits
+            {
+                // if everything is aligned, just read the value
+                let bytes: &[u8] = bit_slice.as_raw_slice();
+
+                // Read value
+                if input_is_le {
+                    <u8>::from_le_bytes(bytes.try_into()?)
+                } else {
+                    <u8>::from_be_bytes(bytes.try_into()?)
+                }
+            } else {
+                // Create a new BitVec from the slice and pad un-aligned chunks
+                // i.e. [10010110, 1110] -> [10010110, 00001110]
+                let bits: BitVec<Msb0, u8> = {
+                    let mut bits = BitVec::with_capacity(bit_slice.len() + pad);
+
+                    // Copy bits to new BitVec
+                    bits.extend_from_bitslice(bit_slice);
+
+                    // Force align
+                    //i.e. [1110, 10010110] -> [11101001, 0110]
+                    bits.force_align();
+
+                    // Some padding to next byte
+                    let index = if input_is_le {
+                        bits.len() - (8 - pad)
+                    } else {
+                        0
+                    };
+                    for _ in 0..pad {
+                        bits.insert(index, false);
+                    }
+
+                    // Pad up-to size of type
+                    for _ in 0..(max_type_bits - bits.len()) {
+                        if input_is_le {
+                            bits.push(false);
+                        } else {
+                            bits.insert(0, false);
+                        }
+                    }
+
+                    bits
+                };
+
+                let bytes: &[u8] = bits.as_raw_slice();
+
+                // Read value
+                if input_is_le {
+                    <u8>::from_le_bytes(bytes.try_into()?)
+                } else {
+                    <u8>::from_be_bytes(bytes.try_into()?)
+                }
+            };
+        Ok((rest, value))
+    }
+}
+
+// specialize u8
+impl DekuRead<'_, (Endian, ByteSize)> for u8 {
+    fn read(
+        input: &BitSlice<Msb0, u8>,
+        (_, size): (Endian, ByteSize),
+        ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
+        let max_type_bits: usize = BitSize::of::<u8>().0;
+        let bit_size: usize = size.0 * 8;
+
+        if bit_size > max_type_bits {
+            return Err(DekuError::Parse(format!(
+                        "too much data: container of {} bits cannot hold {} bits",
+                        max_type_bits, bit_size
+                        )));
+        }
+
+        if input.len() < bit_size {
+            return Err(DekuError::Incomplete(crate::error::NeedSize::new(bit_size)));
+        }
+
+        let (bit_slice, rest) = input.split_at(bit_size);
+        let bytes: &[u8] = bit_slice.as_raw_slice();
+
+        Ok((rest, bytes[0]))
+    }
+}
+
 macro_rules! ImplDekuRead {
-    ($typ:ty) => {
+    ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, BitSize)> for $typ {
             fn read(
                 input: &BitSlice<Msb0, u8>,
@@ -116,14 +230,41 @@ macro_rules! ImplDekuRead {
 
                 let (bit_slice, rest) = input.split_at(bit_size);
 
-                let bytes: &[u8] = bit_slice.as_raw_slice();
+                let pad = 8 * ((bit_slice.len() + 7) / 8) - bit_slice.len();
 
-                // Read value
-                let value = if input_is_le {
-                    <$typ>::from_le_bytes(bytes.try_into()?)
+                // TODO: mention that this is slow? a conditional should be fast...
+                let value = if pad == 0
+                    && bit_slice.len() == max_type_bits
+                    && bit_slice.as_raw_slice().len() * 8 == max_type_bits
+                {
+                    // if everything is aligned, just read the value
+                    let bytes: &[u8] = bit_slice.as_raw_slice();
+
+                    // Read value
+                    if input_is_le {
+                        <$typ>::from_le_bytes(bytes.try_into()?)
+                    } else {
+                        <$typ>::from_be_bytes(bytes.try_into()?)
+                    }
                 } else {
-                    <$typ>::from_be_bytes(bytes.try_into()?)
+                    let bytes: &[u8] = bit_slice.as_raw_slice();
+
+                    // cannot use from_X_bytes as we don't have enough bytes for $typ
+                    // read manually
+                    let mut res: $inner = 0;
+                    for b in bytes.iter().rev() {
+                        res <<= 8 as $inner;
+                        res |= *b as $inner;
+                    }
+
+                    if input_is_le {
+                        res as $typ
+                    } else {
+                        res = res.swap_bytes();
+                        res as $typ
+                    }
                 };
+
                 Ok((rest, value))
             }
         }
@@ -363,7 +504,14 @@ macro_rules! ForwardDekuWrite {
 
 macro_rules! ImplDekuTraits {
     ($typ:ty) => {
-        ImplDekuRead!($typ);
+        ImplDekuRead!($typ, $typ);
+        ForwardDekuRead!($typ);
+
+        ImplDekuWrite!($typ);
+        ForwardDekuWrite!($typ);
+    };
+    ($typ:ty, $inner:ty) => {
+        ImplDekuRead!($typ, $inner);
         ForwardDekuRead!($typ);
 
         ImplDekuWrite!($typ);
@@ -381,7 +529,12 @@ macro_rules! ImplDekuTraitsSignExtend {
     };
 }
 
-ImplDekuTraits!(u8);
+// ImplDekuTraits!(u8);
+// TODO: separate macros for bits vs bytes? we only want to specialize reading a byte u8...
+ForwardDekuRead!(u8);
+ImplDekuWrite!(u8);
+ForwardDekuWrite!(u8);
+
 ImplDekuTraits!(u16);
 ImplDekuTraits!(u32);
 ImplDekuTraits!(u64);
@@ -395,8 +548,8 @@ ImplDekuTraitsSignExtend!(i64, u64);
 ImplDekuTraitsSignExtend!(i128, u128);
 ImplDekuTraitsSignExtend!(isize, usize);
 
-ImplDekuTraits!(f32);
-ImplDekuTraits!(f64);
+ImplDekuTraits!(f32, u32);
+ImplDekuTraits!(f64, u64);
 
 #[cfg(test)]
 mod tests {

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -232,7 +232,6 @@ macro_rules! ImplDekuRead {
 
                 let pad = 8 * ((bit_slice.len() + 7) / 8) - bit_slice.len();
 
-                // TODO: mention that this is slow? a conditional should be fast...
                 let value = if pad == 0
                     && bit_slice.len() == max_type_bits
                     && bit_slice.as_raw_slice().len() * 8 == max_type_bits

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -10,7 +10,7 @@ impl DekuRead<'_, (Endian, BitSize)> for u8 {
     fn read(
         input: &BitSlice<Msb0, u8>,
         (endian, size): (Endian, BitSize),
-        ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
+    ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
         let max_type_bits: usize = BitSize::of::<u8>().0;
         let bit_size: usize = size.0;
 
@@ -18,9 +18,9 @@ impl DekuRead<'_, (Endian, BitSize)> for u8 {
 
         if bit_size > max_type_bits {
             return Err(DekuError::Parse(format!(
-                        "too much data: container of {} bits cannot hold {} bits",
-                        max_type_bits, bit_size
-                        )));
+                "too much data: container of {} bits cannot hold {} bits",
+                max_type_bits, bit_size
+            )));
         }
 
         if input.len() < bit_size {
@@ -34,60 +34,60 @@ impl DekuRead<'_, (Endian, BitSize)> for u8 {
         let value = if pad == 0
             && bit_slice.len() == max_type_bits
             && bit_slice.as_raw_slice().len() * 8 == max_type_bits
-            {
-                // if everything is aligned, just read the value
-                let bytes: &[u8] = bit_slice.as_raw_slice();
+        {
+            // if everything is aligned, just read the value
+            let bytes: &[u8] = bit_slice.as_raw_slice();
 
-                // Read value
-                if input_is_le {
-                    <u8>::from_le_bytes(bytes.try_into()?)
-                } else {
-                    <u8>::from_be_bytes(bytes.try_into()?)
-                }
+            // Read value
+            if input_is_le {
+                <u8>::from_le_bytes(bytes.try_into()?)
             } else {
-                // Create a new BitVec from the slice and pad un-aligned chunks
-                // i.e. [10010110, 1110] -> [10010110, 00001110]
-                let bits: BitVec<Msb0, u8> = {
-                    let mut bits = BitVec::with_capacity(bit_slice.len() + pad);
+                <u8>::from_be_bytes(bytes.try_into()?)
+            }
+        } else {
+            // Create a new BitVec from the slice and pad un-aligned chunks
+            // i.e. [10010110, 1110] -> [10010110, 00001110]
+            let bits: BitVec<Msb0, u8> = {
+                let mut bits = BitVec::with_capacity(bit_slice.len() + pad);
 
-                    // Copy bits to new BitVec
-                    bits.extend_from_bitslice(bit_slice);
+                // Copy bits to new BitVec
+                bits.extend_from_bitslice(bit_slice);
 
-                    // Force align
-                    //i.e. [1110, 10010110] -> [11101001, 0110]
-                    bits.force_align();
+                // Force align
+                //i.e. [1110, 10010110] -> [11101001, 0110]
+                bits.force_align();
 
-                    // Some padding to next byte
-                    let index = if input_is_le {
-                        bits.len() - (8 - pad)
-                    } else {
-                        0
-                    };
-                    for _ in 0..pad {
-                        bits.insert(index, false);
-                    }
-
-                    // Pad up-to size of type
-                    for _ in 0..(max_type_bits - bits.len()) {
-                        if input_is_le {
-                            bits.push(false);
-                        } else {
-                            bits.insert(0, false);
-                        }
-                    }
-
-                    bits
-                };
-
-                let bytes: &[u8] = bits.as_raw_slice();
-
-                // Read value
-                if input_is_le {
-                    <u8>::from_le_bytes(bytes.try_into()?)
+                // Some padding to next byte
+                let index = if input_is_le {
+                    bits.len() - (8 - pad)
                 } else {
-                    <u8>::from_be_bytes(bytes.try_into()?)
+                    0
+                };
+                for _ in 0..pad {
+                    bits.insert(index, false);
                 }
+
+                // Pad up-to size of type
+                for _ in 0..(max_type_bits - bits.len()) {
+                    if input_is_le {
+                        bits.push(false);
+                    } else {
+                        bits.insert(0, false);
+                    }
+                }
+
+                bits
             };
+
+            let bytes: &[u8] = bits.as_raw_slice();
+
+            // Read value
+            if input_is_le {
+                <u8>::from_le_bytes(bytes.try_into()?)
+            } else {
+                <u8>::from_be_bytes(bytes.try_into()?)
+            }
+        };
         Ok((rest, value))
     }
 }
@@ -97,15 +97,15 @@ impl DekuRead<'_, (Endian, ByteSize)> for u8 {
     fn read(
         input: &BitSlice<Msb0, u8>,
         (_, size): (Endian, ByteSize),
-        ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
+    ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
         let max_type_bits: usize = BitSize::of::<u8>().0;
         let bit_size: usize = size.0 * 8;
 
         if bit_size > max_type_bits {
             return Err(DekuError::Parse(format!(
-                        "too much data: container of {} bits cannot hold {} bits",
-                        max_type_bits, bit_size
-                        )));
+                "too much data: container of {} bits cannot hold {} bits",
+                max_type_bits, bit_size
+            )));
         }
 
         if input.len() < bit_size {

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -344,7 +344,12 @@ macro_rules! ForwardDekuRead {
             ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
                 let endian = Endian::default();
 
-                <$typ>::read(input, (endian, bit_size))
+                // check if we can use ByteSize for performance
+                if (bit_size.0 % 8) == 0 {
+                    <$typ>::read(input, (endian, ByteSize(bit_size.0 / 8)))
+                } else {
+                    <$typ>::read(input, (endian, bit_size))
+                }
             }
         }
 

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -79,8 +79,16 @@ where
             }
 
             // Read until a given quantity of bits have been read
-            Limit::Size(size) => {
-                let bit_size = size.bit_size();
+            Limit::BitSize(size) => {
+                let bit_size = size.0;
+                read_slice_with_predicate(input, inner_ctx, move |read_bits, _| {
+                    read_bits == bit_size
+                })
+            }
+
+            // Read until a given quantity of bytes have been read
+            Limit::ByteSize(size) => {
+                let bit_size = size.0 * 8;
                 read_slice_with_predicate(input, inner_ctx, move |read_bits, _| {
                     read_bits == bit_size
                 })

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -85,8 +85,16 @@ impl<'a, T: DekuRead<'a, Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool>
             }
 
             // Read until a given quantity of bits have been read
-            Limit::Size(size) => {
-                let bit_size = size.bit_size();
+            Limit::BitSize(size) => {
+                let bit_size = size.0;
+                read_vec_with_predicate(input, None, inner_ctx, move |read_bits, _| {
+                    read_bits == bit_size
+                })
+            }
+
+            // Read until a given quantity of bits have been read
+            Limit::ByteSize(size) => {
+                let bit_size = size.0 * 8;
                 read_vec_with_predicate(input, None, inner_ctx, move |read_bits, _| {
                     read_bits == bit_size
                 })
@@ -140,7 +148,7 @@ mod tests {
         case::count_1([0xAA, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), vec![0xAA], bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1, 1]),
         case::count_2([0xAA, 0xBB, 0xCC].as_ref(), Endian::Little, Some(8), 2.into(), vec![0xAA, 0xBB], bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0]),
         case::until_null([0xAA, 0, 0xBB].as_ref(), Endian::Little, None, (|v: &u8| *v == 0u8).into(), vec![0xAA, 0], bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::until_bits([0xAA, 0xBB].as_ref(), Endian::Little, None, Size::Bits(8).into(), vec![0xAA], bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1, 1]),
+        case::until_bits([0xAA, 0xBB].as_ref(), Endian::Little, None, BitSize(8).into(), vec![0xAA], bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1, 1]),
         case::bits_6([0b0110_1001, 0b1110_1001].as_ref(), Endian::Little, Some(6), 2.into(), vec![0b00_011010, 0b00_011110], bits![Msb0, u8; 1, 0, 0, 1]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
         case::not_enough_data([].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![Msb0, u8;]),
@@ -151,7 +159,7 @@ mod tests {
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
         case::not_enough_data_until([0xAA].as_ref(), Endian::Little, Some(8), (|_: &u8| false).into(), vec![], bits![Msb0, u8;]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (Size::Bits(16)).into(), vec![], bits![Msb0, u8;]),
+        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (BitSize(16)).into(), vec![], bits![Msb0, u8;]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
         case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![Msb0, u8;]),
     )]
@@ -167,7 +175,7 @@ mod tests {
 
         let (rest, res_read) = match bit_size {
             Some(bit_size) => {
-                Vec::<u8>::read(bit_slice, (limit, (endian, Size::Bits(bit_size)))).unwrap()
+                Vec::<u8>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap()
             }
             None => Vec::<u8>::read(bit_slice, (limit, (endian))).unwrap(),
         };
@@ -191,8 +199,8 @@ mod tests {
         case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD], bits![Msb0, u8;], vec![0xAA, 0xBB, 0xCC, 0xDD]),
         case::predicate_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), (|v: &u16| *v == 0xBBAA).into(), vec![0xBBAA], bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
         case::predicate_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), (|v: &u16| *v == 0xAABB).into(), vec![0xAABB], bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), Size::Bits(16).into(), vec![0xBBAA], bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), Size::Bits(16).into(), vec![0xAABB], bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
+        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), BitSize(16).into(), vec![0xBBAA], bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
+        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), BitSize(16).into(), vec![0xAABB], bits![Msb0, u8; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
     )]
     fn test_vec_read_write<Predicate: FnMut(&u16) -> bool>(
         input: &[u8],
@@ -209,13 +217,13 @@ mod tests {
         let bit_size = bit_size.unwrap();
 
         let (rest, res_read) =
-            Vec::<u16>::read(bit_slice, (limit, (endian, Size::Bits(bit_size)))).unwrap();
+            Vec::<u16>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap();
         assert_eq!(expected, res_read);
         assert_eq!(expected_rest, rest);
 
         let mut res_write = bitvec![Msb0, u8;];
         res_read
-            .write(&mut res_write, (endian, Size::Bits(bit_size)))
+            .write(&mut res_write, (endian, BitSize(bit_size)))
             .unwrap();
         assert_eq!(expected_write, res_write.into_vec());
 

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -52,7 +52,7 @@ mod tests {
                 let _ = TestDeku::try_from(input.as_ref()).unwrap();
             })
             .0,
-            (4, 3, 3) // TODO: why did this change..?
+            (3, 0, 3)
         );
     }
 }

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -52,7 +52,7 @@ mod tests {
                 let _ = TestDeku::try_from(input.as_ref()).unwrap();
             })
             .0,
-            (3, 0, 3)
+            (4, 3, 3) // TODO: why did this change..?
         );
     }
 }

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -21,6 +21,13 @@ enum NestedEnum {
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+#[deku(type = "u32", bytes = "2", ctx = "_endian: Endian")]
+enum NestedEnum2 {
+    #[deku(id = "0x01")]
+    VarA(u8),
+}
+
+#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(endian = "big")]
 struct TestDeku {
     field_a: u8,
@@ -34,6 +41,7 @@ struct TestDeku {
     field_g: u8, // 1 alloc (bits read)
     #[deku(bits = "5")]
     field_h: u8, // 1 alloc (bits read)
+    field_i: NestedEnum2,
 }
 
 mod tests {
@@ -45,7 +53,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_simple() {
-        let input = hex!("aabbbbcc0102ddffffffaa");
+        let input = hex!("aa_bbbb_cc_0102_dd_ffffff_aa_0100ff");
 
         assert_eq!(
             count_alloc(|| {


### PR DESCRIPTION
Remove Size in favor of a BitSize and ByteSize. This allows the
Deku{Read/Write}(Endian, BitSize) and Deku{Read/Write}(Endian, ByteSize)
impls to be created and allow the ByteSize impls to be faster. Most of
the assumption I made (and the perf that is gained) is from the removal
of this branch for bytes:

```rust
let value = if pad == 0
                      && bit_slice.len() == max_type_bits
                      && bit_slice.as_raw_slice().len() * 8 == max_type_bits
                  {
```

See https://github.com/sharksforarms/deku/issues/44

I Added some benchmarks, in order to get a good idea of what perf this
allows. The benchmarks look pretty good, but I'm on my old thinkpad.
These results are vs the benchmarks running from master.

```
deku_read_vec           time:   [744.39 ns 751.13 ns 759.58 ns]
                        change: [-23.681% -21.358% -19.142%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```

 See https://github.com/sharksforarms/deku/issues/25