### PR TITLE
Optimize macros

### DIFF
--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -842,7 +842,7 @@ struct DekuVariantReceiver {
 pub fn proc_deku_read(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match DekuData::from_input(input) {
         Ok(data) => data.emit_reader().into(),
-        Err(err) => err.into(),
+        Err(err) => err,
     }
 }
 
@@ -851,7 +851,7 @@ pub fn proc_deku_read(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 pub fn proc_deku_write(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match DekuData::from_input(input) {
         Ok(data) => data.emit_writer().into(),
-        Err(err) => err.into(),
+        Err(err) => err,
     }
 }
 
@@ -930,7 +930,7 @@ pub fn deku_derive(
     // Parse item
     let mut data = match DekuData::from_input(item.clone()) {
         Ok(data) => data,
-        Err(err) => return err.into(),
+        Err(err) => return err,
     };
 
     // Generate `DekuRead` impl

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -415,8 +415,8 @@ fn emit_field_reads(
     fields: &Fields<&FieldData>,
     ident: &TokenStream,
 ) -> Result<(Vec<FieldIdent>, Vec<TokenStream>), syn::Error> {
-    let mut field_reads = vec![];
-    let mut field_idents = vec![];
+    let mut field_reads = Vec::with_capacity(fields.len());
+    let mut field_idents = Vec::with_capacity(fields.len());
 
     for (i, f) in fields.iter().enumerate() {
         let (field_ident, field_read) = emit_field_read(input, i, f, ident)?;

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -156,9 +156,9 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let magic_read = emit_magic_read(input);
 
     let mut has_default_match = false;
-    let mut pre_match_tokens = vec![];
-    let mut variant_matches = vec![];
-    let mut deku_ids = vec![];
+    let mut pre_match_tokens = Vec::with_capacity(variants.len());
+    let mut variant_matches = Vec::with_capacity(variants.len());
+    let mut deku_ids = Vec::with_capacity(variants.len());
 
     let has_discriminant = variants.iter().any(|v| v.discriminant.is_some());
 

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -48,11 +48,10 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let (field_idents, field_reads) = emit_field_reads(input, &fields, &ident)?;
 
     // filter out temporary fields
-    let field_idents: Vec<&TokenStream> = field_idents
+    let field_idents = field_idents
         .iter()
         .filter(|f| !f.is_temp)
-        .map(|f| &f.field_ident)
-        .collect();
+        .map(|f| &f.field_ident);
 
     let internal_fields = gen_internal_field_idents(is_named_struct, field_idents);
 
@@ -207,11 +206,10 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 emit_field_reads(input, &variant.fields.as_ref(), &ident)?;
 
             // filter out temporary fields
-            let field_idents: Vec<&TokenStream> = field_idents
+            let field_idents = field_idents
                 .iter()
                 .filter(|f| !f.is_temp)
-                .map(|f| &f.field_ident)
-                .collect();
+                .map(|f| &f.field_ident);
 
             let internal_fields = gen_internal_field_idents(variant_is_named, field_idents);
             let initialize_enum =

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -158,8 +158,8 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     let magic_write = emit_magic_write(input);
 
-    let mut variant_writes = vec![];
-    let mut variant_updates = vec![];
+    let mut variant_writes = Vec::with_capacity(variants.len());
+    let mut variant_updates = Vec::with_capacity(variants.len());
 
     let has_discriminant = variants.iter().any(|v| v.discriminant.is_some());
 

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -36,10 +36,9 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let field_idents = fields
         .iter()
         .enumerate()
-        .map(|(i, f)| f.get_ident(i, true))
-        .collect::<Vec<_>>();
+        .map(|(i, f)| f.get_ident(i, true));
 
-    let destructured = gen_struct_destruction(named, &input.ident, &field_idents);
+    let destructured = gen_struct_destruction(named, &input.ident, field_idents);
 
     // Implement `DekuContainerWrite` for types that don't need a context
     if input.ctx.is_none() || (input.ctx.is_some() && input.ctx_default.is_some()) {
@@ -178,11 +177,9 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         let field_idents = variant
             .fields
-            .as_ref()
             .iter()
             .enumerate()
-            .map(|(i, f)| f.get_ident(i, true))
-            .collect::<Vec<_>>();
+            .map(|(i, f)| f.get_ident(i, true));
 
         let variant_id_write = if id.is_some() {
             quote! {

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -126,7 +126,7 @@ fn gen_internal_field_ident(ident: &TokenStream) -> TokenStream {
 fn gen_internal_field_idents<'a>(named: bool, idents: impl Iterator<Item = &'a TokenStream> + 'a) -> impl Iterator<Item = TokenStream> + 'a {
     idents
         .map(move |i| if named {
-            let h = gen_internal_field_ident(&i);
+            let h = gen_internal_field_ident(i);
             quote! {#i: #h}
         } else {
             gen_internal_field_ident(i)


### PR DESCRIPTION
Compile duration of a crate that uses deku (median from 5 samples):

Before: 19.1 s
After: 4.0 s

Same crate, with derive replaced with deku_derive:

Before: 4.0 s
After: 3.7 s