### PR TITLE
Support multiple fields to `id`

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -269,7 +269,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     let variant_id_read = if id.is_some() {
         quote! {
-            let (__deku_new_rest, __deku_variant_id) = (__deku_rest, #id);
+            let (__deku_new_rest, __deku_variant_id) = (__deku_rest, (#id));
         }
     } else if id_type.is_some() {
         quote! {
@@ -372,8 +372,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     // Implement `DekuEnumExt`
     if let Some(deku_id_type) = deku_id_type {
         tokens.extend(quote! {
-            impl #imp DekuEnumExt<#lifetime, #deku_id_type> for #ident #wher {
-                fn deku_id(&self) -> Result<#deku_id_type, DekuError> {
+            impl #imp DekuEnumExt<#lifetime, (#deku_id_type)> for #ident #wher {
+                fn deku_id(&self) -> Result<(#deku_id_type), DekuError> {
                     match self {
                         #(#deku_ids ,)*
                         _ => Err(DekuError::IdVariantNotFound),

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -188,7 +188,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             quote! {
                 // if we don't do this we may get a "unused variable" error if passed via `ctx`
                 // i.e. #[deku(ctx = "my_id: u8", id = "my_id")]
-                let _ = #id;
+                let _ = (#id);
             }
         } else if id_type.is_some() {
             if let Some(variant_id) = &variant.id {

--- a/tests/test_attributes/test_ctx.rs
+++ b/tests/test_attributes/test_ctx.rs
@@ -116,16 +116,27 @@ fn test_struct_enum_ctx_id() {
     }
 
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(ctx = "my_id: u8", id = "my_id")]
+    enum EnumJustId {
+        #[deku(id = "1")]
+        VarA(u8),
+        #[deku(id = "2")]
+        VarB,
+    }
+
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     struct StructEnumId {
         my_id: u8,
         #[deku(bytes = "1")]
         data: usize,
         #[deku(ctx = "*my_id, *data")]
         enum_from_id: EnumId,
+        #[deku(ctx = "*my_id")]
+        enum_from_just_id: EnumJustId,
     }
 
     // VarA
-    let test_data = [0x01_u8, 0x01, 0xab];
+    let test_data = [0x01_u8, 0x01, 0xab, 0xab];
     let ret_read = StructEnumId::try_from(test_data.as_ref()).unwrap();
 
     assert_eq!(
@@ -133,6 +144,7 @@ fn test_struct_enum_ctx_id() {
             my_id: 0x01,
             data: 0x01,
             enum_from_id: EnumId::VarA(0xab),
+            enum_from_just_id: EnumJustId::VarA(0xab),
         },
         ret_read
     );
@@ -149,6 +161,7 @@ fn test_struct_enum_ctx_id() {
             my_id: 0x02,
             data: 0x02,
             enum_from_id: EnumId::VarB,
+            enum_from_just_id: EnumJustId::VarB,
         },
         ret_read
     );
@@ -165,6 +178,7 @@ fn test_struct_enum_ctx_id() {
             my_id: 0x02,
             data: 0x03,
             enum_from_id: EnumId::VarC(0xcc),
+            enum_from_just_id: EnumJustId::VarB,
         },
         ret_read
     );


### PR DESCRIPTION
- Add use of multiple id's from ctx in enums by expanding the match
  statement to tuples