### PR TITLE
Fix issue where endianness trickery wouldn't swap bytes correctly when reading less than the full amount into an integer

### DIFF
--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -168,17 +168,19 @@ macro_rules! ImplDekuReadBytes {
                     // cannot use from_X_bytes as we don't have enough bytes for $typ
                     // read manually
                     let mut res: $inner = 0;
-                    for b in bytes.iter().rev() {
-                        res <<= 8 as $inner;
-                        res |= *b as $inner;
-                    }
-
                     if input_is_le {
-                        res as $typ
+                        for b in bytes.iter().rev() {
+                            res <<= 8 as $inner;
+                            res |= *b as $inner;
+                        }
                     } else {
-                        res = res.swap_bytes();
-                        res as $typ
-                    }
+                        for b in bytes.iter() {
+                            res <<= 8 as $inner;
+                            res |= *b as $inner;
+                        }
+                    };
+
+                    res as $typ
                 };
 
                 Ok((rest, value))


### PR DESCRIPTION
- Add regression test
- add little-endian test as well
- Fix issue where endianness trickery wouldn't swap bytes correctly when reading less than the full amount

Closes #282
