### PR TITLE
Constify primitive bit size of types

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -151,11 +151,10 @@ pub struct BitSize(pub usize);
 
 impl BitSize {
     /// Convert the size in bytes to a bit size.
-    ///
-    /// # Panic
-    /// Panic if `byte_size * 8` is greater than `usize::MAX`.
-    fn bits_from_bytes(byte_size: usize) -> Self {
-        Self(byte_size.checked_mul(8).expect("bit size overflow"))
+    const fn bits_from_bytes(byte_size: usize) -> Self {
+        // TODO: use checked_mul when const_option is enabled
+        // link: https://github.com/rust-lang/rust/issues/67441
+        Self(byte_size * 8)
     }
 
     /// Returns the bit size of a type.
@@ -165,10 +164,7 @@ impl BitSize {
     ///
     /// assert_eq!(BitSize::of::<i32>(), BitSize(4 * 8));
     /// ```
-    ///
-    /// # Panics
-    /// Panic if the bit size of given type is greater than `usize::MAX`
-    pub fn of<T>() -> Self {
+    pub const fn of<T>() -> Self {
         Self::bits_from_bytes(core::mem::size_of::<T>())
     }
 

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -11,13 +11,13 @@ impl DekuRead<'_, (Endian, ByteSize)> for u8 {
         input: &BitSlice<Msb0, u8>,
         (_, size): (Endian, ByteSize),
     ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
-        let max_type_bits: usize = BitSize::of::<u8>().0;
+        const MAX_TYPE_BITS: usize = BitSize::of::<u8>().0;
         let bit_size: usize = size.0 * 8;
 
-        if bit_size > max_type_bits {
+        if bit_size > MAX_TYPE_BITS {
             return Err(DekuError::Parse(format!(
                 "too much data: container of {} bits cannot hold {} bits",
-                max_type_bits, bit_size
+                MAX_TYPE_BITS, bit_size
             )));
         }
 
@@ -39,15 +39,15 @@ macro_rules! ImplDekuReadBits {
                 input: &BitSlice<Msb0, u8>,
                 (endian, size): (Endian, BitSize),
             ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
-                let max_type_bits: usize = BitSize::of::<$typ>().0;
+                const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 let bit_size: usize = size.0;
 
                 let input_is_le = endian.is_le();
 
-                if bit_size > max_type_bits {
+                if bit_size > MAX_TYPE_BITS {
                     return Err(DekuError::Parse(format!(
                         "too much data: container of {} bits cannot hold {} bits",
-                        max_type_bits, bit_size
+                        MAX_TYPE_BITS, bit_size
                     )));
                 }
 
@@ -60,8 +60,8 @@ macro_rules! ImplDekuReadBits {
                 let pad = 8 * ((bit_slice.len() + 7) / 8) - bit_slice.len();
 
                 let value = if pad == 0
-                    && bit_slice.len() == max_type_bits
-                    && bit_slice.as_raw_slice().len() * 8 == max_type_bits
+                    && bit_slice.len() == MAX_TYPE_BITS
+                    && bit_slice.as_raw_slice().len() * 8 == MAX_TYPE_BITS
                 {
                     // if everything is aligned, just read the value
                     let bytes: &[u8] = bit_slice.as_raw_slice();
@@ -96,7 +96,7 @@ macro_rules! ImplDekuReadBits {
                         }
 
                         // Pad up-to size of type
-                        for _ in 0..(max_type_bits - bits.len()) {
+                        for _ in 0..(MAX_TYPE_BITS - bits.len()) {
                             if input_is_le {
                                 bits.push(false);
                             } else {
@@ -129,15 +129,15 @@ macro_rules! ImplDekuReadBytes {
                 input: &BitSlice<Msb0, u8>,
                 (endian, size): (Endian, ByteSize),
             ) -> Result<(&BitSlice<Msb0, u8>, Self), DekuError> {
-                let max_type_bits: usize = BitSize::of::<$typ>().0;
+                const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 let bit_size: usize = size.0 * 8;
 
                 let input_is_le = endian.is_le();
 
-                if bit_size > max_type_bits {
+                if bit_size > MAX_TYPE_BITS {
                     return Err(DekuError::Parse(format!(
                         "too much data: container of {} bits cannot hold {} bits",
-                        max_type_bits, bit_size
+                        MAX_TYPE_BITS, bit_size
                     )));
                 }
 
@@ -150,8 +150,8 @@ macro_rules! ImplDekuReadBytes {
                 let pad = 8 * ((bit_slice.len() + 7) / 8) - bit_slice.len();
 
                 let value = if pad == 0
-                    && bit_slice.len() == max_type_bits
-                    && bit_slice.as_raw_slice().len() * 8 == max_type_bits
+                    && bit_slice.len() == MAX_TYPE_BITS
+                    && bit_slice.as_raw_slice().len() * 8 == MAX_TYPE_BITS
                 {
                     // if everything is aligned, just read the value
                     let bytes: &[u8] = bit_slice.as_raw_slice();
@@ -197,9 +197,9 @@ macro_rules! ImplDekuReadSignExtend {
                 let (rest, value) =
                     <$inner as DekuRead<'_, (Endian, ByteSize)>>::read(input, (endian, size))?;
 
-                let max_type_bits = BitSize::of::<$typ>().0;
+                const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 let bit_size = size.0 * 8;
-                let shift = max_type_bits - bit_size;
+                let shift = MAX_TYPE_BITS - bit_size;
                 let value = (value as $typ) << shift >> shift;
                 Ok((rest, value))
             }
@@ -212,9 +212,9 @@ macro_rules! ImplDekuReadSignExtend {
                 let (rest, value) =
                     <$inner as DekuRead<'_, (Endian, BitSize)>>::read(input, (endian, size))?;
 
-                let max_type_bits = BitSize::of::<$typ>().0;
+                const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 let bit_size = size.0;
-                let shift = max_type_bits - bit_size;
+                let shift = MAX_TYPE_BITS - bit_size;
                 let value = (value as $typ) << shift >> shift;
                 Ok((rest, value))
             }


### PR DESCRIPTION
The following are from benchmarks vs the current master. The checked_mul is removed, as we can't currently panic in const.
```
deku_read_byte          time:   [5.8110 ns 5.9354 ns 6.0773 ns]
                        change: [-14.417% -10.955% -7.2630%] (p = 0.00 < 0.05)

deku_write_byte         time:   [46.900 ns 47.660 ns 48.633 ns]
                        change: [-12.747% -9.1856% -5.6869%] (p = 0.00 < 0.05)

deku_read_bits          time:   [364.10 ns 368.39 ns 372.98 ns]
                        change: [-1.5093% +0.5970% +2.8900%] (p = 0.59 > 0.05)

deku_write_bits         time:   [73.628 ns 74.842 ns 76.069 ns]
                        change: [-11.619% -9.2405% -6.9498%] (p = 0.00 < 0.05)

deku_read_enum          time:   [10.270 ns 10.528 ns 10.809 ns]
                        change: [-13.440% -10.368% -7.1636%] (p = 0.00 < 0.05)

deku_write_enum         time:   [75.269 ns 76.175 ns 77.083 ns]
                        change: [-11.316% -9.0440% -6.3322%] (p = 0.00 < 0.05)

deku_read_vec           time:   [506.90 ns 516.85 ns 527.33 ns]
                        change: [-18.733% -16.265% -13.612%] (p = 0.00 < 0.05)

deku_write_vec          time:   [3.0721 µs 3.0974 µs 3.1234 µs]
                        change: [-16.929% -15.820% -14.695%] (p = 0.00 < 0.05)

deku_read_vec_perf      time:   [485.14 ns 494.13 ns 503.52 ns]
                        change: [-11.852% -8.3565% -4.9234%] (p = 0.00 < 0.05)

deku_write_vec_perf     time:   [3.3761 µs 3.4090 µs 3.4442 µs]
                        change: [-14.783% -12.624% -10.196%] (p = 0.00 < 0.05)
```