### PR TITLE
Add support for specifying the ID's endianness

### DIFF
--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -134,6 +134,9 @@ struct DekuData {
     /// enum only: type of the enum `id`
     id_type: Option<TokenStream>,
 
+    /// enum only: endianness of the enum `id`
+    id_endian: Option<syn::LitStr>,
+
     /// enum only: bit size of the enum `id`
     bits: Option<Num>,
 
@@ -185,6 +188,7 @@ impl DekuData {
             magic: receiver.magic,
             id: receiver.id,
             id_type: receiver.id_type?,
+            id_endian: receiver.id_endian,
             bits: receiver.bits,
             bytes: receiver.bytes,
         };
@@ -211,6 +215,8 @@ impl DekuData {
                     Err(cerror(data.id_type.span(), "`type` only supported on enum"))
                 } else if data.id.is_some() {
                     Err(cerror(data.id.span(), "`id` only supported on enum"))
+                } else if data.id_endian.is_some() {
+                    Err(cerror(data.id.span(), "`id_endian` only supported on enum"))
                 } else if data.bytes.is_some() {
                     Err(cerror(data.bytes.span(), "`bytes` only supported on enum"))
                 } else if data.bits.is_some() {
@@ -316,6 +322,7 @@ impl<'a> TryFrom<&'a DekuData> for DekuDataEnum<'a> {
 
         let id_args = crate::macros::gen_id_args(
             deku_data.endian.as_ref(),
+            deku_data.id_endian.as_ref(),
             deku_data.bits.as_ref(),
             deku_data.bytes.as_ref(),
         )?;
@@ -660,6 +667,10 @@ struct DekuReceiver {
         map = "map_litstr_as_tokenstream"
     )]
     id_type: Result<Option<TokenStream>, ReplacementError>,
+
+    /// enum only: endianness of the enum `id`
+    #[darling(default)]
+    id_endian: Option<syn::LitStr>,
 
     /// enum only: bit size of the enum `id`
     #[darling(default)]

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -238,11 +238,15 @@ fn gen_type_from_ctx_id(
 /// `#deku(endian = "big", bytes = 1)` -> `Endian::Big, ByteSize(1)`
 pub(crate) fn gen_id_args(
     endian: Option<&syn::LitStr>,
+    id_endian: Option<&syn::LitStr>,
     bits: Option<&Num>,
     bytes: Option<&Num>,
 ) -> syn::Result<TokenStream> {
     let crate_ = get_crate_name();
-    let endian = endian.map(gen_endian_from_str).transpose()?;
+    let endian = id_endian
+        .map(gen_endian_from_str)
+        .or_else(|| endian.map(gen_endian_from_str))
+        .transpose()?;
     let bits = bits.map(|n| quote! {::#crate_::ctx::BitSize(#n)});
     let bytes = bytes.map(|n| quote! {::#crate_::ctx::ByteSize(#n)});
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -59,6 +59,7 @@ enum DekuEnum {
 | [ctx](#ctx) | top-level, field| Context list for context sensitive parsing
 | [ctx_default](#ctx_default) | top-level, field| Default context values
 | enum: [id](#id) | top-level, variant | enum or variant id value
+| enum: [id_endian](#id_endian) | top-level | Endianness of *just* the enum `id`
 | enum: [id_pat](#id_pat) | variant | variant id match pattern
 | enum: [type](#type) | top-level | Set the type of the variant `id`
 | enum: [bits](#bits-1) | top-level | Set the bit-size of the variant `id`
@@ -1123,6 +1124,48 @@ assert_eq!(
 
 let variant_bytes: Vec<u8> = value.try_into().unwrap();
 assert_eq!(vec![0x02], variant_bytes);
+```
+
+# id_endian
+
+Specify the endianness of the variant `id`, without mandating the same endianness for the fields.
+
+Example:
+```rust
+# use deku::prelude::*;
+# use std::convert::{TryInto, TryFrom};
+# #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+#[deku(type = "u16", id_endian = "big", endian = "little")]
+enum DekuTest {
+    // Takes its endianness from the enum spec
+    #[deku(id = "0x01")]
+    VariantLittle(u16),
+    // Force the endianness on the field
+    #[deku(id = "0x02")]
+    VariantBig {
+        #[deku(endian = "big")]
+        x: u16,
+    },
+}
+
+let data: Vec<u8> = vec![0x00, 0x01, 0x01, 0x00];
+
+let (_, value) = DekuTest::from_bytes((data.as_ref(), 0)).unwrap();
+
+assert_eq!(
+    DekuTest::VariantLittle(1),
+    value
+);
+
+// ID changes, data bytes the same
+let data: Vec<u8> = vec![0x00, 0x02, 0x01, 0x00];
+
+let (_, value) = DekuTest::from_bytes((data.as_ref(), 0)).unwrap();
+
+assert_eq!(
+    DekuTest::VariantBig { x: 256 },
+    value
+);
 ```
 
 # id_pat

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -152,3 +152,27 @@ fn test_id_pat_with_id() {
     );
     assert_eq!(input, &*v.to_bytes().unwrap());
 }
+
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+#[deku(type = "u16", id_endian = "big", endian = "little")]
+enum VariableEndian {
+    #[deku(id = "0x01")]
+    Little(u16),
+    #[deku(id = "0x02")]
+    Big {
+        #[deku(endian = "big")]
+        x: u16,
+    },
+}
+
+#[rstest(input, expected,
+case(&hex!("00010100"), VariableEndian::Little(1)),
+case(&hex!("00020100"), VariableEndian::Big{x: 256})
+)]
+fn test_variable_endian_enum(input: &[u8], expected: VariableEndian) {
+    let ret_read = VariableEndian::try_from(input).unwrap();
+    assert_eq!(expected, ret_read);
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(input.to_vec(), ret_write);
+}


### PR DESCRIPTION
I've got a need to specify the endianness of a discriminator, without having that propagate to substructures.  Hence this little change.

Great crate, BTW; well-documented and easy to use!