### PR TITLE
fix clippy warnings

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unusual_byte_groupings)]
+
 use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
 

--- a/src/impls/bool.rs
+++ b/src/impls/bool.rs
@@ -73,7 +73,7 @@ mod tests {
         let bit_slice = input.view_bits::<Msb0>();
 
         let (rest, res_read) = bool::read(bit_slice, crate::ctx::BitSize(2)).unwrap();
-        assert_eq!(true, res_read);
+        assert!(res_read);
         assert_eq!(6, rest.len());
 
         let mut res_write = bitvec![u8, Msb0;];

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -52,10 +52,10 @@ impl DekuRead<'_, (Endian, ByteSize)> for u8 {
             // read manually
             let mut res: u8 = 0;
             for b in bytes.iter().rev() {
-                res |= *b as u8;
+                res |= *b;
             }
 
-            res as u8
+            res
         };
 
         Ok((rest, value))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,7 @@ pub struct EncodedString {
 */
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::unusual_byte_groupings)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,2 +1,4 @@
+#![allow(clippy::unusual_byte_groupings, clippy::redundant_closure_call)]
+
 mod test_attributes;
 mod test_compile;

--- a/tests/test_attributes/test_padding/mod.rs
+++ b/tests/test_attributes/test_padding/mod.rs
@@ -7,6 +7,7 @@ mod test_pad_bytes_after;
 mod test_pad_bytes_before;
 
 #[test]
+#[allow(clippy::identity_op)]
 fn test_pad_bits_before_and_pad_bytes_before() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     struct TestStruct {

--- a/tests/test_from_bytes.rs
+++ b/tests/test_from_bytes.rs
@@ -12,17 +12,17 @@ fn test_from_bytes_struct() {
     assert_eq!(2, rest.len());
     assert_eq!(4, i);
 
-    let ((rest, i), ret_read) = TestDeku::from_bytes((&rest, i)).unwrap();
+    let ((rest, i), ret_read) = TestDeku::from_bytes((rest, i)).unwrap();
     assert_eq!(TestDeku(0b0110), ret_read);
     assert_eq!(1, rest.len());
     assert_eq!(0, i);
 
-    let ((rest, i), ret_read) = TestDeku::from_bytes((&rest, i)).unwrap();
+    let ((rest, i), ret_read) = TestDeku::from_bytes((rest, i)).unwrap();
     assert_eq!(TestDeku(0b0101), ret_read);
     assert_eq!(1, rest.len());
     assert_eq!(4, i);
 
-    let ((rest, i), ret_read) = TestDeku::from_bytes((&rest, i)).unwrap();
+    let ((rest, i), ret_read) = TestDeku::from_bytes((rest, i)).unwrap();
     assert_eq!(TestDeku(0b1010), ret_read);
     assert_eq!(0, rest.len());
     assert_eq!(0, i);
@@ -46,7 +46,7 @@ fn test_from_bytes_enum() {
     assert_eq!(1, rest.len());
     assert_eq!(0, i);
 
-    let ((rest, i), ret_read) = TestDeku::from_bytes((&rest, i)).unwrap();
+    let ((rest, i), ret_read) = TestDeku::from_bytes((rest, i)).unwrap();
     assert_eq!(TestDeku::VariantB(0b10), ret_read);
     assert_eq!(1, rest.len());
     assert_eq!(6, i);

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unusual_byte_groupings)]
+
 use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
 


### PR DESCRIPTION
I'm not sure how these got in here since there's CI to deny them, but it was blowing up my editor.
