### PR TITLE
Add bound attribute to restrict derived impls

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -36,6 +36,8 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         fields,
     } = DekuDataStruct::try_from(input)?;
 
+    let wher = wher.as_deref();
+
     let magic_read = emit_magic_read(input);
 
     // check if the first field has an ident, if not, it's a unnamed struct

--- a/tests/test_attributes/mod.rs
+++ b/tests/test_attributes/mod.rs
@@ -1,5 +1,6 @@
 mod test_assert;
 mod test_assert_eq;
+mod test_bound;
 mod test_cond;
 mod test_ctx;
 mod test_limits;

--- a/tests/test_attributes/test_bound.rs
+++ b/tests/test_attributes/test_bound.rs
@@ -1,0 +1,28 @@
+use std::convert::{TryFrom, TryInto};
+use std::marker::PhantomData;
+
+use deku::prelude::*;
+
+#[test]
+fn test_bound() {
+    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    #[deku(bound = "T: DekuRead<'a, ()>, T: DekuWrite<()>")]
+    struct GenericType<'a, T> {
+        t: T,
+        #[deku(skip)]
+        phantom: PhantomData<&'a ()>,
+    }
+
+    let test_data = [0x01_u8];
+    let ret_read = <GenericType<u8>>::try_from(&test_data[..]).unwrap();
+    assert_eq!(
+        ret_read,
+        GenericType {
+            t: 0x01,
+            phantom: PhantomData
+        }
+    );
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(ret_write, test_data);
+}


### PR DESCRIPTION
Analogous to [serde's](https://serde.rs/attr-bound.html)

This allows using generics without restricting them in the struct definition

The use-case for me is parsing into a raw form, then post-processing some fields, while retaining most of the structure. With this both can use the same generic type, and only the raw form needs to implement DekuRead/DekuWrite.

Inferring the bounds automatically would be better, but I'm not up to writing that right now.