### PR TITLE
Fix std::result::Result path in deku-derive

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -109,7 +109,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp ::#crate_::DekuRead<#lifetime, #ctx_types> for #ident #wher {
-            fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, #ctx_arg) -> Result<(&#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, Self), ::#crate_::DekuError> {
+            fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, #ctx_arg) -> core::result::Result<(&#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, Self), ::#crate_::DekuError> {
                 #read_body
             }
         }
@@ -120,7 +120,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         tokens.extend(quote! {
             impl #imp ::#crate_::DekuRead<#lifetime> for #ident #wher {
-                fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, _: ()) -> Result<(&#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, Self), ::#crate_::DekuError> {
+                fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, _: ()) -> core::result::Result<(&#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, Self), ::#crate_::DekuError> {
                     #read_body
                 }
             }
@@ -338,7 +338,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     tokens.extend(quote! {
         #[allow(non_snake_case)]
         impl #imp ::#crate_::DekuRead<#lifetime, #ctx_types> for #ident #wher {
-            fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, #ctx_arg) -> Result<(&#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, Self), ::#crate_::DekuError> {
+            fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, #ctx_arg) -> core::result::Result<(&#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, Self), ::#crate_::DekuError> {
                 #read_body
             }
         }
@@ -350,7 +350,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             #[allow(non_snake_case)]
             impl #imp ::#crate_::DekuRead<#lifetime> for #ident #wher {
-                fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, _: ()) -> Result<(&#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, Self), ::#crate_::DekuError> {
+                fn read(__deku_input_bits: &#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, _: ()) -> core::result::Result<(&#lifetime ::#crate_::bitvec::BitSlice<u8, ::#crate_::bitvec::Msb0>, Self), ::#crate_::DekuError> {
                     #read_body
                 }
             }
@@ -371,7 +371,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     if let Some(deku_id_type) = deku_id_type {
         tokens.extend(quote! {
             impl #imp DekuEnumExt<#lifetime, (#deku_id_type)> for #ident #wher {
-                fn deku_id(&self) -> Result<(#deku_id_type), DekuError> {
+                fn deku_id(&self) -> core::result::Result<(#deku_id_type), DekuError> {
                     match self {
                         #(#deku_ids ,)*
                         _ => Err(DekuError::IdVariantNotFound),
@@ -518,7 +518,7 @@ fn emit_field_read(
         .map(|v| {
             quote! { (#v) }
         })
-        .or_else(|| Some(quote! { Result::<_, ::#crate_::DekuError>::Ok }));
+        .or_else(|| Some(quote! { core::result::Result::<_, ::#crate_::DekuError>::Ok }));
 
     let ident = ident.to_string();
     let field_ident = f.get_ident(i, true);
@@ -710,7 +710,7 @@ pub fn emit_from_bytes(
     quote! {
         impl #imp ::#crate_::DekuContainerRead<#lifetime> for #ident #wher {
             #[allow(non_snake_case)]
-            fn from_bytes(__deku_input: (&#lifetime [u8], usize)) -> Result<((&#lifetime [u8], usize), Self), ::#crate_::DekuError> {
+            fn from_bytes(__deku_input: (&#lifetime [u8], usize)) -> core::result::Result<((&#lifetime [u8], usize), Self), ::#crate_::DekuError> {
                 #body
             }
         }
@@ -729,7 +729,7 @@ pub fn emit_try_from(
         impl #imp core::convert::TryFrom<&#lifetime [u8]> for #ident #wher {
             type Error = ::#crate_::DekuError;
 
-            fn try_from(input: &#lifetime [u8]) -> Result<Self, Self::Error> {
+            fn try_from(input: &#lifetime [u8]) -> core::result::Result<Self, Self::Error> {
                 let (rest, res) = <Self as ::#crate_::DekuContainerRead>::from_bytes((input, 0))?;
                 if !rest.0.is_empty() {
                     return Err(::#crate_::DekuError::Parse(format!("Too much data")));

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -67,7 +67,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> #wher {
                 type Error = ::#crate_::DekuError;
 
-                fn try_from(input: #ident) -> Result<Self, Self::Error> {
+                fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     input.to_bits()
                 }
             }
@@ -75,19 +75,19 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
                 type Error = ::#crate_::DekuError;
 
-                fn try_from(input: #ident) -> Result<Self, Self::Error> {
+                fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     ::#crate_::DekuContainerWrite::to_bytes(&input)
                 }
             }
 
             impl #imp DekuContainerWrite for #ident #wher {
-                fn to_bytes(&self) -> Result<Vec<u8>, ::#crate_::DekuError> {
+                fn to_bytes(&self) -> core::result::Result<Vec<u8>, ::#crate_::DekuError> {
                     let mut acc: ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> = self.to_bits()?;
                     Ok(acc.into_vec())
                 }
 
                 #[allow(unused_variables)]
-                fn to_bits(&self) -> Result<::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, ::#crate_::DekuError> {
+                fn to_bits(&self) -> core::result::Result<::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, ::#crate_::DekuError> {
                     #to_bits_body
                 }
             }
@@ -112,7 +112,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
-            fn update(&mut self) -> Result<(), ::#crate_::DekuError> {
+            fn update(&mut self) -> core::result::Result<(), ::#crate_::DekuError> {
                 #update_use
                 #(#field_updates)*
 
@@ -122,7 +122,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         impl #imp DekuWrite<#ctx_types> for #ident #wher {
             #[allow(unused_variables)]
-            fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, #ctx_arg) -> Result<(), ::#crate_::DekuError> {
+            fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, #ctx_arg) -> core::result::Result<(), ::#crate_::DekuError> {
                 #write_body
             }
         }
@@ -134,7 +134,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             impl #imp DekuWrite for #ident #wher {
                 #[allow(unused_variables)]
-                fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, _: ()) -> Result<(), ::#crate_::DekuError> {
+                fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, _: ()) -> core::result::Result<(), ::#crate_::DekuError> {
                     #write_body
                 }
             }
@@ -279,7 +279,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> #wher {
                 type Error = ::#crate_::DekuError;
 
-                fn try_from(input: #ident) -> Result<Self, Self::Error> {
+                fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     input.to_bits()
                 }
             }
@@ -287,19 +287,19 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
                 type Error = ::#crate_::DekuError;
 
-                fn try_from(input: #ident) -> Result<Self, Self::Error> {
+                fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     ::#crate_::DekuContainerWrite::to_bytes(&input)
                 }
             }
 
             impl #imp DekuContainerWrite for #ident #wher {
-                fn to_bytes(&self) -> Result<Vec<u8>, ::#crate_::DekuError> {
+                fn to_bytes(&self) -> core::result::Result<Vec<u8>, ::#crate_::DekuError> {
                     let mut acc: ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> = self.to_bits()?;
                     Ok(acc.into_vec())
                 }
 
                 #[allow(unused_variables)]
-                fn to_bits(&self) -> Result<::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, ::#crate_::DekuError> {
+                fn to_bits(&self) -> core::result::Result<::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, ::#crate_::DekuError> {
                     #to_bits_body
                 }
             }
@@ -323,7 +323,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
-            fn update(&mut self) -> Result<(), ::#crate_::DekuError> {
+            fn update(&mut self) -> core::result::Result<(), ::#crate_::DekuError> {
                 #update_use
 
                 match self {
@@ -336,7 +336,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         impl #imp DekuWrite<#ctx_types> for #ident #wher {
             #[allow(unused_variables)]
-            fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, #ctx_arg) -> Result<(), ::#crate_::DekuError> {
+            fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, #ctx_arg) -> core::result::Result<(), ::#crate_::DekuError> {
                 #write_body
             }
         }
@@ -348,7 +348,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             impl #imp DekuWrite for #ident #wher {
                 #[allow(unused_variables)]
-                fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, _: ()) -> Result<(), ::#crate_::DekuError> {
+                fn write(&self, __deku_output: &mut ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0>, _: ()) -> core::result::Result<(), ::#crate_::DekuError> {
                     #write_body
                 }
             }
@@ -538,7 +538,7 @@ fn emit_field_write(
                     ::#crate_::DekuWrite::write(#object_prefix &#field_ident, __deku_output, (#write_args))
                 }
             } else {
-                quote! { Result::<(), ::#crate_::DekuError>::Ok(()) }
+                quote! { core::result::Result::<(), ::#crate_::DekuError>::Ok(()) }
             }
         } else {
             quote! { ::#crate_::DekuWrite::write(#object_prefix #field_ident, __deku_output, (#write_args)) }

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -262,3 +262,14 @@ fn test_regression_292() {
         }
     );
 }
+
+#[test]
+fn issue_310() {
+    use deku::prelude::*;
+
+    #[allow(dead_code)]
+    struct Result {}
+
+    #[derive(DekuRead, DekuWrite)]
+    struct Test {}
+}


### PR DESCRIPTION
Use std::result::Result in all derived quotes in deku-derive{read/write}.

Closes #310 