### PR TITLE
DRAFT: Add aligned attribute

### DIFF
--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -21,13 +21,13 @@ enum DekuEnum {
     VariantA(u8),
 }
 
-/// This is faster, because we go right to (endian, bytes)
+/// This is faster, because we go right to (endian, bytes, Aligned)
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuVecPerf {
-    #[deku(bytes = "1")]
+    #[deku(aligned)]
     count: u8,
     #[deku(count = "count")]
-    #[deku(bytes = "1")]
+    #[deku(aligned)]
     data: Vec<u8>,
 }
 
@@ -74,10 +74,6 @@ fn deku_read_vec_perf(input: &[u8]) {
     let (_rest, _v) = DekuVecPerf::from_bytes((input, 0)).unwrap();
 }
 
-fn deku_write_vec_perf(input: &DekuVecPerf) {
-    let _v = input.to_bytes().unwrap();
-}
-
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("deku_read_byte", |b| {
         b.iter(|| deku_read_byte(black_box([0x01].as_ref())))
@@ -120,15 +116,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| deku_write_vec(black_box(&deku_write_vec_input)))
     });
 
-    let deku_write_vec_input = DekuVecPerf {
-        count: 100,
-        data: vec![0xFF; 100],
-    };
     c.bench_function("deku_read_vec_perf", |b| {
         b.iter(|| deku_read_vec_perf(black_box(&deku_read_vec_input)))
-    });
-    c.bench_function("deku_write_vec_perf", |b| {
-        b.iter(|| deku_write_vec_perf(black_box(&deku_write_vec_input)))
     });
 }
 

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -574,6 +574,7 @@ fn emit_field_read(
             field_endian,
             f.bits.as_ref(),
             f.bytes.as_ref(),
+            f.aligned,
             f.ctx.as_ref(),
         )?;
 

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -529,6 +529,7 @@ fn emit_field_write(
             field_endian,
             f.bits.as_ref(),
             f.bytes.as_ref(),
+            false, /* don't emit aligned */
             f.ctx.as_ref(),
         )?;
 

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -236,19 +236,31 @@ fn gen_field_args(
     endian: Option<&syn::LitStr>,
     bits: Option<&Num>,
     bytes: Option<&Num>,
+    aligned: bool,
     ctx: Option<&Punctuated<syn::Expr, syn::token::Comma>>,
 ) -> syn::Result<TokenStream> {
     let crate_ = get_crate_name();
     let endian = endian.map(gen_endian_from_str).transpose()?;
     let bits = bits.map(|n| quote! {::#crate_::ctx::BitSize(#n)});
     let bytes = bytes.map(|n| quote! {::#crate_::ctx::ByteSize(#n)});
+    let aligned = if aligned {
+        Some(quote! {::#crate_::ctx::Aligned})
+    } else {
+        None
+    };
     let ctx = ctx.map(|c| quote! {#c});
 
     // FIXME: Should be `into_iter` here, see https://github.com/rust-lang/rust/issues/66145.
-    let field_args = [endian.as_ref(), bits.as_ref(), bytes.as_ref(), ctx.as_ref()]
-        .iter()
-        .filter_map(|i| *i)
-        .collect::<Vec<_>>();
+    let field_args = [
+        endian.as_ref(),
+        bits.as_ref(),
+        bytes.as_ref(),
+        aligned.as_ref(),
+        ctx.as_ref(),
+    ]
+    .iter()
+    .filter_map(|i| *i)
+    .collect::<Vec<_>>();
 
     // Because `impl DekuRead<'_, (T1, T2)>` but `impl DekuRead<'_, T1>`(not tuple)
     match &field_args[..] {

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -32,6 +32,7 @@ enum DekuEnum {
 
 | Attribute | Scope | Description
 |-----------|------------------|------------
+| [aligned](#aligned) | field | Assert byte aligned field when reading
 | [endian](#endian) | top-level, field | Set the endianness
 | [magic](#magic) | top-level | A magic value that must be present at the start of this struct/enum
 | [assert](#assert) | field | Assert a condition
@@ -61,6 +62,70 @@ enum DekuEnum {
 | enum: [type](#type) | top-level | Set the type of the variant `id`
 | enum: [bits](#bits-1) | top-level | Set the bit-size of the variant `id`
 | enum: [bytes](#bytes-1) | top-level | Set the byte-size of the variant `id`
+
+# aligned
+
+For the following primitives, an `aligned` attribute can be used to allow performance gains when the field is byte aligned
+
+**Warning**: This type must be aligned as a byte in memory
+
+**Note**: Cannot be used in combination with [bytes](#bytes) or [bits](#bits)
+
+| Type   |
+|--------|
+| u8     |
+| u16    |
+| u32    |
+| u64    |
+| u128   |
+| usize  |
+| i8     |
+| i16    |
+| i32    |
+| i64    |
+| i128   |
+| isize  |
+| f32    |
+| f64    |
+
+### Example:
+```rust
+# use deku::prelude::*;
+# use std::convert::{TryInto, TryFrom};
+# #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+struct DekuTest {
+    #[deku(aligned)]
+    field_a: u8,
+    #[deku(aligned)]
+    field_b: u16,
+}
+
+let data: Vec<u8> = vec![0xaa, 0xbb, 0xcc];
+
+let value = DekuTest::try_from(data.as_ref()).unwrap();
+
+assert_eq!(
+    DekuTest {
+       field_a: 0xaa,
+       field_b: 0xccbb,
+    },
+    value
+);
+```
+
+### Error:
+**Warning**: Example of un-aligned usage
+```ignore
+# use deku::prelude::*;
+# use std::convert::{TryInto, TryFrom};
+# #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+struct DekuTest {
+    #[deku(bits = "4")]
+    field_a: u8,
+    #[deku(aligned)]
+    field_b: u16,
+}
+```
 
 # endian
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -4,6 +4,10 @@
 use core::marker::PhantomData;
 use core::str::FromStr;
 
+/// Aligned and correctly padded bytes
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Aligned;
+
 /// An endian
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Endian {

--- a/tests/test_attributes/mod.rs
+++ b/tests/test_attributes/mod.rs
@@ -1,3 +1,4 @@
+mod test_aligned;
 mod test_assert;
 mod test_assert_eq;
 mod test_cond;

--- a/tests/test_attributes/test_aligned.rs
+++ b/tests/test_attributes/test_aligned.rs
@@ -1,0 +1,64 @@
+use deku::prelude::*;
+use hexlit::hex;
+use rstest::rstest;
+use std::convert::{TryFrom, TryInto};
+
+#[derive(Default, PartialEq, Debug, DekuRead, DekuWrite)]
+struct TestStruct {
+    #[deku(aligned)]
+    field_a: u8,
+    #[deku(aligned)]
+    field_b: u8,
+}
+
+#[rstest(input, expected,
+    case(&hex!("0102"), TestStruct {
+        field_a: 0x01,
+        field_b: 0x02,
+    }),
+)]
+fn test_aligned_read(input: &[u8], expected: TestStruct) {
+    let ret_read = TestStruct::try_from(input).unwrap();
+    assert_eq!(expected, ret_read);
+}
+
+#[rstest(input, expected,
+    case(TestStruct {
+        field_a: 0x01,
+        field_b: 0x02,
+    }, hex!("0102").to_vec()),
+)]
+fn test_aligned_write(input: TestStruct, expected: Vec<u8>) {
+    let ret_write: Vec<u8> = input.try_into().unwrap();
+    assert_eq!(expected, ret_write);
+}
+
+#[derive(Default, PartialEq, Debug, DekuRead, DekuWrite)]
+struct TestStructNotAligned {
+    #[deku(bits = "4")]
+    field_a: u8,
+    two: TestStructNotAlignedInner,
+}
+
+#[derive(Default, PartialEq, Debug, DekuRead, DekuWrite)]
+struct TestStructNotAlignedInner {
+    #[deku(aligned)]
+    field_a: u8,
+    #[deku(aligned)]
+    field_b: u8,
+}
+
+#[rstest(input, expected,
+    #[should_panic(expected = r#"called `Result::unwrap()` on an `Err` value: Parse("error parsing from slice: could not convert slice to array")"#)]
+    case(&hex!("f01020"), TestStructNotAligned {
+        field_a: 0x0f,
+        two: TestStructNotAlignedInner {
+            field_a: 0x01,
+            field_b: 0x02,
+        },
+    }),
+)]
+fn test_aligned_failed(input: &[u8], expected: TestStructNotAligned) {
+    let ret_read = TestStructNotAligned::try_from(input).unwrap();
+    assert_eq!(expected, ret_read);
+}


### PR DESCRIPTION
This is a draft for now, but I tested out adding an `aligned` attribute to test the performance increase.

```
deku_read_vec           time:   [765.59 ns 769.06 ns 772.51 ns]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
deku_read_vec_perf      time:   [686.51 ns 691.37 ns 696.95 ns]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```

not bad

@sharksforarms I'm curious of what you think of the approach of adding an attribute and ctx for this? I acknowledge it's a bit of a foot-gun.