### PR TITLE
Impl `from_reader`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,22 @@
+name: Coverage
+
+on: [pull_request, push]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --workspace --codecov --output-path codecov.json
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: codecov.json
+          fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,30 +33,31 @@ jobs:
           command: test
           args: --all
 
-  test_miri:
-    name: Miri Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: miri
-      - run: cargo miri test
-
-  test_miri_big_endian:
-    name: Miri Test Big Endian
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: miri
-          target: mips64-unknown-linux-gnuabi64
-      - run: cargo miri test --target mips64-unknown-linux-gnuabi64
+# TODO: Enable Miri
+#  test_miri:
+#    name: Miri Test
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: nightly
+#          override: true
+#          components: miri
+#      - run: cargo miri test
+#
+#  test_miri_big_endian:
+#    name: Miri Test Big Endian
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: nightly
+#          override: true
+#          components: miri
+#          target: armebv7r-none-eabi
+#      - run: cargo miri test --target armebv7r-none-eabi
 
   examples:
     name: Examples
@@ -111,7 +112,8 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - run: cd ensure_no_std && cargo run --release
+          target: thumbv7em-none-eabihf
+      - run: cd ensure_no_std && cargo build --release --target thumbv7em-none-eabihf
 
   ensure_wasm:
     name: Ensure wasm
@@ -126,20 +128,3 @@ jobs:
         with:
           version: 'latest'
       - run: cd ensure_wasm && wasm-pack build --target web && wasm-pack test --node
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    container:
-      image: xd009642/tarpaulin:develop
-      options: --security-opt seccomp=unconfined
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Generate code coverage
-        run: |
-          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["deku", "bits", "serialization", "deserialization", "struct"]
 categories = ["encoding", "parsing", "no-std"]
 description = "bit level serialization/deserialization proc-macro for structs"
 readme = "README.md"
+rust-version = "1.65.0"
 
 [lib]
 bench = false
@@ -19,16 +20,16 @@ members = [
 ]
 
 [features]
-default = ["std", "const_generics"]
-std = ["deku_derive/std", "bitvec/std", "alloc"]
+default = ["std"]
+std = ["deku_derive/std", "bitvec/std", "alloc", "no_std_io/std"]
 alloc = ["bitvec/alloc"]
 logging = ["deku_derive/logging", "log"]
-const_generics = []
 
 [dependencies]
 deku_derive = { version = "^0.16.0", path = "deku-derive", default-features = false}
 bitvec = { version = "1.0.1", default-features = false }
 log = { version = "0.4.17", optional = true }
+no_std_io = { version = "0.5.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 rstest = "0.16.0"

--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -1,17 +1,23 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::io::{Cursor, Read};
+
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use deku::prelude::*;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuBits {
     #[deku(bits = "1")]
     data_01: u8,
-    #[deku(bits = "7")]
+    #[deku(bits = "2")]
     data_02: u8,
+    #[deku(bits = "5")]
+    data_03: u8,
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-struct DekuByte {
-    data: u8,
+struct DekuBytes {
+    data_00: u8,
+    data_01: u16,
+    data_02: u32,
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
@@ -21,16 +27,6 @@ enum DekuEnum {
     VariantA(u8),
 }
 
-/// This is faster, because we go right to (endian, bytes)
-#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-struct DekuVecPerf {
-    #[deku(bytes = "1")]
-    count: u8,
-    #[deku(count = "count")]
-    #[deku(bytes = "1")]
-    data: Vec<u8>,
-}
-
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuVec {
     count: u8,
@@ -38,97 +34,104 @@ struct DekuVec {
     data: Vec<u8>,
 }
 
-fn deku_read_bits(input: &[u8]) {
-    let (_rest, _v) = DekuBits::from_bytes((input, 0)).unwrap();
+fn deku_read_bits(mut reader: impl Read) {
+    let mut reader = Reader::new(&mut reader);
+    let _v = DekuBits::from_reader_with_ctx(&mut reader, ()).unwrap();
 }
 
 fn deku_write_bits(input: &DekuBits) {
     let _v = input.to_bytes().unwrap();
 }
 
-fn deku_read_byte(input: &[u8]) {
-    let (_rest, _v) = DekuByte::from_bytes((input, 0)).unwrap();
+fn deku_read_byte(mut reader: impl Read) {
+    let mut reader = Reader::new(&mut reader);
+    let _v = DekuBytes::from_reader_with_ctx(&mut reader, ()).unwrap();
 }
 
-fn deku_write_byte(input: &DekuByte) {
+fn deku_write_byte(input: &DekuBytes) {
     let _v = input.to_bytes().unwrap();
 }
 
-fn deku_read_enum(input: &[u8]) {
-    let (_rest, _v) = DekuEnum::from_bytes((input, 0)).unwrap();
+fn deku_read_enum(mut reader: impl Read) {
+    let mut reader = Reader::new(&mut reader);
+    let _v = DekuEnum::from_reader_with_ctx(&mut reader, ()).unwrap();
 }
 
 fn deku_write_enum(input: &DekuEnum) {
     let _v = input.to_bytes().unwrap();
 }
 
-fn deku_read_vec(input: &[u8]) {
-    let (_rest, _v) = DekuVec::from_bytes((input, 0)).unwrap();
+fn deku_read_vec(mut reader: impl Read) {
+    let mut reader = Reader::new(&mut reader);
+    let _v = DekuVec::from_reader_with_ctx(&mut reader, ()).unwrap();
 }
 
 fn deku_write_vec(input: &DekuVec) {
     let _v = input.to_bytes().unwrap();
 }
 
-fn deku_read_vec_perf(input: &[u8]) {
-    let (_rest, _v) = DekuVecPerf::from_bytes((input, 0)).unwrap();
-}
-
-fn deku_write_vec_perf(input: &DekuVecPerf) {
-    let _v = input.to_bytes().unwrap();
-}
-
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("deku_read_byte", |b| {
-        b.iter(|| deku_read_byte(black_box([0x01].as_ref())))
+        let reader = Cursor::new(&[0x01; 1 + 2 + 4]);
+        b.iter_batched(
+            || reader.clone(),
+            |mut reader| deku_read_byte(&mut reader),
+            BatchSize::SmallInput,
+        )
     });
     c.bench_function("deku_write_byte", |b| {
-        b.iter(|| deku_write_byte(black_box(&DekuByte { data: 0x01 })))
+        b.iter(|| {
+            deku_write_byte(black_box(&DekuBytes {
+                data_00: 0x00,
+                data_01: 0x02,
+                data_02: 0x03,
+            }))
+        })
     });
     c.bench_function("deku_read_bits", |b| {
-        b.iter(|| deku_read_bits(black_box([0xf1].as_ref())))
+        let reader = Cursor::new(&[0x01; 1]);
+        b.iter_batched(
+            || reader.clone(),
+            |mut reader| deku_read_bits(&mut reader),
+            BatchSize::SmallInput,
+        )
     });
     c.bench_function("deku_write_bits", |b| {
         b.iter(|| {
             deku_write_bits(black_box(&DekuBits {
                 data_01: 0x0f,
-                data_02: 0x01,
+                data_02: 0x00,
+                data_03: 0x01,
             }))
         })
     });
 
     c.bench_function("deku_read_enum", |b| {
-        b.iter(|| deku_read_enum(black_box([0x01, 0x02].as_ref())))
+        let reader = Cursor::new(&[0x01; 2]);
+        b.iter_batched(
+            || reader.clone(),
+            |mut reader| deku_read_enum(&mut reader),
+            BatchSize::SmallInput,
+        )
     });
     c.bench_function("deku_write_enum", |b| {
         b.iter(|| deku_write_enum(black_box(&DekuEnum::VariantA(0x02))))
     });
 
-    let deku_read_vec_input = {
-        let mut v = [0xFFu8; 101].to_vec();
-        v[0] = 100u8;
-        v
-    };
     let deku_write_vec_input = DekuVec {
         count: 100,
-        data: vec![0xFF; 100],
+        data: vec![0xff; 100],
     };
     c.bench_function("deku_read_vec", |b| {
-        b.iter(|| deku_read_vec(black_box(&deku_read_vec_input)))
+        let reader = Cursor::new(&[0x08; 8 + 1]);
+        b.iter_batched(
+            || reader.clone(),
+            |mut reader| deku_read_vec(&mut reader),
+            BatchSize::SmallInput,
+        )
     });
     c.bench_function("deku_write_vec", |b| {
         b.iter(|| deku_write_vec(black_box(&deku_write_vec_input)))
-    });
-
-    let deku_write_vec_input = DekuVecPerf {
-        count: 100,
-        data: vec![0xFF; 100],
-    };
-    c.bench_function("deku_read_vec_perf", |b| {
-        b.iter(|| deku_read_vec_perf(black_box(&deku_read_vec_input)))
-    });
-    c.bench_function("deku_write_vec_perf", |b| {
-        b.iter(|| deku_write_vec_perf(black_box(&deku_write_vec_input)))
     });
 }
 

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -4,13 +4,18 @@ Procedural macros that implement `DekuRead` and `DekuWrite` traits
 
 #![warn(missing_docs)]
 
-use crate::macros::{deku_read::emit_deku_read, deku_write::emit_deku_write};
+use std::borrow::Cow;
+use std::convert::TryFrom;
+
 use darling::{ast, FromDeriveInput, FromField, FromMeta, FromVariant, ToTokens};
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::borrow::Cow;
-use std::convert::TryFrom;
-use syn::{punctuated::Punctuated, spanned::Spanned, AttributeArgs};
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::AttributeArgs;
+
+use crate::macros::deku_read::emit_deku_read;
+use crate::macros::deku_write::emit_deku_write;
 
 mod macros;
 
@@ -662,10 +667,8 @@ fn apply_replacements(input: &syn::LitStr) -> Result<Cow<'_, syn::LitStr>, Repla
     }
 
     let input_str = input_value
-        .replace("deku::input", "__deku_input") // part of the public API `from_bytes`
-        .replace("deku::input_bits", "__deku_input_bits") // part of the public API `read`
+        .replace("deku::reader", "__deku_reader")
         .replace("deku::output", "__deku_output") // part of the public API `write`
-        .replace("deku::rest", "__deku_rest")
         .replace("deku::bit_offset", "__deku_bit_offset")
         .replace("deku::byte_offset", "__deku_byte_offset");
 
@@ -1006,9 +1009,10 @@ pub fn deku_derive(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rstest::rstest;
     use syn::parse_str;
+
+    use super::*;
 
     #[rstest(input,
         // Valid struct

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -1,12 +1,14 @@
+use std::convert::TryFrom;
+
+use darling::ast::{Data, Fields};
+use proc_macro2::TokenStream;
+use quote::quote;
+
 use crate::macros::{
     gen_ctx_types_and_arg, gen_field_args, gen_struct_destruction, pad_bits, token_contains_string,
     wrap_default_ctx,
 };
 use crate::{DekuData, DekuDataEnum, DekuDataStruct, FieldData, Id};
-use darling::ast::{Data, Fields};
-use proc_macro2::TokenStream;
-use quote::quote;
-use std::convert::TryFrom;
 
 pub(crate) fn emit_deku_write(input: &DekuData) -> Result<TokenStream, syn::Error> {
     match &input.data {

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -1,10 +1,11 @@
-use crate::Num;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::Comma;
+
+use crate::Num;
 
 pub(crate) mod deku_read;
 pub(crate) mod deku_write;

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -19,5 +19,7 @@ default = ["alloc"]
 alloc = []
 
 [dependencies]
-wee_alloc = "0.4"
+cortex-m-rt = "0.7.3"
 deku = { path = "../", default-features = false, features = ["alloc"] }
+embedded-alloc = "0.5.0"
+

--- a/ensure_wasm/src/lib.rs
+++ b/ensure_wasm/src/lib.rs
@@ -34,7 +34,8 @@ pub struct DekuTest {
 
 #[wasm_bindgen]
 pub fn deku_read(input: &[u8]) -> DekuTest {
-    let (_rest, val) = DekuTest::from_bytes((input, 0)).unwrap();
+    let mut cursor = deku::no_std_io::Cursor::new(input);
+    let (_rest, val) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 
     val
 }

--- a/ensure_wasm/tests/deku.rs
+++ b/ensure_wasm/tests/deku.rs
@@ -15,7 +15,7 @@ fn test_read() {
             field_b: 0b101,
             field_c: 0xBE
         },
-        deku_read([0b10101_101, 0xBE].as_ref())
+        deku_read(&mut [0b10101_101, 0xBE])
     )
 }
 

--- a/examples/deku_input.rs
+++ b/examples/deku_input.rs
@@ -1,0 +1,43 @@
+//! Example of a close replacement for deku::input
+use deku::prelude::*;
+use std::io::{self, Cursor, Read};
+
+/// Every read to this struct will be saved into an internal cache. This is to keep the cache
+/// around for the crc without reading from the buffer twice
+struct ReaderCrc<R: Read> {
+    reader: R,
+    pub cache: Vec<u8>,
+}
+
+impl<R: Read> ReaderCrc<R> {
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            cache: vec![],
+        }
+    }
+}
+
+impl<R: Read> Read for ReaderCrc<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.reader.read(buf);
+        self.cache.extend_from_slice(buf);
+        n
+    }
+}
+
+#[derive(Debug, DekuRead)]
+pub struct DekuStruct {
+    pub a: u8,
+    pub b: u8,
+}
+
+fn main() {
+    let data = vec![0x01, 0x02];
+    let input = Cursor::new(&data);
+    let mut reader = ReaderCrc::new(input);
+    let (_, s) = DekuStruct::from_reader((&mut reader, 0)).unwrap();
+    assert_eq!(reader.cache, data);
+    assert_eq!(s.a, 1);
+    assert_eq!(s.b, 2);
+}

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -1,6 +1,7 @@
-use deku::prelude::*;
+use std::io::Cursor;
+
+use deku::{prelude::*, reader::Reader};
 use hexlit::hex;
-use std::convert::TryFrom;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(type = "u8")]
@@ -21,12 +22,16 @@ enum DekuTest {
     Var5 { id: u8 },
     #[deku(id_pat = "&id if id > 6")]
     Var6 { id: u8 },
+    #[deku(id_pat = "_")]
+    VarDefault { id: u8, value: u8 },
 }
 
 fn main() {
     let test_data = hex!("03020102").to_vec();
 
-    let deku_test = DekuTest::try_from(test_data.as_ref()).unwrap();
+    let mut cursor = Cursor::new(&test_data);
+    let mut reader = Reader::new(&mut cursor);
+    let deku_test = DekuTest::from_reader_with_ctx(&mut reader, ()).unwrap();
 
     assert_eq!(
         DekuTest::Var4 {

--- a/examples/enums_catch_all.rs
+++ b/examples/enums_catch_all.rs
@@ -1,7 +1,7 @@
+use std::convert::{TryFrom, TryInto};
+
 use deku::prelude::*;
 use hexlit::hex;
-use std::convert::TryFrom;
-use std::convert::TryInto;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, DekuWrite, DekuRead)]
 #[deku(type = "u8")]

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,11 +1,18 @@
+//! To test out the "logging" feature:
+//! ```
+//! $ RUST_LOG=trace cargo run --example example --features logging
+//! ```
+
 #![allow(clippy::unusual_byte_groupings)]
 
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct FieldF {
     #[deku(bits = "6")]
+    #[deku(assert_eq = "6")]
     data: u8,
 }
 
@@ -15,7 +22,6 @@ struct FieldF {
 //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //  |    field_a    |   field_b   |c|            field_d              | e |     f     |
 //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 // #[deku(endian = "little")] // By default it uses the system endianness, but can be overwritten
 struct DekuTest {
@@ -35,32 +41,33 @@ struct DekuTest {
 }
 
 fn main() {
-    let test_data: &[u8] = [
-        0xAB,
+    env_logger::init();
+    let test_data: &[u8] = &[
+        0xab,
         0b1010010_1,
-        0xAB,
-        0xCD,
+        0xab,
+        0xcd,
         0b1100_0110,
         0x02,
-        0xBE,
-        0xEF,
-        0xC0,
-        0xFE,
-    ]
-    .as_ref();
+        0xbe,
+        0xef,
+        0xc0,
+        0xfe,
+    ];
 
     let test_deku = DekuTest::try_from(test_data).unwrap();
 
+    println!("{test_deku:02x?}");
     assert_eq!(
         DekuTest {
-            field_a: 0xAB,
+            field_a: 0xab,
             field_b: 0b0_1010010,
             field_c: 0b0000000_1,
-            field_d: 0xABCD,
+            field_d: 0xabcd,
             field_e: 0b0000_0011,
             field_f: FieldF { data: 0b00_000110 },
             num_items: 2,
-            items: vec![0xBEEF, 0xC0FE],
+            items: vec![0xbeef, 0xc0fe],
         },
         test_deku
     );

--- a/examples/ipv4.rs
+++ b/examples/ipv4.rs
@@ -1,7 +1,8 @@
+use std::convert::TryInto;
+use std::net::Ipv4Addr;
+
 use deku::prelude::*;
 use hexlit::hex;
-use std::convert::{TryFrom, TryInto};
-use std::net::Ipv4Addr;
 
 /// Ipv4 Header
 /// ```text
@@ -42,15 +43,17 @@ pub struct Ipv4Header {
     pub protocol: u8,        // Protocol
     pub checksum: u16,       // Header checksum
     pub src: Ipv4Addr,       // Source IP Address
-    pub dst: Ipv4Addr,       // Destination IP Address
-                             // options
-                             // padding
+    pub dst: Ipv4Addr,       /* Destination IP Address
+                              * options
+                              * padding */
 }
 
 fn main() {
     let test_data = hex!("4500004b0f490000801163a591fea0ed91fd02cb").to_vec();
 
-    let ip_header = Ipv4Header::try_from(test_data.as_ref()).unwrap();
+    let mut cursor = std::io::Cursor::new(test_data.clone());
+    let mut reader = deku::reader::Reader::new(&mut cursor);
+    let ip_header = Ipv4Header::from_reader_with_ctx(&mut reader, ()).unwrap();
 
     assert_eq!(
         Ipv4Header {

--- a/examples/many.rs
+++ b/examples/many.rs
@@ -1,0 +1,32 @@
+use deku::{ctx::Limit, prelude::*, DekuRead, DekuWrite};
+use std::io::Cursor;
+
+#[derive(Debug, DekuRead, DekuWrite)]
+struct Test {
+    pub a: u64,
+    pub b: u64,
+    pub c: u64,
+}
+
+fn main() {
+    let input: Vec<_> = (0..10_0000)
+        .map(|i| Test {
+            a: i,
+            b: i + 1,
+            c: i + 2,
+        })
+        .collect();
+    let custom: Vec<u8> = input
+        .iter()
+        .flat_map(|x| x.to_bytes().unwrap().into_iter())
+        .collect();
+
+    let mut binding = Cursor::new(custom.clone());
+    let mut reader = Reader::new(&mut binding);
+    let ret = <Vec<Test> as DekuReader<Limit<_, _>>>::from_reader_with_ctx(
+        &mut reader,
+        Limit::new_count(10_0000),
+    );
+
+    println!("{:?}", ret);
+}

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -75,6 +75,7 @@ Example:
 ```rust
 # use deku::prelude::*;
 # use std::convert::{TryInto, TryFrom};
+# use std::io::Cursor;
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 // #[deku(endian = "little")] // top-level, defaults to system endianness
 struct DekuTest {
@@ -83,9 +84,10 @@ struct DekuTest {
     field_default: u16, // defaults to top-level
 }
 
-let data: Vec<u8> = vec![0xAB, 0xCD, 0xAB, 0xCD];
+let data: &[u8] = &[0xAB, 0xCD, 0xAB, 0xCD];
+let mut cursor = Cursor::new(data);
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -96,7 +98,7 @@ assert_eq!(
 );
 
 let value: Vec<u8> = value.try_into().unwrap();
-assert_eq!(data, value);
+assert_eq!(data, &*value);
 ```
 
 **Note**: The `endian` is passed as a context argument to sub-types
@@ -123,9 +125,9 @@ struct DekuTest {
     field_child: Child,
 }
 
-let data: Vec<u8> = vec![0xAB, 0xCD, 0xAB, 0xCD, 0xEF, 0xBE];
+let data: &[u8] = &[0xAB, 0xCD, 0xAB, 0xCD, 0xEF, 0xBE];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -137,7 +139,7 @@ assert_eq!(
 );
 
 let value: Vec<u8> = value.try_into().unwrap();
-assert_eq!(data, value);
+assert_eq!(&*data, value);
 ```
 
 # magic
@@ -156,9 +158,9 @@ struct DekuTest {
     data: u8
 }
 
-let data: Vec<u8> = vec![b'd', b'e', b'k', b'u', 50];
+let data: &[u8] = &[b'd', b'e', b'k', b'u', 50];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { data: 50 },
@@ -183,9 +185,9 @@ struct DekuTest {
     data: u8
 }
 
-let data: Vec<u8> = vec![0x00, 0x01, 0x02];
+let data: &[u8] = &[0x00, 0x01, 0x02];
 
-let value = DekuTest::try_from(data.as_ref());
+let value = DekuTest::try_from(data);
 
 assert_eq!(
     Err(DekuError::Assertion("DekuTest.data field failed assertion: * data >= 8".into())),
@@ -207,9 +209,9 @@ struct DekuTest {
     data: u8,
 }
 
-let data: Vec<u8> = vec![0x01];
+let data: &[u8] = &[0x01];
 
-let mut value = DekuTest::try_from(data.as_ref()).unwrap();
+let mut value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { data: 0x01 },
@@ -245,9 +247,9 @@ struct DekuTest {
     field_c: u8, // defaults to size_of<u8>*8
 }
 
-let data: Vec<u8> = vec![0b11_101010, 0xFF];
+let data: &[u8] = &[0b11_101010, 0xFF];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -259,7 +261,7 @@ assert_eq!(
 );
 
 let value: Vec<u8> = value.try_into().unwrap();
-assert_eq!(data, value);
+assert_eq!(&*data, value);
 ```
 
 # bytes
@@ -279,9 +281,9 @@ struct DekuTest {
     field_b: u8, // defaults to size_of<u8>
 }
 
-let data: Vec<u8> = vec![0xAB, 0xCD, 0xFF];
+let data: &[u8] = &[0xAB, 0xCD, 0xFF];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -311,9 +313,9 @@ struct DekuTest {
     items: Vec<u8>,
 }
 
-let data: Vec<u8> = vec![0x02, 0xAB, 0xCD];
+let data: &[u8] = &[0x02, 0xAB, 0xCD];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -354,9 +356,9 @@ struct DekuTest {
     items: Vec<InnerDekuTest>,
 }
 
-let data: Vec<u8> = vec![0x04, 0xAB, 0xBC, 0xDE, 0xEF];
+let data: &[u8] = &[0x04, 0xAB, 0xBC, 0xDE, 0xEF];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -369,7 +371,7 @@ assert_eq!(
 );
 
 let value: Vec<u8> = value.try_into().unwrap();
-assert_eq!(data, value);
+assert_eq!(&*data, value);
 ```
 
 **Note**: See [update](#update) for more information on the attribute!
@@ -401,8 +403,8 @@ struct DekuTest {
     string: Vec<u8>
 }
 
-let data: Vec<u8> = vec![b'H', b'e', b'l', b'l', b'o', 0];
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let data: &[u8] = &[b'H', b'e', b'l', b'l', b'o', 0];
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -429,10 +431,10 @@ struct DekuTest {
     items: Vec<u8>,
 }
 
-let data: Vec<u8> = vec![0x02, 0xAB, 0xCD];
+let data: &[u8] = &[0x02, 0xAB, 0xCD];
 
 // `mut` so it can be updated
-let mut value = DekuTest::try_from(data.as_ref()).unwrap();
+let mut value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { count: 0x02, items: vec![0xAB, 0xCD] },
@@ -478,9 +480,9 @@ struct DekuTest {
     items: Vec<u16>,
 }
 
-let data: Vec<u8> = vec![0x01, 0xBE, 0xEF];
+let data: &[u8] = &[0x01, 0xBE, 0xEF];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -546,9 +548,9 @@ struct DekuTest {
     field_c: u8,
 }
 
-let data: Vec<u8> = vec![0x01, 0x02];
+let data: &[u8] = &[0x01, 0x02];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { field_a: 0x01, field_b: None, field_c: 0x02 },
@@ -572,9 +574,9 @@ pub struct DekuTest {
     pub field_b: u8,
 }
 
-let data: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0xDD];
+let data: &[u8] = &[0xAA, 0xBB, 0xCC, 0xDD];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -605,9 +607,9 @@ struct DekuTest {
     field_b: u8,
 }
 
-let data: Vec<u8> = vec![0b10_01_1001];
+let data: &[u8] = &[0b10_01_1001];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -637,9 +639,9 @@ pub struct DekuTest {
     pub field_b: u8,
 }
 
-let data: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0xDD];
+let data: &[u8] = &[0xAA, 0xBB, 0xCC, 0xDD];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -670,9 +672,9 @@ struct DekuTest {
     field_b: u8,
 }
 
-let data: Vec<u8> = vec![0b10_01_1001];
+let data: &[u8] = &[0b10_01_1001];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -708,9 +710,9 @@ struct DekuTest {
     field_d: Option<u8>,
 }
 
-let data: Vec<u8> = vec![0x01, 0x02];
+let data: &[u8] = &[0x01, 0x02];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { field_a: 0x01, field_b: Some(0x02), field_c: Some(0x05), field_d: Some(0x06)},
@@ -742,9 +744,9 @@ struct DekuTest {
     field_c: u8,
 }
 
-let data: Vec<u8> = vec![0x01, 0x02];
+let data: &[u8] = &[0x01, 0x02];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { field_a: 0x01, field_b: Some(0x01), field_c: 0x02 },
@@ -777,9 +779,9 @@ impl DekuTest {
     }
 }
 
-let data: Vec<u8> = vec![0x01, 0x02];
+let data: &[u8] = &[0x01, 0x02];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { field_a: "1".to_string(), field_b: "2".to_string() },
@@ -800,7 +802,7 @@ use deku::prelude::*;
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(
-        reader = "DekuTest::read(deku::rest)",
+        reader = "DekuTest::read(deku::reader)",
         writer = "DekuTest::write(deku::output, &self.field_a)"
     )]
     field_a: String,
@@ -808,11 +810,11 @@ struct DekuTest {
 
 impl DekuTest {
     /// Read and convert to String
-    fn read(
-        rest: &BitSlice<u8, Msb0>,
-    ) -> Result<(&BitSlice<u8, Msb0>, String), DekuError> {
-        let (rest, value) = u8::read(rest, ())?;
-        Ok((rest, value.to_string()))
+    fn read<R: std::io::Read>(
+        reader: &mut deku::reader::Reader<R>,
+    ) -> Result<String, DekuError> {
+        let value = u8::from_reader_with_ctx(reader, ())?;
+        Ok(value.to_string())
     }
 
     /// Parse from String to u8 and write
@@ -822,9 +824,9 @@ impl DekuTest {
     }
 }
 
-let data: Vec<u8> = vec![0x01];
+let data: &[u8] = &[0x01];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { field_a: "1".to_string() },
@@ -832,7 +834,7 @@ assert_eq!(
 );
 
 let value: Vec<u8> = value.try_into().unwrap();
-assert_eq!(data, value);
+assert_eq!(data, &*value);
 ```
 
 # ctx
@@ -852,9 +854,12 @@ for example `#[deku("a, b")]`
 2. `endian`, `bytes`, `bits` attributes declared on the top-level
     - These are prepended to the list of ctx variables
 
+**Note**: The `enum` or `struct` that uses `ctx` will not implement [DekuContainerRead](crate::DekuContainerRead) or [DekuContainerWrite](crate::DekuContainerWrite) unless [ctx_default](#ctx_default) is also used.
+
 Example
 ```rust
 # use deku::prelude::*;
+# use std::io::Cursor;
 #[derive(DekuRead, DekuWrite)]
 #[deku(ctx = "a: u8")]
 struct Subtype {
@@ -869,9 +874,10 @@ struct Test {
     sub: Subtype
 }
 
-let data: Vec<u8> = vec![0x01, 0x02];
+let data: &[u8] = &[0x01, 0x02];
+let mut cursor = Cursor::new(data);
 
-let (rest, value) = Test::from_bytes((&data[..], 0)).unwrap();
+let (amt_read, value) = Test::from_reader((&mut cursor, 0)).unwrap();
 assert_eq!(value.a, 0x01);
 assert_eq!(value.sub.b, 0x01 + 0x02)
 ```
@@ -920,6 +926,7 @@ values for the context
 Example:
 ```rust
 # use deku::prelude::*;
+# use std::io::Cursor;
 #[derive(DekuRead, DekuWrite)]
 #[deku(ctx = "a: u8", ctx_default = "1")] // Defaults `a` to 1
 struct Subtype {
@@ -934,18 +941,20 @@ struct Test {
     sub: Subtype
 }
 
-let data: Vec<u8> = vec![0x01, 0x02];
+let data: &[u8] = &[0x01, 0x02];
+let mut cursor = Cursor::new(data);
 
 // Use with context from `Test`
-let (rest, value) = Test::from_bytes((&data[..], 0)).unwrap();
+let (amt_read, value) = Test::from_reader((&mut cursor, 0)).unwrap();
 assert_eq!(value.a, 0x01);
 assert_eq!(value.sub.b, 0x01 + 0x02);
 
 // Use as a stand-alone container, using defaults
-// Note: `from_bytes` is now available on `SubType`
-let data: Vec<u8> = vec![0x02];
+// Note: `from_reader` is now available on `SubType`
+let data: &[u8] = &[0x02];
+let mut cursor = Cursor::new(data);
 
-let (rest, value) = Subtype::from_bytes((&data[..], 0)).unwrap();
+let (amt_read, value) = Subtype::from_reader((&mut cursor, 0)).unwrap();
 assert_eq!(value.b, 0x01 + 0x02)
 ```
 
@@ -979,8 +988,8 @@ enum MyEnum {
     VariantB,
 }
 
-let data: Vec<u8> = vec![0x01_u8, 0xff, 0xab];
-let ret_read = DekuTest::try_from(data.as_ref()).unwrap();
+let data: &[u8] = &[0x01_u8, 0xff, 0xab];
+let ret_read = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest {
@@ -992,7 +1001,7 @@ assert_eq!(
 );
 
 let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-assert_eq!(ret_write, data)
+assert_eq!(&*ret_write, data)
 ```
 
 ## id (variant)
@@ -1007,6 +1016,7 @@ or [id (top-level)](#id-top-level)
 Example:
 ```rust
 # use deku::prelude::*;
+# use std::io::Cursor;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(type = "u8")]
@@ -1017,9 +1027,10 @@ enum DekuTest {
     VariantB(u8, u16),
 }
 
-let data: Vec<u8> = vec![0x01, 0xFF, 0x02, 0xAB, 0xEF, 0xBE];
+let data: &[u8] = &[0x01, 0xFF, 0x02, 0xAB, 0xEF, 0xBE];
+let mut cursor = Cursor::new(data);
 
-let (rest, value) = DekuTest::from_bytes((data.as_ref(), 0)).unwrap();
+let (amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 
 assert_eq!(
     DekuTest::VariantA(0xFF),
@@ -1029,7 +1040,7 @@ assert_eq!(
 let variant_bytes: Vec<u8> = value.try_into().unwrap();
 assert_eq!(vec![0x01, 0xFF], variant_bytes);
 
-let (rest, value) = DekuTest::from_bytes(rest).unwrap();
+let (amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 
 assert_eq!(
     DekuTest::VariantB(0xAB, 0xBEEF),
@@ -1043,6 +1054,7 @@ assert_eq!(vec![0x02, 0xAB, 0xEF, 0xBE], variant_bytes);
 Example discriminant
 ```rust
 # use deku::prelude::*;
+# use std::io::Cursor;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(type = "u8")]
@@ -1051,9 +1063,10 @@ enum DekuTest {
     VariantB,
 }
 
-let data: Vec<u8> = vec![0x01, 0x02];
+let data: &[u8] = &[0x01, 0x02];
+let mut cursor = Cursor::new(data);
 
-let (rest, value) = DekuTest::from_bytes((data.as_ref(), 0)).unwrap();
+let (amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 
 assert_eq!(
     DekuTest::VariantA,
@@ -1063,7 +1076,7 @@ assert_eq!(
 let variant_bytes: Vec<u8> = value.try_into().unwrap();
 assert_eq!(vec![0x01], variant_bytes);
 
-let (rest, value) = DekuTest::from_bytes(rest).unwrap();
+let (rest, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 
 assert_eq!(
     DekuTest::VariantB,
@@ -1083,6 +1096,7 @@ The enum variant must have space to store the identifier for proper writing.
 Example:
 ```rust
 # use deku::prelude::*;
+# use std::io::Cursor;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(type = "u8")]
@@ -1097,9 +1111,10 @@ enum DekuTest {
     VariantC(u8),
 }
 
-let data: Vec<u8> = vec![0x03, 0xFF];
+let data: &[u8] = &[0x03, 0xFF];
+let mut cursor = Cursor::new(data);
 
-let (rest, value) = DekuTest::from_bytes((data.as_ref(), 0)).unwrap();
+let (amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 
 assert_eq!(
     DekuTest::VariantB { id: 0x03 },
@@ -1109,7 +1124,7 @@ assert_eq!(
 let variant_bytes: Vec<u8> = value.try_into().unwrap();
 assert_eq!(vec![0x03], variant_bytes);
 
-let (rest, value) = DekuTest::from_bytes(rest).unwrap();
+let (rest, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 
 assert_eq!(
     DekuTest::VariantC(0xFF),
@@ -1133,6 +1148,7 @@ Set the bit size of the enum variant `id`
 Example:
 ```rust
 # use deku::prelude::*;
+# use std::io::Cursor;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(type = "u8", bits = "4")]
@@ -1141,9 +1157,10 @@ enum DekuTest {
     VariantA( #[deku(bits = "4")] u8, u8),
 }
 
-let data: Vec<u8> = vec![0b1001_0110, 0xFF];
+let data: &[u8] = &[0b1001_0110, 0xFF];
+let mut cursor = Cursor::new(data);
 
-let (rest, value) = DekuTest::from_bytes((&data, 0)).unwrap();
+let (amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 
 assert_eq!(
     DekuTest::VariantA(0b0110, 0xFF),
@@ -1171,9 +1188,9 @@ enum DekuTest {
     VariantA(u8),
 }
 
-let data: Vec<u8> = vec![0xEF, 0xBE, 0xFF];
+let data: &[u8] = &[0xEF, 0xBE, 0xFF];
 
-let value = DekuTest::try_from(data.as_ref()).unwrap();
+let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest::VariantA(0xFF),

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -23,6 +23,7 @@ impl Endian {
     /// [`Endian::default`], but const.
     ///
     /// [`Endian::default`]: Endian::default()
+    #[inline]
     pub const fn new() -> Self {
         #[cfg(target_endian = "little")]
         let endian = Endian::Little;
@@ -34,11 +35,13 @@ impl Endian {
     }
 
     /// Is it little endian
+    #[inline]
     pub fn is_le(self) -> bool {
         self == Endian::Little
     }
 
     /// Is it big endian
+    #[inline]
     pub fn is_be(self) -> bool {
         self == Endian::Big
     }
@@ -46,6 +49,7 @@ impl Endian {
 
 impl Default for Endian {
     /// Return the endianness of the target's CPU.
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
@@ -58,11 +62,13 @@ impl FromStr for Endian {
     /// # Examples
     /// ```rust
     /// use std::str::FromStr;
+    ///
     /// use deku::ctx::Endian;
     /// assert_eq!(FromStr::from_str("little"), Ok(Endian::Little));
     /// assert_eq!(FromStr::from_str("big"), Ok(Endian::Big));
     /// assert!(<Endian as FromStr>::from_str("not an endian").is_err());
     /// ```
+    #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "little" => Ok(Endian::Little),
@@ -92,24 +98,28 @@ pub enum Limit<T, Predicate: FnMut(&T) -> bool> {
 }
 
 impl<T> From<usize> for Limit<T, fn(&T) -> bool> {
+    #[inline]
     fn from(n: usize) -> Self {
         Limit::Count(n)
     }
 }
 
 impl<T, Predicate: for<'a> FnMut(&'a T) -> bool> From<Predicate> for Limit<T, Predicate> {
+    #[inline]
     fn from(predicate: Predicate) -> Self {
         Limit::Until(predicate, PhantomData)
     }
 }
 
 impl<T> From<ByteSize> for Limit<T, fn(&T) -> bool> {
+    #[inline]
     fn from(size: ByteSize) -> Self {
         Limit::ByteSize(size)
     }
 }
 
 impl<T> From<BitSize> for Limit<T, fn(&T) -> bool> {
+    #[inline]
     fn from(size: BitSize) -> Self {
         Limit::BitSize(size)
     }
@@ -119,6 +129,7 @@ impl<T, Predicate: for<'a> FnMut(&'a T) -> bool> Limit<T, Predicate> {
     /// Constructs a new Limit that reads until the given predicate returns true
     /// The predicate is given a reference to the latest read value and must return
     /// true to stop reading
+    #[inline]
     pub fn new_until(predicate: Predicate) -> Self {
         predicate.into()
     }
@@ -126,16 +137,19 @@ impl<T, Predicate: for<'a> FnMut(&'a T) -> bool> Limit<T, Predicate> {
 
 impl<T> Limit<T, fn(&T) -> bool> {
     /// Constructs a new Limit that reads until the given number of elements are read
+    #[inline]
     pub fn new_count(count: usize) -> Self {
         count.into()
     }
 
     /// Constructs a new Limit that reads until the given size
+    #[inline]
     pub fn new_bit_size(size: BitSize) -> Self {
         size.into()
     }
 
     /// Constructs a new Limit that reads until the given size
+    #[inline]
     pub fn new_byte_size(size: ByteSize) -> Self {
         size.into()
     }
@@ -151,7 +165,8 @@ pub struct BitSize(pub usize);
 
 impl BitSize {
     /// Convert the size in bytes to a bit size.
-    const fn bits_from_bytes(byte_size: usize) -> Self {
+    #[inline]
+    const fn bits_from_reader(byte_size: usize) -> Self {
         // TODO: use checked_mul when const_option is enabled
         // link: https://github.com/rust-lang/rust/issues/67441
         Self(byte_size * 8)
@@ -164,12 +179,14 @@ impl BitSize {
     ///
     /// assert_eq!(BitSize::of::<i32>(), BitSize(4 * 8));
     /// ```
+    #[inline]
     pub const fn of<T>() -> Self {
-        Self::bits_from_bytes(core::mem::size_of::<T>())
+        Self::bits_from_reader(core::mem::size_of::<T>())
     }
 
     /// Returns the bit size of the pointed-to value
+    #[inline]
     pub fn of_val<T: ?Sized>(val: &T) -> Self {
-        Self::bits_from_bytes(core::mem::size_of_val(val))
+        Self::bits_from_reader(core::mem::size_of_val(val))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,8 @@
 
 #![cfg(feature = "alloc")]
 
-use alloc::{format, string::String};
+use alloc::format;
+use alloc::string::String;
 
 /// Number of bits needed to retry parsing
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/impls/bool.rs
+++ b/src/impls/bool.rs
@@ -1,21 +1,22 @@
-use crate::{DekuError, DekuRead, DekuWrite};
-use bitvec::prelude::*;
+use no_std_io::io::Read;
 
 #[cfg(feature = "alloc")]
 use alloc::format;
 
-impl<'a, Ctx> DekuRead<'a, Ctx> for bool
+use bitvec::prelude::*;
+
+use crate::{DekuError, DekuReader, DekuWrite};
+
+impl<'a, Ctx> DekuReader<'a, Ctx> for bool
 where
     Ctx: Copy,
-    u8: DekuRead<'a, Ctx>,
+    u8: DekuReader<'a, Ctx>,
 {
-    /// wrapper around u8::read with consideration to context, such as bit size
-    /// true if the result of the read is `1`, false if `0` and error otherwise
-    fn read(
-        input: &'a BitSlice<u8, Msb0>,
+    fn from_reader_with_ctx<R: Read>(
+        reader: &mut crate::reader::Reader<R>,
         inner_ctx: Ctx,
-    ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError> {
-        let (rest, val) = u8::read(input, inner_ctx)?;
+    ) -> Result<bool, DekuError> {
+        let val = u8::from_reader_with_ctx(reader, inner_ctx)?;
 
         let ret = match val {
             0x01 => Ok(true),
@@ -23,7 +24,7 @@ where
             _ => Err(DekuError::Parse(format!("cannot parse bool value: {val}",))),
         }?;
 
-        Ok((rest, ret))
+        Ok(ret)
     }
 }
 
@@ -42,9 +43,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use hexlit::hex;
+    use no_std_io::io::Cursor;
     use rstest::rstest;
+
+    use crate::reader::Reader;
+
+    use super::*;
 
     #[rstest(input, expected,
         case(&hex!("00"), false),
@@ -53,25 +58,20 @@ mod tests {
         #[should_panic(expected = "Parse(\"cannot parse bool value: 2\")")]
         case(&hex!("02"), false),
     )]
-    fn test_bool(input: &[u8], expected: bool) {
-        let bit_slice = input.view_bits::<Msb0>();
-        let (rest, res_read) = bool::read(bit_slice, ()).unwrap();
+    fn test_bool(mut input: &[u8], expected: bool) {
+        let mut reader = Reader::new(&mut input);
+        let res_read = bool::from_reader_with_ctx(&mut reader, ()).unwrap();
         assert_eq!(expected, res_read);
-        assert!(rest.is_empty());
-
-        let mut res_write = bitvec![u8, Msb0;];
-        res_read.write(&mut res_write, ()).unwrap();
-        assert_eq!(input.to_vec(), res_write.into_vec());
     }
 
     #[test]
     fn test_bool_with_context() {
         let input = &[0b01_000000];
-        let bit_slice = input.view_bits::<Msb0>();
 
-        let (rest, res_read) = bool::read(bit_slice, crate::ctx::BitSize(2)).unwrap();
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        let res_read = bool::from_reader_with_ctx(&mut reader, crate::ctx::BitSize(2)).unwrap();
         assert!(res_read);
-        assert_eq!(6, rest.len());
 
         let mut res_write = bitvec![u8, Msb0;];
         res_read.write(&mut res_write, ()).unwrap();

--- a/src/impls/hashmap.rs
+++ b/src/impls/hashmap.rs
@@ -1,7 +1,11 @@
-use crate::{ctx::*, DekuError, DekuRead, DekuWrite};
-use bitvec::prelude::*;
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
+
+use bitvec::prelude::*;
+use no_std_io::io::Read;
+
+use crate::ctx::*;
+use crate::{DekuError, DekuReader, DekuWrite};
 
 /// Read `K, V`s into a hashmap until a given predicate returns true
 /// * `capacity` - an optional capacity to pre-allocate the hashmap with
@@ -11,66 +15,63 @@ use std::hash::{BuildHasher, Hash};
 /// and a borrow of the latest value to have been read. It should return `true` if reading
 /// should now stop, and `false` otherwise
 #[allow(clippy::type_complexity)]
-fn read_hashmap_with_predicate<
-    'a,
-    K: DekuRead<'a, Ctx> + Eq + Hash,
-    V: DekuRead<'a, Ctx>,
-    S: BuildHasher + Default,
-    Ctx: Copy,
-    Predicate: FnMut(usize, &(K, V)) -> bool,
->(
-    input: &'a BitSlice<u8, Msb0>,
+fn from_reader_with_ctx_hashmap_with_predicate<'a, K, V, S, Ctx, Predicate, R: Read>(
+    reader: &mut crate::reader::Reader<R>,
     capacity: Option<usize>,
     ctx: Ctx,
     mut predicate: Predicate,
-) -> Result<(&'a BitSlice<u8, Msb0>, HashMap<K, V, S>), DekuError> {
+) -> Result<HashMap<K, V, S>, DekuError>
+where
+    K: DekuReader<'a, Ctx> + Eq + Hash,
+    V: DekuReader<'a, Ctx>,
+    S: BuildHasher + Default,
+    Ctx: Copy,
+    Predicate: FnMut(usize, &(K, V)) -> bool,
+{
     let mut res = HashMap::with_capacity_and_hasher(capacity.unwrap_or(0), S::default());
 
-    let mut rest = input;
     let mut found_predicate = false;
+    let orig_bits_read = reader.bits_read;
 
     while !found_predicate {
-        let (new_rest, kv) = <(K, V)>::read(rest, ctx)?;
-        found_predicate = predicate(
-            unsafe { new_rest.as_bitptr().offset_from(input.as_bitptr()) } as usize,
-            &kv,
-        );
-        res.insert(kv.0, kv.1);
-        rest = new_rest;
+        let val = <(K, V)>::from_reader_with_ctx(reader, ctx)?;
+        found_predicate = predicate(reader.bits_read - orig_bits_read, &val);
+        res.insert(val.0, val.1);
     }
 
-    Ok((rest, res))
+    Ok(res)
 }
 
-impl<
-        'a,
-        K: DekuRead<'a, Ctx> + Eq + Hash,
-        V: DekuRead<'a, Ctx>,
-        S: BuildHasher + Default,
-        Ctx: Copy,
-        Predicate: FnMut(&(K, V)) -> bool,
-    > DekuRead<'a, (Limit<(K, V), Predicate>, Ctx)> for HashMap<K, V, S>
+impl<'a, K, V, S, Ctx, Predicate> DekuReader<'a, (Limit<(K, V), Predicate>, Ctx)>
+    for HashMap<K, V, S>
+where
+    K: DekuReader<'a, Ctx> + Eq + Hash,
+    V: DekuReader<'a, Ctx>,
+    S: BuildHasher + Default,
+    Ctx: Copy,
+    Predicate: FnMut(&(K, V)) -> bool,
 {
-    /// Read `K, V`s until the given limit
-    /// * `limit` - the limiting factor on the amount of `K, V`s to read
-    /// * `inner_ctx` - The context required by `K, V`. It will be passed to every `K, V`s when constructing.
+    /// Read `T`s until the given limit
+    /// * `limit` - the limiting factor on the amount of `T`s to read
+    /// * `inner_ctx` - The context required by `T`. It will be passed to every `T`s when constructing.
     /// # Examples
     /// ```rust
     /// # use deku::ctx::*;
-    /// # use deku::DekuRead;
-    /// # use deku::bitvec::BitView;
+    /// # use deku::DekuReader;
     /// # use std::collections::HashMap;
-    /// let input: Vec<u8> = vec![100, 1, 2, 3, 4];
-    /// let (rest, map) = HashMap::<u8, u32>::read(input.view_bits(), (1.into(), Endian::Little)).unwrap();
-    /// assert!(rest.is_empty());
+    /// # use std::io::Cursor;
+    /// let mut input = Cursor::new(vec![100, 1, 2, 3, 4]);
+    /// let mut reader = deku::reader::Reader::new(&mut input);
+    /// let map =
+    ///     HashMap::<u8, u32>::from_reader_with_ctx(&mut reader, (1.into(), Endian::Little)).unwrap();
     /// let mut expected = HashMap::<u8, u32>::default();
     /// expected.insert(100, 0x04030201);
     /// assert_eq!(expected, map)
     /// ```
-    fn read(
-        input: &'a BitSlice<u8, Msb0>,
+    fn from_reader_with_ctx<R: Read>(
+        reader: &mut crate::reader::Reader<R>,
         (limit, inner_ctx): (Limit<(K, V), Predicate>, Ctx),
-    ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError>
+    ) -> Result<Self, DekuError>
     where
         Self: Sized,
     {
@@ -79,20 +80,28 @@ impl<
             Limit::Count(mut count) => {
                 // Handle the trivial case of reading an empty hashmap
                 if count == 0 {
-                    return Ok((input, HashMap::<K, V, S>::default()));
+                    return Ok(HashMap::<K, V, S>::default());
                 }
 
                 // Otherwise, read until we have read `count` elements
-                read_hashmap_with_predicate(input, Some(count), inner_ctx, move |_, _| {
-                    count -= 1;
-                    count == 0
-                })
+                from_reader_with_ctx_hashmap_with_predicate(
+                    reader,
+                    Some(count),
+                    inner_ctx,
+                    move |_, _| {
+                        count -= 1;
+                        count == 0
+                    },
+                )
             }
 
             // Read until a given predicate returns true
-            Limit::Until(mut predicate, _) => {
-                read_hashmap_with_predicate(input, None, inner_ctx, move |_, kv| predicate(kv))
-            }
+            Limit::Until(mut predicate, _) => from_reader_with_ctx_hashmap_with_predicate(
+                reader,
+                None,
+                inner_ctx,
+                move |_, kv| predicate(kv),
+            ),
 
             // Read until a given quantity of bits have been read
             Limit::BitSize(size) => {
@@ -100,48 +109,53 @@ impl<
 
                 // Handle the trivial case of reading an empty hashmap
                 if bit_size == 0 {
-                    return Ok((input, HashMap::<K, V, S>::default()));
+                    return Ok(HashMap::<K, V, S>::default());
                 }
 
-                read_hashmap_with_predicate(input, None, inner_ctx, move |read_bits, _| {
-                    read_bits == bit_size
-                })
+                from_reader_with_ctx_hashmap_with_predicate(
+                    reader,
+                    None,
+                    inner_ctx,
+                    move |read_bits, _| read_bits == bit_size,
+                )
             }
 
-            // Read until a given quantity of bits have been read
+            // Read until a given quantity of byte bits have been read
             Limit::ByteSize(size) => {
                 let bit_size = size.0 * 8;
 
                 // Handle the trivial case of reading an empty hashmap
                 if bit_size == 0 {
-                    return Ok((input, HashMap::<K, V, S>::default()));
+                    return Ok(HashMap::<K, V, S>::default());
                 }
 
-                read_hashmap_with_predicate(input, None, inner_ctx, move |read_bits, _| {
-                    read_bits == bit_size
-                })
+                from_reader_with_ctx_hashmap_with_predicate(
+                    reader,
+                    None,
+                    inner_ctx,
+                    move |read_bits, _| read_bits == bit_size,
+                )
             }
         }
     }
 }
 
-impl<
-        'a,
-        K: DekuRead<'a> + Eq + Hash,
-        V: DekuRead<'a>,
-        S: BuildHasher + Default,
-        Predicate: FnMut(&(K, V)) -> bool,
-    > DekuRead<'a, Limit<(K, V), Predicate>> for HashMap<K, V, S>
+impl<'a, K, V, S, Predicate> DekuReader<'a, Limit<(K, V), Predicate>> for HashMap<K, V, S>
+where
+    K: DekuReader<'a> + Eq + Hash,
+    V: DekuReader<'a>,
+    S: BuildHasher + Default,
+    Predicate: FnMut(&(K, V)) -> bool,
 {
     /// Read `K, V`s until the given limit from input for types which don't require context.
-    fn read(
-        input: &'a BitSlice<u8, Msb0>,
+    fn from_reader_with_ctx<R: Read>(
+        reader: &mut crate::reader::Reader<R>,
         limit: Limit<(K, V), Predicate>,
-    ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError>
+    ) -> Result<Self, DekuError>
     where
         Self: Sized,
     {
-        Self::read(input, (limit, ()))
+        Self::from_reader_with_ctx(reader, (limit, ()))
     }
 }
 
@@ -173,9 +187,13 @@ impl<K: DekuWrite<Ctx>, V: DekuWrite<Ctx>, S, Ctx: Copy> DekuWrite<Ctx> for Hash
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use no_std_io::io::Cursor;
     use rstest::rstest;
     use rustc_hash::FxHashMap;
+
+    use crate::reader::Reader;
+
+    use super::*;
 
     // Macro to create a deterministic HashMap for tests
     // This is needed for tests since the default HashMap Hasher
@@ -194,45 +212,55 @@ mod tests {
          };
     );
 
-    #[rstest(input, endian, bit_size, limit, expected, expected_rest,
-        case::count_0([0xAA].as_ref(), Endian::Little, Some(8), 0.into(), FxHashMap::default(), bits![u8, Msb0; 1, 0, 1, 0, 1, 0, 1, 0]),
-        case::count_1([0x01, 0xAA, 0x02, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), fxhashmap!{0x01 => 0xAA}, bits![u8, Msb0; 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::count_2([0x01, 0xAA, 0x02, 0xBB, 0xBB].as_ref(), Endian::Little, Some(8), 2.into(), fxhashmap!{0x01 => 0xAA, 0x02 => 0xBB}, bits![u8, Msb0; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::until_null([0x01, 0xAA, 0, 0, 0xBB].as_ref(), Endian::Little, None, (|kv: &(u8, u8)| kv.0 == 0u8 && kv.1 == 0u8).into(), fxhashmap!{0x01 => 0xAA, 0 => 0}, bits![u8, Msb0; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::until_bits([0x01, 0xAA, 0xBB].as_ref(), Endian::Little, None, BitSize(16).into(), fxhashmap!{0x01 => 0xAA}, bits![u8, Msb0; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::bits_6([0b0000_0100, 0b1111_0000, 0b1000_0000].as_ref(), Endian::Little, Some(6), 2.into(), fxhashmap!{0x01 => 0x0F, 0x02 => 0}, bits![u8, Msb0;]),
+    #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes,
+        case::count_0([0xAA].as_ref(), Endian::Little, Some(8), 0.into(), FxHashMap::default(), bits![u8, Msb0;], &[0xaa]),
+        case::count_1([0x01, 0xAA, 0x02, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), fxhashmap!{0x01 => 0xAA}, bits![u8, Msb0;], &[0x02, 0xbb]),
+        case::count_2([0x01, 0xAA, 0x02, 0xBB, 0xBB].as_ref(), Endian::Little, Some(8), 2.into(), fxhashmap!{0x01 => 0xAA, 0x02 => 0xBB}, bits![u8, Msb0;], &[0xbb]),
+        case::until_null([0x01, 0xAA, 0, 0, 0xBB].as_ref(), Endian::Little, None, (|kv: &(u8, u8)| kv.0 == 0u8 && kv.1 == 0u8).into(), fxhashmap!{0x01 => 0xAA, 0 => 0}, bits![u8, Msb0;], &[0xbb]),
+        case::until_bits([0x01, 0xAA, 0xBB].as_ref(), Endian::Little, None, BitSize(16).into(), fxhashmap!{0x01 => 0xAA}, bits![u8, Msb0;], &[0xbb]),
+        case::bits_6([0b0000_0100, 0b1111_0000, 0b1000_0000].as_ref(), Endian::Little, Some(6), 2.into(), fxhashmap!{0x01 => 0x0F, 0x02 => 0}, bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::not_enough_data([].as_ref(), Endian::Little, Some(9), 1.into(), FxHashMap::default(), bits![u8, Msb0;]),
+        case::not_enough_data([].as_ref(), Endian::Little, Some(9), 1.into(), FxHashMap::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(9), 1.into(), FxHashMap::default(), bits![u8, Msb0;]),
+        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(9), 1.into(), FxHashMap::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(8), 2.into(), FxHashMap::default(), bits![u8, Msb0;]),
+        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(8), 2.into(), FxHashMap::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data_until([0xAA].as_ref(), Endian::Little, Some(8), (|_: &(u8, u8)| false).into(), FxHashMap::default(), bits![u8, Msb0;]),
+        case::not_enough_data_until([0xAA].as_ref(), Endian::Little, Some(8), (|_: &(u8, u8)| false).into(), FxHashMap::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (BitSize(16)).into(), FxHashMap::default(), bits![u8, Msb0;]),
+        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (BitSize(16)).into(), FxHashMap::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), FxHashMap::default(), bits![u8, Msb0;]),
+        case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), FxHashMap::default(), bits![u8, Msb0;], &[]),
     )]
-    fn test_hashmap_read<Predicate: FnMut(&(u8, u8)) -> bool>(
+    fn test_hashmap_read<Predicate: FnMut(&(u8, u8)) -> bool + Copy>(
         input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         limit: Limit<(u8, u8), Predicate>,
         expected: FxHashMap<u8, u8>,
-        expected_rest: &BitSlice<u8, Msb0>,
+        expected_rest_bits: &BitSlice<u8, Msb0>,
+        expected_rest_bytes: &[u8],
     ) {
-        let bit_slice = input.view_bits::<Msb0>();
-
-        let (rest, res_read) = match bit_size {
-            Some(bit_size) => {
-                FxHashMap::<u8, u8>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap()
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        let res_read = match bit_size {
+            Some(bit_size) => FxHashMap::<u8, u8>::from_reader_with_ctx(
+                &mut reader,
+                (limit, (endian, BitSize(bit_size))),
+            )
+            .unwrap(),
+            None => {
+                FxHashMap::<u8, u8>::from_reader_with_ctx(&mut reader, (limit, (endian))).unwrap()
             }
-            None => FxHashMap::<u8, u8>::read(bit_slice, (limit, (endian))).unwrap(),
         };
-
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
+        assert_eq!(
+            reader.rest(),
+            expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
+        );
+        let mut buf = vec![];
+        cursor.read_to_end(&mut buf).unwrap();
+        assert_eq!(expected_rest_bytes, buf);
     }
 
     #[rstest(input, endian, expected,
@@ -245,27 +273,35 @@ mod tests {
     }
 
     // Note: These tests also exist in boxed.rs
-    #[rstest(input, endian, limit, expected, expected_rest, expected_write,
-        case::normal_le([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Little, 2.into(), fxhashmap!{0xBBAA => 0, 0xDDCC => 0}, bits![u8, Msb0;], vec![0xCC, 0xDD, 0, 0xAA, 0xBB, 0]),
-        case::normal_be([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Big, 2.into(), fxhashmap!{0xAABB => 0, 0xCCDD => 0}, bits![u8, Msb0;], vec![0xCC, 0xDD, 0, 0xAA, 0xBB, 0]),
-        case::predicate_le([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Little, (|kv: &(u16, u8)| kv.0 == 0xBBAA && kv.1 == 0).into(), fxhashmap!{0xBBAA => 0}, bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0], vec![0xAA, 0xBB, 0]),
-        case::predicate_be([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Big, (|kv: &(u16, u8)| kv.0 == 0xAABB && kv.1 == 0).into(), fxhashmap!{0xAABB => 0}, bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0], vec![0xAA, 0xBB, 0]),
-        case::bytes_le([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Little, BitSize(24).into(), fxhashmap!{0xBBAA => 0}, bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0], vec![0xAA, 0xBB, 0]),
-        case::bytes_be([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Big, BitSize(24).into(), fxhashmap!{0xAABB => 0}, bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0], vec![0xAA, 0xBB, 0]),
+    #[rstest(input, endian, limit, expected, expected_rest_bits, expected_rest_bytes, expected_write,
+        case::normal_le([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Little, 2.into(), fxhashmap!{0xBBAA => 0, 0xDDCC => 0}, bits![u8, Msb0;], &[], vec![0xCC, 0xDD, 0, 0xAA, 0xBB, 0]),
+        case::normal_be([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Big, 2.into(), fxhashmap!{0xAABB => 0, 0xCCDD => 0}, bits![u8, Msb0;], &[], vec![0xCC, 0xDD, 0, 0xAA, 0xBB, 0]),
+        case::predicate_le([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Little, (|kv: &(u16, u8)| kv.0 == 0xBBAA && kv.1 == 0).into(), fxhashmap!{0xBBAA => 0}, bits![u8, Msb0;], &[0xcc, 0xdd, 0], vec![0xAA, 0xBB, 0]),
+        case::predicate_be([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Big, (|kv: &(u16, u8)| kv.0 == 0xAABB && kv.1 == 0).into(), fxhashmap!{0xAABB => 0}, bits![u8, Msb0;], &[0xcc, 0xdd, 0], vec![0xAA, 0xBB, 0]),
+        case::bytes_le([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Little, BitSize(24).into(), fxhashmap!{0xBBAA => 0}, bits![u8, Msb0;], &[0xcc, 0xdd, 0], vec![0xAA, 0xBB, 0]),
+        case::bytes_be([0xAA, 0xBB, 0, 0xCC, 0xDD, 0].as_ref(), Endian::Big, BitSize(24).into(), fxhashmap!{0xAABB => 0}, bits![u8, Msb0;], &[0xcc, 0xdd, 0], vec![0xAA, 0xBB, 0]),
     )]
-    fn test_hashmap_read_write<Predicate: FnMut(&(u16, u8)) -> bool>(
+    fn test_hashmap_read_write<Predicate: FnMut(&(u16, u8)) -> bool + Copy>(
         input: &[u8],
         endian: Endian,
         limit: Limit<(u16, u8), Predicate>,
         expected: FxHashMap<u16, u8>,
-        expected_rest: &BitSlice<u8, Msb0>,
+        expected_rest_bits: &BitSlice<u8, Msb0>,
+        expected_rest_bytes: &[u8],
         expected_write: Vec<u8>,
     ) {
-        let bit_slice = input.view_bits::<Msb0>();
-
-        let (rest, res_read) = FxHashMap::<u16, u8>::read(bit_slice, (limit, endian)).unwrap();
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        let res_read =
+            FxHashMap::<u16, u8>::from_reader_with_ctx(&mut reader, (limit, endian)).unwrap();
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
+        assert_eq!(
+            reader.rest(),
+            expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
+        );
+        let mut buf = vec![];
+        cursor.read_to_end(&mut buf).unwrap();
+        assert_eq!(expected_rest_bytes, buf);
 
         let mut res_write = bitvec![u8, Msb0;];
         res_read.write(&mut res_write, endian).unwrap();

--- a/src/impls/hashset.rs
+++ b/src/impls/hashset.rs
@@ -1,7 +1,11 @@
-use crate::{ctx::*, DekuError, DekuRead, DekuWrite};
-use bitvec::prelude::*;
 use std::collections::HashSet;
 use std::hash::{BuildHasher, Hash};
+
+use bitvec::prelude::*;
+use no_std_io::io::Read;
+
+use crate::ctx::*;
+use crate::{DekuError, DekuReader, DekuWrite};
 
 /// Read `T`s into a hashset until a given predicate returns true
 /// * `capacity` - an optional capacity to pre-allocate the hashset with
@@ -11,43 +15,38 @@ use std::hash::{BuildHasher, Hash};
 /// and a borrow of the latest value to have been read. It should return `true` if reading
 /// should now stop, and `false` otherwise
 #[allow(clippy::type_complexity)]
-fn read_hashset_with_predicate<
-    'a,
-    T: DekuRead<'a, Ctx> + Eq + Hash,
-    S: BuildHasher + Default,
-    Ctx: Copy,
-    Predicate: FnMut(usize, &T) -> bool,
->(
-    input: &'a BitSlice<u8, Msb0>,
+fn from_reader_with_ctx_hashset_with_predicate<'a, T, S, Ctx, Predicate, R: Read>(
+    reader: &mut crate::reader::Reader<R>,
     capacity: Option<usize>,
     ctx: Ctx,
     mut predicate: Predicate,
-) -> Result<(&'a BitSlice<u8, Msb0>, HashSet<T, S>), DekuError> {
+) -> Result<HashSet<T, S>, DekuError>
+where
+    T: DekuReader<'a, Ctx> + Eq + Hash,
+    S: BuildHasher + Default,
+    Ctx: Copy,
+    Predicate: FnMut(usize, &T) -> bool,
+{
     let mut res = HashSet::with_capacity_and_hasher(capacity.unwrap_or(0), S::default());
 
-    let mut rest = input;
     let mut found_predicate = false;
+    let orig_bits_read = reader.bits_read;
 
     while !found_predicate {
-        let (new_rest, val) = <T>::read(rest, ctx)?;
-        found_predicate = predicate(
-            unsafe { new_rest.as_bitptr().offset_from(input.as_bitptr()) } as usize,
-            &val,
-        );
+        let val = <T>::from_reader_with_ctx(reader, ctx)?;
+        found_predicate = predicate(reader.bits_read - orig_bits_read, &val);
         res.insert(val);
-        rest = new_rest;
     }
 
-    Ok((rest, res))
+    Ok(res)
 }
 
-impl<
-        'a,
-        T: DekuRead<'a, Ctx> + Eq + Hash,
-        S: BuildHasher + Default,
-        Ctx: Copy,
-        Predicate: FnMut(&T) -> bool,
-    > DekuRead<'a, (Limit<T, Predicate>, Ctx)> for HashSet<T, S>
+impl<'a, T, S, Ctx, Predicate> DekuReader<'a, (Limit<T, Predicate>, Ctx)> for HashSet<T, S>
+where
+    T: DekuReader<'a, Ctx> + Eq + Hash,
+    S: BuildHasher + Default,
+    Ctx: Copy,
+    Predicate: FnMut(&T) -> bool,
 {
     /// Read `T`s until the given limit
     /// * `limit` - the limiting factor on the amount of `T`s to read
@@ -55,19 +54,19 @@ impl<
     /// # Examples
     /// ```rust
     /// # use deku::ctx::*;
-    /// # use deku::DekuRead;
-    /// # use deku::bitvec::BitView;
+    /// # use deku::DekuReader;
     /// # use std::collections::HashSet;
-    /// let input = vec![1u8, 2, 3, 4];
+    /// # use std::io::Cursor;
+    /// let mut input = Cursor::new(vec![1u8, 2, 3, 4]);
     /// let expected: HashSet<u32> = vec![0x04030201].into_iter().collect();
-    /// let (rest, set) = HashSet::<u32>::read(input.view_bits(), (1.into(), Endian::Little)).unwrap();
-    /// assert!(rest.is_empty());
+    /// let mut reader = deku::reader::Reader::new(&mut input);
+    /// let set = HashSet::<u32>::from_reader_with_ctx(&mut reader, (1.into(), Endian::Little)).unwrap();
     /// assert_eq!(expected, set)
     /// ```
-    fn read(
-        input: &'a BitSlice<u8, Msb0>,
+    fn from_reader_with_ctx<R: Read>(
+        reader: &mut crate::reader::Reader<R>,
         (limit, inner_ctx): (Limit<T, Predicate>, Ctx),
-    ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError>
+    ) -> Result<Self, DekuError>
     where
         Self: Sized,
     {
@@ -76,22 +75,28 @@ impl<
             Limit::Count(mut count) => {
                 // Handle the trivial case of reading an empty hashset
                 if count == 0 {
-                    return Ok((input, HashSet::<T, S>::default()));
+                    return Ok(HashSet::<T, S>::default());
                 }
 
                 // Otherwise, read until we have read `count` elements
-                read_hashset_with_predicate(input, Some(count), inner_ctx, move |_, _| {
-                    count -= 1;
-                    count == 0
-                })
+                from_reader_with_ctx_hashset_with_predicate(
+                    reader,
+                    Some(count),
+                    inner_ctx,
+                    move |_, _| {
+                        count -= 1;
+                        count == 0
+                    },
+                )
             }
 
             // Read until a given predicate returns true
-            Limit::Until(mut predicate, _) => {
-                read_hashset_with_predicate(input, None, inner_ctx, move |_, value| {
-                    predicate(value)
-                })
-            }
+            Limit::Until(mut predicate, _) => from_reader_with_ctx_hashset_with_predicate(
+                reader,
+                None,
+                inner_ctx,
+                move |_, value| predicate(value),
+            ),
 
             // Read until a given quantity of bits have been read
             Limit::BitSize(size) => {
@@ -99,12 +104,15 @@ impl<
 
                 // Handle the trivial case of reading an empty hashset
                 if bit_size == 0 {
-                    return Ok((input, HashSet::<T, S>::default()));
+                    return Ok(HashSet::<T, S>::default());
                 }
 
-                read_hashset_with_predicate(input, None, inner_ctx, move |read_bits, _| {
-                    read_bits == bit_size
-                })
+                from_reader_with_ctx_hashset_with_predicate(
+                    reader,
+                    None,
+                    inner_ctx,
+                    move |read_bits, _| read_bits == bit_size,
+                )
             }
 
             // Read until a given quantity of bits have been read
@@ -113,29 +121,32 @@ impl<
 
                 // Handle the trivial case of reading an empty hashset
                 if bit_size == 0 {
-                    return Ok((input, HashSet::<T, S>::default()));
+                    return Ok(HashSet::<T, S>::default());
                 }
 
-                read_hashset_with_predicate(input, None, inner_ctx, move |read_bits, _| {
-                    read_bits == bit_size
-                })
+                from_reader_with_ctx_hashset_with_predicate(
+                    reader,
+                    None,
+                    inner_ctx,
+                    move |read_bits, _| read_bits == bit_size,
+                )
             }
         }
     }
 }
 
-impl<'a, T: DekuRead<'a> + Eq + Hash, S: BuildHasher + Default, Predicate: FnMut(&T) -> bool>
-    DekuRead<'a, Limit<T, Predicate>> for HashSet<T, S>
+impl<'a, T: DekuReader<'a> + Eq + Hash, S: BuildHasher + Default, Predicate: FnMut(&T) -> bool>
+    DekuReader<'a, Limit<T, Predicate>> for HashSet<T, S>
 {
     /// Read `T`s until the given limit from input for types which don't require context.
-    fn read(
-        input: &'a BitSlice<u8, Msb0>,
+    fn from_reader_with_ctx<R: Read>(
+        reader: &mut crate::reader::Reader<R>,
         limit: Limit<T, Predicate>,
-    ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError>
+    ) -> Result<Self, DekuError>
     where
         Self: Sized,
     {
-        Self::read(input, (limit, ()))
+        Self::from_reader_with_ctx(reader, (limit, ()))
     }
 }
 
@@ -165,49 +176,61 @@ impl<T: DekuWrite<Ctx>, S, Ctx: Copy> DekuWrite<Ctx> for HashSet<T, S> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use no_std_io::io::Cursor;
     use rstest::rstest;
     use rustc_hash::FxHashSet;
 
-    #[rstest(input, endian, bit_size, limit, expected, expected_rest,
-        case::count_0([0xAA].as_ref(), Endian::Little, Some(8), 0.into(), FxHashSet::default(), bits![u8, Msb0; 1, 0, 1, 0, 1, 0, 1, 0]),
-        case::count_1([0xAA, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), vec![0xAA].into_iter().collect(), bits![u8, Msb0; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::count_2([0xAA, 0xBB, 0xCC].as_ref(), Endian::Little, Some(8), 2.into(), vec![0xAA, 0xBB].into_iter().collect(), bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0]),
-        case::until_null([0xAA, 0, 0xBB].as_ref(), Endian::Little, None, (|v: &u8| *v == 0u8).into(), vec![0xAA, 0].into_iter().collect(), bits![u8, Msb0; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::until_bits([0xAA, 0xBB].as_ref(), Endian::Little, None, BitSize(8).into(), vec![0xAA].into_iter().collect(), bits![u8, Msb0; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::bits_6([0b0110_1001, 0b1110_1001].as_ref(), Endian::Little, Some(6), 2.into(), vec![0b00_011010, 0b00_011110].into_iter().collect(), bits![u8, Msb0; 1, 0, 0, 1]),
+    use crate::reader::Reader;
+
+    use super::*;
+
+    #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes,
+        case::count_0([0xAA].as_ref(), Endian::Little, Some(8), 0.into(), FxHashSet::default(), bits![u8, Msb0;], &[0xaa]),
+        case::count_1([0xAA, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), vec![0xAA].into_iter().collect(), bits![u8, Msb0;], &[0xbb]),
+        case::count_2([0xAA, 0xBB, 0xCC].as_ref(), Endian::Little, Some(8), 2.into(), vec![0xAA, 0xBB].into_iter().collect(), bits![u8, Msb0;], &[0xcc]),
+        case::until_null([0xAA, 0, 0xBB].as_ref(), Endian::Little, None, (|v: &u8| *v == 0u8).into(), vec![0xAA, 0].into_iter().collect(), bits![u8, Msb0;], &[0xbb]),
+        case::until_bits([0xAA, 0xBB].as_ref(), Endian::Little, None, BitSize(8).into(), vec![0xAA].into_iter().collect(), bits![u8, Msb0;], &[0xbb]),
+        case::bits_6([0b0110_1001, 0b1110_1001].as_ref(), Endian::Little, Some(6), 2.into(), vec![0b00_011010, 0b00_011110].into_iter().collect(), bits![u8, Msb0; 1, 0, 0, 1], &[]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::not_enough_data([].as_ref(), Endian::Little, Some(9), 1.into(), FxHashSet::default(), bits![u8, Msb0;]),
+        case::not_enough_data([].as_ref(), Endian::Little, Some(9), 1.into(), FxHashSet::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(9), 1.into(), FxHashSet::default(), bits![u8, Msb0;]),
+        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(9), 1.into(), FxHashSet::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(8), 2.into(), FxHashSet::default(), bits![u8, Msb0;]),
+        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(8), 2.into(), FxHashSet::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data_until([0xAA].as_ref(), Endian::Little, Some(8), (|_: &u8| false).into(), FxHashSet::default(), bits![u8, Msb0;]),
+        case::not_enough_data_until([0xAA].as_ref(), Endian::Little, Some(8), (|_: &u8| false).into(), FxHashSet::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (BitSize(16)).into(), FxHashSet::default(), bits![u8, Msb0;]),
+        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (BitSize(16)).into(), FxHashSet::default(), bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), FxHashSet::default(), bits![u8, Msb0;]),
+        case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), FxHashSet::default(), bits![u8, Msb0;], &[]),
     )]
-    fn test_hashset_read<Predicate: FnMut(&u8) -> bool>(
+    fn test_hashset_read<Predicate: FnMut(&u8) -> bool + Copy>(
         input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         limit: Limit<u8, Predicate>,
         expected: FxHashSet<u8>,
-        expected_rest: &BitSlice<u8, Msb0>,
+        expected_rest_bits: &BitSlice<u8, Msb0>,
+        expected_rest_bytes: &[u8],
     ) {
-        let bit_slice = input.view_bits::<Msb0>();
-
-        let (rest, res_read) = match bit_size {
-            Some(bit_size) => {
-                FxHashSet::<u8>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap()
-            }
-            None => FxHashSet::<u8>::read(bit_slice, (limit, (endian))).unwrap(),
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        let res_read = match bit_size {
+            Some(bit_size) => FxHashSet::<u8>::from_reader_with_ctx(
+                &mut reader,
+                (limit, (endian, BitSize(bit_size))),
+            )
+            .unwrap(),
+            None => FxHashSet::<u8>::from_reader_with_ctx(&mut reader, (limit, (endian))).unwrap(),
         };
-
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
+        assert_eq!(
+            reader.rest(),
+            expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
+        );
+        let mut buf = vec![];
+        cursor.read_to_end(&mut buf).unwrap();
+        assert_eq!(expected_rest_bytes, buf);
     }
 
     #[rstest(input, endian, expected,
@@ -220,32 +243,42 @@ mod tests {
     }
 
     // Note: These tests also exist in boxed.rs
-    #[rstest(input, endian, bit_size, limit, expected, expected_rest, expected_write,
-        case::normal_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), 2.into(), vec![0xBBAA, 0xDDCC].into_iter().collect(), bits![u8, Msb0;], vec![0xCC, 0xDD, 0xAA, 0xBB]),
-        case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD].into_iter().collect(), bits![u8, Msb0;], vec![0xCC, 0xDD, 0xAA, 0xBB]),
-        case::predicate_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), (|v: &u16| *v == 0xBBAA).into(), vec![0xBBAA].into_iter().collect(), bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::predicate_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), (|v: &u16| *v == 0xAABB).into(), vec![0xAABB].into_iter().collect(), bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), BitSize(16).into(), vec![0xBBAA].into_iter().collect(), bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), BitSize(16).into(), vec![0xAABB].into_iter().collect(), bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
+    #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes, expected_write,
+        case::normal_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), 2.into(), vec![0xBBAA, 0xDDCC].into_iter().collect(), bits![u8, Msb0;], &[], vec![0xCC, 0xDD, 0xAA, 0xBB]),
+        case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD].into_iter().collect(), bits![u8, Msb0;], &[], vec![0xCC, 0xDD, 0xAA, 0xBB]),
+        case::predicate_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), (|v: &u16| *v == 0xBBAA).into(), vec![0xBBAA].into_iter().collect(), bits![u8, Msb0;], &[0xcc, 0xdd], vec![0xAA, 0xBB]),
+        case::predicate_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), (|v: &u16| *v == 0xAABB).into(), vec![0xAABB].into_iter().collect(), bits![u8, Msb0;], &[0xcc, 0xdd], vec![0xAA, 0xBB]),
+        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), BitSize(16).into(), vec![0xBBAA].into_iter().collect(), bits![u8, Msb0;], &[0xcc, 0xdd], vec![0xAA, 0xBB]),
+        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), BitSize(16).into(), vec![0xAABB].into_iter().collect(), bits![u8, Msb0;], &[0xcc, 0xdd], vec![0xAA, 0xBB]),
     )]
-    fn test_hashset_read_write<Predicate: FnMut(&u16) -> bool>(
+    fn test_hashset_read_write<Predicate: FnMut(&u16) -> bool + Copy>(
         input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         limit: Limit<u16, Predicate>,
         expected: FxHashSet<u16>,
-        expected_rest: &BitSlice<u8, Msb0>,
+        expected_rest_bits: &BitSlice<u8, Msb0>,
+        expected_rest_bytes: &[u8],
         expected_write: Vec<u8>,
     ) {
-        let bit_slice = input.view_bits::<Msb0>();
-
         // Unwrap here because all test cases are `Some`.
         let bit_size = bit_size.unwrap();
 
-        let (rest, res_read) =
-            FxHashSet::<u16>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap();
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        let res_read = FxHashSet::<u16>::from_reader_with_ctx(
+            &mut reader,
+            (limit, (endian, BitSize(bit_size))),
+        )
+        .unwrap();
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
+        assert_eq!(
+            reader.rest(),
+            expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
+        );
+        let mut buf = vec![];
+        cursor.read_to_end(&mut buf).unwrap();
+        assert_eq!(expected_rest_bytes, buf);
 
         let mut res_write = bitvec![u8, Msb0;];
         res_read

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -1,89 +1,87 @@
-use crate::{ctx::*, DekuError, DekuRead, DekuWrite};
-use bitvec::prelude::*;
-use core::convert::TryInto;
-
 #[cfg(feature = "alloc")]
 use alloc::format;
+#[cfg(feature = "alloc")]
+use alloc::string::ToString;
+use core::convert::TryInto;
+
+use bitvec::prelude::*;
+use no_std_io::io::Read;
+
+use crate::ctx::*;
+use crate::reader::{Reader, ReaderRet};
+use crate::{DekuError, DekuReader, DekuWrite};
+
+/// "Read" trait: read bits and construct type
+trait DekuRead<'a, Ctx = ()> {
+    /// Read bits and construct type
+    /// * **input** - Input as bits
+    /// * **ctx** - A context required by context-sensitive reading. A unit type `()` means no context
+    /// needed.
+    ///
+    /// Returns the amount of bits read after parsing in addition to Self.
+    ///
+    /// NOTE: since this is only used internally by primitive types, we don't need to verify the
+    /// size of BitSize or ByteSize to check if they fit in the requested container size
+    /// (size_of::<type>()).
+    fn read(
+        input: &'a crate::bitvec::BitSlice<u8, crate::bitvec::Msb0>,
+        ctx: Ctx,
+    ) -> Result<(usize, Self), DekuError>
+    where
+        Self: Sized;
+}
 
 // specialize u8 for ByteSize
 impl DekuRead<'_, (Endian, ByteSize)> for u8 {
+    #[inline]
     fn read(
         input: &BitSlice<u8, Msb0>,
-        (_, size): (Endian, ByteSize),
-    ) -> Result<(&BitSlice<u8, Msb0>, Self), DekuError> {
+        (_, _): (Endian, ByteSize),
+    ) -> Result<(usize, Self), DekuError> {
         const MAX_TYPE_BITS: usize = BitSize::of::<u8>().0;
-        let bit_size: usize = size.0 * 8;
 
-        // TODO
-        // if they never give [bits] or [bytes] we don't need to check the size
-        if bit_size > MAX_TYPE_BITS {
-            return Err(DekuError::Parse(format!(
-                "too much data: container of {MAX_TYPE_BITS} bits cannot hold {bit_size} bits",
-            )));
-        }
+        // PANIC: We already check that input.len() < bit_size above, so no panic will happen
+        let value = input[..MAX_TYPE_BITS].load::<u8>();
+        Ok((MAX_TYPE_BITS, value))
+    }
+}
 
-        if input.len() < bit_size {
-            return Err(DekuError::Incomplete(crate::error::NeedSize::new(bit_size)));
-        }
-
-        let (bit_slice, rest) = input.split_at(bit_size);
-        let pad = 8 * ((bit_slice.len() + 7) / 8) - bit_slice.len();
-
-        let value = if pad == 0
-            && bit_slice.len() == MAX_TYPE_BITS
-            && bit_slice.domain().region().unwrap().1.len() * 8 == MAX_TYPE_BITS
-        {
-            // if everything is aligned, just read the value
-            bit_slice.load::<u8>()
-        } else {
-            let mut bits: BitVec<u8, Msb0> = BitVec::with_capacity(bit_slice.len() + pad);
-
-            // Copy bits to new BitVec
-            bits.extend_from_bitslice(bit_slice);
-
-            // Force align
-            //i.e. [1110, 10010110] -> [11101001, 0110]
-            bits.force_align();
-
-            let bytes: &[u8] = bits.as_raw_slice();
-
-            // cannot use from_X_bytes as we don't have enough bytes for $typ
-            // read manually
-            let mut res: u8 = 0;
-            for b in bytes.iter().rev() {
-                res |= *b;
+impl DekuReader<'_, (Endian, ByteSize)> for u8 {
+    #[inline]
+    fn from_reader_with_ctx<R: Read>(
+        reader: &mut Reader<R>,
+        (endian, size): (Endian, ByteSize),
+    ) -> Result<u8, DekuError> {
+        let mut buf = [0; core::mem::size_of::<u8>()];
+        let ret = reader.read_bytes(size.0, &mut buf)?;
+        let a = match ret {
+            ReaderRet::Bits(bits) => {
+                let Some(bits) = bits else {
+                    return Err(DekuError::Parse("no bits read from reader".to_string()));
+                };
+                let a = <u8>::read(&bits, (endian, size))?;
+                a.1
             }
-
-            res
+            ReaderRet::Bytes => <u8>::from_be_bytes(buf),
         };
-
-        Ok((rest, value))
+        Ok(a)
     }
 }
 
 macro_rules! ImplDekuReadBits {
     ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, BitSize)> for $typ {
+            #[inline]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, BitSize),
-            ) -> Result<(&BitSlice<u8, Msb0>, Self), DekuError> {
+            ) -> Result<(usize, Self), DekuError> {
                 const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 let bit_size: usize = size.0;
 
                 let input_is_le = endian.is_le();
 
-                if bit_size > MAX_TYPE_BITS {
-                    return Err(DekuError::Parse(format!(
-                        "too much data: container of {MAX_TYPE_BITS} bits cannot hold {bit_size} bits",
-                    )));
-                }
-
-                if input.len() < bit_size {
-                    return Err(DekuError::Incomplete(crate::error::NeedSize::new(bit_size)));
-                }
-
-                let (bit_slice, rest) = input.split_at(bit_size);
+                let bit_slice = &input[..bit_size];
 
                 let pad = 8 * ((bit_slice.len() + 7) / 8) - bit_slice.len();
 
@@ -98,53 +96,75 @@ macro_rules! ImplDekuReadBits {
                         } else {
                             <$typ>::from_be_bytes(bytes.try_into()?)
                         };
-                        return Ok((rest, value));
+                        return Ok((bit_size, value));
                     }
                 }
 
-                    // Create a new BitVec from the slice and pad un-aligned chunks
-                    // i.e. [10010110, 1110] -> [10010110, 00001110]
-                    let bits: BitVec<u8, Msb0> = {
-                        let mut bits = BitVec::with_capacity(bit_slice.len() + pad);
+                // Create a new BitVec from the slice and pad un-aligned chunks
+                // i.e. [10010110, 1110] -> [10010110, 00001110]
+                let bits: BitVec<u8, Msb0> = {
+                    let mut bits = BitVec::with_capacity(bit_slice.len() + pad);
 
-                        // Copy bits to new BitVec
-                        bits.extend_from_bitslice(bit_slice);
+                    // Copy bits to new BitVec
+                    bits.extend_from_bitslice(&bit_slice);
 
-                        // Force align
-                        //i.e. [1110, 10010110] -> [11101001, 0110]
-                        bits.force_align();
+                    // Force align
+                    //i.e. [1110, 10010110] -> [11101001, 0110]
+                    bits.force_align();
 
-                        // Some padding to next byte
-                        let index = if input_is_le {
-                            bits.len() - (8 - pad)
-                        } else {
-                            0
-                        };
-                        for _ in 0..pad {
-                            bits.insert(index, false);
-                        }
-
-                        // Pad up-to size of type
-                        for _ in 0..(MAX_TYPE_BITS - bits.len()) {
-                            if input_is_le {
-                                bits.push(false);
-                            } else {
-                                bits.insert(0, false);
-                            }
-                        }
-
-                        bits
-                    };
-
-                    let bytes: &[u8] = bits.domain().region().unwrap().1;
-
-                    // Read value
-                    let value = if input_is_le {
-                        <$typ>::from_le_bytes(bytes.try_into()?)
+                    // Some padding to next byte
+                    let index = if input_is_le {
+                        bits.len() - (8 - pad)
                     } else {
-                        <$typ>::from_be_bytes(bytes.try_into()?)
+                        0
                     };
-                    Ok((rest, value))
+                    for _ in 0..pad {
+                        bits.insert(index, false);
+                    }
+
+                    // Pad up-to size of type
+                    for _ in 0..(MAX_TYPE_BITS - bits.len()) {
+                        if input_is_le {
+                            bits.push(false);
+                        } else {
+                            bits.insert(0, false);
+                        }
+                    }
+
+                    bits
+                };
+
+                let bytes: &[u8] = bits.domain().region().unwrap().1;
+
+                // Read value
+                let value = if input_is_le {
+                    <$typ>::from_le_bytes(bytes.try_into()?)
+                } else {
+                    <$typ>::from_be_bytes(bytes.try_into()?)
+                };
+                Ok((bit_size, value))
+            }
+        }
+
+        impl DekuReader<'_, (Endian, BitSize)> for $typ {
+            #[inline]
+            fn from_reader_with_ctx<R: Read>(
+                reader: &mut Reader<R>,
+                (endian, size): (Endian, BitSize),
+            ) -> Result<$typ, DekuError> {
+                const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
+                if size.0 > MAX_TYPE_BITS {
+                    return Err(DekuError::Parse(format!(
+                        "too much data: container of {MAX_TYPE_BITS} bits cannot hold {} bits",
+                        size.0
+                    )));
+                }
+                let bits = reader.read_bits(size.0)?;
+                let Some(bits) = bits else {
+                    return Err(DekuError::Parse(format!("no bits read from reader",)));
+                };
+                let a = <$typ>::read(&bits, (endian, size))?;
+                Ok(a.1)
             }
         }
     };
@@ -153,69 +173,65 @@ macro_rules! ImplDekuReadBits {
 macro_rules! ImplDekuReadBytes {
     ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, ByteSize)> for $typ {
+            #[inline]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, ByteSize),
-            ) -> Result<(&BitSlice<u8, Msb0>, Self), DekuError> {
-                const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
+            ) -> Result<(usize, Self), DekuError> {
                 let bit_size: usize = size.0 * 8;
 
                 let input_is_le = endian.is_le();
 
-                if bit_size > MAX_TYPE_BITS {
-                    return Err(DekuError::Parse(format!(
-                        "too much data: container of {MAX_TYPE_BITS} bits cannot hold {bit_size} bits",
-                    )));
-                }
-
-                if input.len() < bit_size {
-                    return Err(DekuError::Incomplete(crate::error::NeedSize::new(bit_size)));
-                }
-
-                let (bit_slice, rest) = input.split_at(bit_size);
-
-                let pad = 8 * ((bit_slice.len() + 7) / 8) - bit_slice.len();
+                let bit_slice = &input[..bit_size];
 
                 let bytes = bit_slice.domain().region().unwrap().1;
-                let value = if pad == 0
-                    && bit_slice.len() == MAX_TYPE_BITS
-                    && bytes.len() * 8 == MAX_TYPE_BITS
-                {
-                    // if everything is aligned, just read the value
-                    if input_is_le {
-                        <$typ>::from_le_bytes(bytes.try_into()?)
-                    } else {
-                        <$typ>::from_be_bytes(bytes.try_into()?)
-                    }
+                let value = if input_is_le {
+                    <$typ>::from_le_bytes(bytes.try_into()?)
                 } else {
-                    let mut bits: BitVec<u8, Msb0> = BitVec::with_capacity(bit_slice.len() + pad);
-
-                    // Copy bits to new BitVec
-                    bits.extend_from_bitslice(bit_slice);
-
-                    // Force align
-                    //i.e. [1110, 10010110] -> [11101001, 0110]
-                    bits.force_align();
-
-                    // cannot use from_X_bytes as we don't have enough bytes for $typ
-                    // read manually
-                    let mut res: $inner = 0;
-                    if input_is_le {
-                        for b in bytes.iter().rev() {
-                            res <<= 8 as $inner;
-                            res |= *b as $inner;
-                        }
-                    } else {
-                        for b in bytes.iter() {
-                            res <<= 8 as $inner;
-                            res |= *b as $inner;
-                        }
-                    };
-
-                    res as $typ
+                    <$typ>::from_be_bytes(bytes.try_into()?)
                 };
 
-                Ok((rest, value))
+                Ok((bit_size, value))
+            }
+        }
+
+        impl DekuReader<'_, (Endian, ByteSize)> for $typ {
+            #[inline]
+            fn from_reader_with_ctx<R: Read>(
+                reader: &mut Reader<R>,
+                (endian, size): (Endian, ByteSize),
+            ) -> Result<$typ, DekuError> {
+                const MAX_TYPE_BYTES: usize = core::mem::size_of::<$typ>();
+                if size.0 > MAX_TYPE_BYTES {
+                    return Err(DekuError::Parse(format!(
+                        "too much data: container of {MAX_TYPE_BYTES} bytes cannot hold {} bytes",
+                        size.0
+                    )));
+                }
+                let mut buf = [0; core::mem::size_of::<$typ>()];
+                let ret = reader.read_bytes(size.0, &mut buf)?;
+                let a = match ret {
+                    ReaderRet::Bits(Some(bits)) => {
+                        let a = <$typ>::read(&bits, (endian, size))?;
+                        a.1
+                    }
+                    ReaderRet::Bits(None) => {
+                        return Err(DekuError::Parse(format!("no bits read from reader")));
+                    }
+                    ReaderRet::Bytes => {
+                        if endian.is_le() {
+                            <$typ>::from_le_bytes(buf.try_into().unwrap())
+                        } else {
+                            if size.0 != core::mem::size_of::<$typ>() {
+                                let padding = core::mem::size_of::<$typ>() - size.0;
+                                buf.copy_within(0..size.0, padding);
+                                buf[..padding].fill(0x00);
+                            }
+                            <$typ>::from_be_bytes(buf.try_into().unwrap())
+                        }
+                    }
+                };
+                Ok(a)
             }
         }
     };
@@ -224,92 +240,151 @@ macro_rules! ImplDekuReadBytes {
 macro_rules! ImplDekuReadSignExtend {
     ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, ByteSize)> for $typ {
+            #[inline]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, ByteSize),
-            ) -> Result<(&BitSlice<u8, Msb0>, Self), DekuError> {
-                let (rest, value) =
+            ) -> Result<(usize, Self), DekuError> {
+                let (amt_read, value) =
                     <$inner as DekuRead<'_, (Endian, ByteSize)>>::read(input, (endian, size))?;
 
                 const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 let bit_size = size.0 * 8;
                 let shift = MAX_TYPE_BITS - bit_size;
                 let value = (value as $typ) << shift >> shift;
-                Ok((rest, value))
+                Ok((amt_read, value))
             }
         }
+
+        impl DekuReader<'_, (Endian, ByteSize)> for $typ {
+            #[inline]
+            fn from_reader_with_ctx<R: Read>(
+                reader: &mut Reader<R>,
+                (endian, size): (Endian, ByteSize),
+            ) -> Result<$typ, DekuError> {
+                let mut buf = [0; core::mem::size_of::<$typ>()];
+                let ret = reader.read_bytes(size.0, &mut buf)?;
+                let a = match ret {
+                    ReaderRet::Bits(bits) => {
+                        let Some(bits) = bits else {
+                            return Err(DekuError::Parse("no bits read from reader".to_string()));
+                        };
+                        let a = <$typ>::read(&bits, (endian, size))?;
+                        a.1
+                    }
+                    ReaderRet::Bytes => {
+                        if endian.is_le() {
+                            <$typ>::from_le_bytes(buf.try_into()?)
+                        } else {
+                            <$typ>::from_be_bytes(buf.try_into()?)
+                        }
+                    }
+                };
+
+                const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
+                let bit_size = size.0 * 8;
+                let shift = MAX_TYPE_BITS - bit_size;
+                let value = (a as $typ) << shift >> shift;
+                Ok(value)
+            }
+        }
+
         impl DekuRead<'_, (Endian, BitSize)> for $typ {
+            #[inline]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, BitSize),
-            ) -> Result<(&BitSlice<u8, Msb0>, Self), DekuError> {
-                let (rest, value) =
+            ) -> Result<(usize, Self), DekuError> {
+                let (amt_read, value) =
                     <$inner as DekuRead<'_, (Endian, BitSize)>>::read(input, (endian, size))?;
 
                 const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 let bit_size = size.0;
                 let shift = MAX_TYPE_BITS - bit_size;
                 let value = (value as $typ) << shift >> shift;
-                Ok((rest, value))
+                Ok((amt_read, value))
+            }
+        }
+
+        impl DekuReader<'_, (Endian, BitSize)> for $typ {
+            #[inline]
+            fn from_reader_with_ctx<R: Read>(
+                reader: &mut Reader<R>,
+                (endian, size): (Endian, BitSize),
+            ) -> Result<$typ, DekuError> {
+                const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
+                if size.0 > MAX_TYPE_BITS {
+                    return Err(DekuError::Parse(format!(
+                        "too much data: container of {MAX_TYPE_BITS} bits cannot hold {} bits",
+                        size.0
+                    )));
+                }
+                let bits = reader.read_bits(size.0)?;
+                let Some(bits) = bits else {
+                    return Err(DekuError::Parse(format!("no bits read from reader",)));
+                };
+                let a = <$typ>::read(&bits, (endian, size))?;
+                Ok(a.1)
             }
         }
     };
 }
 
+// TODO: these forward types should forward on a ContainerCanHoldSize or something if ByteSize or
+// BitSize wasn't defined
 macro_rules! ForwardDekuRead {
     ($typ:ty) => {
         // Only have `endian`, set `bit_size` to `Size::of::<Type>()`
-        impl DekuRead<'_, Endian> for $typ {
-            fn read(
-                input: &BitSlice<u8, Msb0>,
+        impl DekuReader<'_, Endian> for $typ {
+            #[inline]
+            fn from_reader_with_ctx<R: Read>(
+                reader: &mut Reader<R>,
                 endian: Endian,
-            ) -> Result<(&BitSlice<u8, Msb0>, Self), DekuError> {
-                let bit_size = BitSize::of::<$typ>();
+            ) -> Result<$typ, DekuError> {
+                let byte_size = core::mem::size_of::<$typ>();
 
-                // Since we don't have a #[bits] or [bytes], check if we can use bytes for perf
-                if (bit_size.0 % 8) == 0 {
-                    <$typ>::read(input, (endian, ByteSize(bit_size.0 / 8)))
-                } else {
-                    <$typ>::read(input, (endian, bit_size))
-                }
+                <$typ>::from_reader_with_ctx(reader, (endian, ByteSize(byte_size)))
             }
         }
 
-        // Only have `bit_size`, set `endian` to `Endian::default`.
-        impl DekuRead<'_, ByteSize> for $typ {
-            fn read(
-                input: &BitSlice<u8, Msb0>,
+        // Only have `byte_size`, set `endian` to `Endian::default`.
+        impl DekuReader<'_, ByteSize> for $typ {
+            #[inline]
+            fn from_reader_with_ctx<R: Read>(
+                reader: &mut Reader<R>,
                 byte_size: ByteSize,
-            ) -> Result<(&BitSlice<u8, Msb0>, Self), DekuError> {
+            ) -> Result<$typ, DekuError> {
                 let endian = Endian::default();
 
-                <$typ>::read(input, (endian, byte_size))
+                let a = <$typ>::from_reader_with_ctx(reader, (endian, byte_size))?;
+                Ok(a)
             }
         }
 
-        // Only have `bit_size`, set `endian` to `Endian::default`.
-        impl DekuRead<'_, BitSize> for $typ {
-            fn read(
-                input: &BitSlice<u8, Msb0>,
+        //// Only have `bit_size`, set `endian` to `Endian::default`.
+        impl DekuReader<'_, BitSize> for $typ {
+            #[inline]
+            fn from_reader_with_ctx<R: Read>(
+                reader: &mut Reader<R>,
                 bit_size: BitSize,
-            ) -> Result<(&BitSlice<u8, Msb0>, Self), DekuError> {
+            ) -> Result<$typ, DekuError> {
                 let endian = Endian::default();
 
-                // check if we can use ByteSize for performance
                 if (bit_size.0 % 8) == 0 {
-                    <$typ>::read(input, (endian, ByteSize(bit_size.0 / 8)))
+                    <$typ>::from_reader_with_ctx(reader, (endian, ByteSize(bit_size.0 / 8)))
                 } else {
-                    <$typ>::read(input, (endian, bit_size))
+                    <$typ>::from_reader_with_ctx(reader, (endian, bit_size))
                 }
             }
         }
 
-        impl DekuRead<'_> for $typ {
-            fn read(
-                input: &BitSlice<u8, Msb0>,
+        impl DekuReader<'_> for $typ {
+            #[inline]
+            fn from_reader_with_ctx<R: Read>(
+                reader: &mut Reader<R>,
                 _: (),
-            ) -> Result<(&BitSlice<u8, Msb0>, Self), DekuError> {
-                <$typ>::read(input, Endian::default())
+            ) -> Result<$typ, DekuError> {
+                <$typ>::from_reader_with_ctx(reader, Endian::default())
             }
         }
     };
@@ -318,6 +393,7 @@ macro_rules! ForwardDekuRead {
 macro_rules! ImplDekuWrite {
     ($typ:ty) => {
         impl DekuWrite<(Endian, BitSize)> for $typ {
+            #[inline]
             fn write(
                 &self,
                 output: &mut BitVec<u8, Msb0>,
@@ -363,6 +439,7 @@ macro_rules! ImplDekuWrite {
         }
 
         impl DekuWrite<(Endian, ByteSize)> for $typ {
+            #[inline]
             fn write(
                 &self,
                 output: &mut BitVec<u8, Msb0>,
@@ -409,6 +486,7 @@ macro_rules! ImplDekuWrite {
 
         // Only have `endian`, return all input
         impl DekuWrite<Endian> for $typ {
+            #[inline]
             fn write(
                 &self,
                 output: &mut BitVec<u8, Msb0>,
@@ -429,6 +507,7 @@ macro_rules! ForwardDekuWrite {
     ($typ:ty) => {
         // Only have `bit_size`, set `endian` to `Endian::default`.
         impl DekuWrite<BitSize> for $typ {
+            #[inline]
             fn write(
                 &self,
                 output: &mut BitVec<u8, Msb0>,
@@ -440,6 +519,7 @@ macro_rules! ForwardDekuWrite {
 
         // Only have `bit_size`, set `endian` to `Endian::default`.
         impl DekuWrite<ByteSize> for $typ {
+            #[inline]
             fn write(
                 &self,
                 output: &mut BitVec<u8, Msb0>,
@@ -450,6 +530,7 @@ macro_rules! ForwardDekuWrite {
         }
 
         impl DekuWrite for $typ {
+            #[inline]
             fn write(&self, output: &mut BitVec<u8, Msb0>, _: ()) -> Result<(), DekuError> {
                 <$typ>::write(self, output, Endian::default())
             }
@@ -518,9 +599,10 @@ ImplDekuTraitsBytes!(f64, u64);
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::native_endian;
     use rstest::rstest;
+
+    use super::*;
+    use crate::{native_endian, reader::Reader};
 
     static ENDIAN: Endian = Endian::new();
 
@@ -528,130 +610,185 @@ mod tests {
         ($test_name:ident, $typ:ty, $input:expr, $expected:expr) => {
             #[test]
             fn $test_name() {
-                let input = $input;
-                let bit_slice = input.view_bits::<Msb0>();
-                let (_rest, res_read) = <$typ>::read(bit_slice, ENDIAN).unwrap();
+                let mut r = std::io::Cursor::new($input);
+                let mut reader = Reader::new(&mut r);
+                let res_read = <$typ>::from_reader_with_ctx(&mut reader, ENDIAN).unwrap();
                 assert_eq!($expected, res_read);
 
                 let mut res_write = bitvec![u8, Msb0;];
                 res_read.write(&mut res_write, ENDIAN).unwrap();
-                assert_eq!(input, res_write.into_vec());
+                assert_eq!($input, res_write.into_vec());
             }
         };
     }
 
-    TestPrimitive!(test_u8, u8, vec![0xAAu8], 0xAAu8);
+    TestPrimitive!(test_u8, u8, vec![0xaau8], 0xaau8);
     TestPrimitive!(
         test_u16,
         u16,
-        vec![0xABu8, 0xCD],
-        native_endian!(0xCDAB_u16)
+        vec![0xabu8, 0xcd],
+        native_endian!(0xcdab_u16)
     );
     TestPrimitive!(
         test_u32,
         u32,
-        vec![0xABu8, 0xCD, 0xEF, 0xBE],
-        native_endian!(0xBEEFCDAB_u32)
+        vec![0xabu8, 0xcd, 0xef, 0xbe],
+        native_endian!(0xbeefcdab_u32)
     );
     TestPrimitive!(
         test_u64,
         u64,
-        vec![0xABu8, 0xCD, 0xEF, 0xBE, 0xAB, 0xCD, 0xFE, 0xC0],
-        native_endian!(0xC0FECDABBEEFCDAB_u64)
+        vec![0xabu8, 0xcd, 0xef, 0xbe, 0xab, 0xcd, 0xfe, 0xc0],
+        native_endian!(0xc0fecdabbeefcdab_u64)
     );
     TestPrimitive!(
         test_u128,
         u128,
         vec![
-            0xABu8, 0xCD, 0xEF, 0xBE, 0xAB, 0xCD, 0xFE, 0xC0, 0xAB, 0xCD, 0xEF, 0xBE, 0xAB, 0xCD,
-            0xFE, 0xC0
+            0xabu8, 0xcd, 0xef, 0xbe, 0xab, 0xcd, 0xfe, 0xc0, 0xab, 0xcd, 0xef, 0xbe, 0xab, 0xcd,
+            0xfe, 0xc0
         ],
-        native_endian!(0xC0FECDABBEEFCDABC0FECDABBEEFCDAB_u128)
+        native_endian!(0xc0fecdabbeefcdabc0fecdabbeefcdab_u128)
     );
     TestPrimitive!(
         test_usize,
         usize,
-        vec![0xABu8, 0xCD, 0xEF, 0xBE, 0xAB, 0xCD, 0xFE, 0xC0],
+        vec![0xabu8, 0xcd, 0xef, 0xbe, 0xab, 0xcd, 0xfe, 0xc0],
         if core::mem::size_of::<usize>() == 8 {
-            native_endian!(0xC0FECDABBEEFCDAB_usize)
+            native_endian!(0xc0fecdabbeefcdab_usize)
         } else {
-            native_endian!(0xBEEFCDAB_usize)
+            native_endian!(0xbeefcdab_usize)
         }
     );
-    TestPrimitive!(test_i8, i8, vec![0xFBu8], -5);
-    TestPrimitive!(test_i16, i16, vec![0xFDu8, 0xFE], native_endian!(-259_i16));
+    TestPrimitive!(test_i8, i8, vec![0xfbu8], -5);
+    TestPrimitive!(test_i16, i16, vec![0xfdu8, 0xfe], native_endian!(-259_i16));
     TestPrimitive!(
         test_i32,
         i32,
-        vec![0x02u8, 0x3F, 0x01, 0xEF],
-        native_endian!(-0x10FEC0FE_i32)
+        vec![0x02u8, 0x3f, 0x01, 0xef],
+        native_endian!(-0x10fec0fe_i32)
     );
     TestPrimitive!(
         test_i64,
         i64,
-        vec![0x02u8, 0x3F, 0x01, 0xEF, 0x01, 0x3F, 0x01, 0xEF],
-        native_endian!(-0x10FEC0FE10FEC0FE_i64)
+        vec![0x02u8, 0x3f, 0x01, 0xef, 0x01, 0x3f, 0x01, 0xef],
+        native_endian!(-0x10fec0fe10fec0fe_i64)
     );
     TestPrimitive!(
         test_i128,
         i128,
         vec![
-            0x02u8, 0x3F, 0x01, 0xEF, 0x01, 0x3F, 0x01, 0xEF, 0x01, 0x3F, 0x01, 0xEF, 0x01, 0x3F,
-            0x01, 0xEF
+            0x02u8, 0x3f, 0x01, 0xef, 0x01, 0x3f, 0x01, 0xef, 0x01, 0x3f, 0x01, 0xef, 0x01, 0x3f,
+            0x01, 0xef
         ],
-        native_endian!(-0x10FEC0FE10FEC0FE10FEC0FE10FEC0FE_i128)
+        native_endian!(-0x10fec0fe10fec0fe10fec0fe10fec0fe_i128)
     );
     TestPrimitive!(
         test_isize,
         isize,
-        vec![0x02u8, 0x3F, 0x01, 0xEF, 0x01, 0x3F, 0x01, 0xEF],
+        vec![0x02u8, 0x3f, 0x01, 0xef, 0x01, 0x3f, 0x01, 0xef],
         if core::mem::size_of::<isize>() == 8 {
-            native_endian!(-0x10FEC0FE10FEC0FE_isize)
+            native_endian!(-0x10fec0fe10fec0fe_isize)
         } else {
-            native_endian!(-0x10FEC0FE_isize)
+            native_endian!(-0x10fec0fe_isize)
         }
     );
     TestPrimitive!(
         test_f32,
         f32,
-        vec![0xA6u8, 0x9B, 0xC4, 0xBB],
+        vec![0xa6u8, 0x9b, 0xc4, 0xbb],
         native_endian!(-0.006_f32)
     );
     TestPrimitive!(
         test_f64,
         f64,
-        vec![0xFAu8, 0x7E, 0x6A, 0xBC, 0x74, 0x93, 0x78, 0xBF],
+        vec![0xfau8, 0x7e, 0x6a, 0xbc, 0x74, 0x93, 0x78, 0xbf],
         native_endian!(-0.006_f64)
     );
 
-    #[rstest(input, endian, bit_size, expected, expected_rest,
-        case::normal([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, Some(32), 0xAABB_CCDD, bits![u8, Msb0;]),
-        case::normal_bits_12_le([0b1001_0110, 0b1110_0000, 0xCC, 0xDD ].as_ref(), Endian::Little, Some(12), 0b1110_1001_0110, bits![u8, Msb0; 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1]),
-        case::normal_bits_12_be([0b1001_0110, 0b1110_0000, 0xCC, 0xDD ].as_ref(), Endian::Big, Some(12), 0b1001_0110_1110, bits![u8, Msb0; 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1]),
-        case::normal_bit_6([0b1001_0110].as_ref(), Endian::Little, Some(6), 0b1001_01, bits![u8, Msb0; 1, 0,]),
+    #[rstest(input, endian, bit_size, expected, expected_rest_bits, expected_rest_bytes,
+        case::normal([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, Some(32), 0xAABB_CCDD, bits![u8, Msb0;], &[]),
+        case::normal([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Big, Some(32), 0xDDCC_BBAA, bits![u8, Msb0;], &[]),
+        case::normal_bits_12_le([0b1001_0110, 0b1110_0000, 0xCC, 0xDD ].as_ref(), Endian::Little, Some(12), 0b1110_1001_0110, bits![u8, Msb0; 0, 0, 0, 0], &[0xcc, 0xdd]),
+        case::normal_bits_12_be([0b1001_0110, 0b1110_0000, 0xCC, 0xDD ].as_ref(), Endian::Big, Some(12), 0b1001_0110_1110, bits![u8, Msb0; 0, 0, 0, 0], &[0xcc, 0xdd]),
+        case::normal_bit_6([0b1001_0110].as_ref(), Endian::Little, Some(6), 0b1001_01, bits![u8, Msb0; 1, 0,], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 32 })")]
-        case::not_enough_data([].as_ref(), Endian::Little, Some(32), 0xFF, bits![u8, Msb0;]),
+        case::not_enough_data([].as_ref(), Endian::Little, Some(32), 0xFF, bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 32 })")]
-        case::not_enough_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(32), 0xFF, bits![u8, Msb0;]),
-        #[should_panic(expected = "Parse(\"too much data: container of 32 bits cannot hold 64 bits\")")]
-        case::too_much_data([0xAA, 0xBB, 0xCC, 0xDD, 0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(64), 0xFF, bits![u8, Msb0;]),
+        case::not_enough_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(32), 0xFF, bits![u8, Msb0;], &[]),
+        #[should_panic(expected = "Parse(\"too much data: container of 32 bits cannot hold 64 bits\")")] // This will end up in ByteSize b/c 64 % 8 == 0
+        case::too_much_data([0xAA, 0xBB, 0xCC, 0xDD, 0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(64), 0xFF, bits![u8, Msb0;], &[]),
+        #[should_panic(expected = "Parse(\"too much data: container of 32 bits cannot hold 63 bits\")")] // This will end up staying BitSize
+        case::too_much_data([0xAA, 0xBB, 0xCC, 0xDD, 0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(63), 0xFF, bits![u8, Msb0;], &[]),
     )]
     fn test_bit_read(
-        input: &[u8],
+        mut input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         expected: u32,
-        expected_rest: &BitSlice<u8, Msb0>,
+        expected_rest_bits: &BitSlice<u8, Msb0>,
+        expected_rest_bytes: &[u8],
     ) {
-        let bit_slice = input.view_bits::<Msb0>();
-
-        let (rest, res_read) = match bit_size {
-            Some(bit_size) => u32::read(bit_slice, (endian, BitSize(bit_size))).unwrap(),
-            None => u32::read(bit_slice, endian).unwrap(),
+        // test both Read &[u8] and Read BitVec
+        let mut reader = Reader::new(&mut input);
+        let res_read = match bit_size {
+            Some(bit_size) => {
+                u32::from_reader_with_ctx(&mut reader, (endian, BitSize(bit_size))).unwrap()
+            }
+            None => u32::from_reader_with_ctx(&mut reader, endian).unwrap(),
         };
-
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
+        assert_eq!(
+            reader.rest(),
+            expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
+        );
+        let mut buf = vec![];
+        input.read_to_end(&mut buf).unwrap();
+        assert_eq!(expected_rest_bytes, buf);
+    }
+
+    #[rstest(input, endian, byte_size, expected, expected_rest_bytes,
+        case::normal_be([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Big, Some(4), 0xDDCC_BBAA, &[]),
+        case::normal_le([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, Some(4), 0xAABB_CCDD, &[]),
+        case::normal_be([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Big, Some(3), 0x00DDCC_BB, &[0xaa]),
+        case::normal_be([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, Some(3), 0x00BB_CCDD, &[0xaa]),
+        #[should_panic(expected = "Incomplete(NeedSize { bits: 32 })")]
+        case::not_enough_data([].as_ref(), Endian::Little, Some(4), 0xFF, &[]),
+        #[should_panic(expected = "Incomplete(NeedSize { bits: 32 })")]
+        case::not_enough_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(4), 0xFF, &[]),
+        #[should_panic(expected = "Parse(\"too much data: container of 4 bytes cannot hold 8 bytes\")")]
+        case::too_much_data([0xAA, 0xBB, 0xCC, 0xDD, 0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(8), 0xFF, &[]),
+    )]
+    fn test_byte_read(
+        mut input: &[u8],
+        endian: Endian,
+        byte_size: Option<usize>,
+        expected: u32,
+        expected_rest_bytes: &[u8],
+    ) {
+        let mut bit_slice = input.view_bits::<Msb0>();
+
+        // test both Read &[u8] and Read BitVec
+        let mut reader = Reader::new(&mut input);
+        let res_read = match byte_size {
+            Some(byte_size) => {
+                u32::from_reader_with_ctx(&mut reader, (endian, ByteSize(byte_size))).unwrap()
+            }
+            None => u32::from_reader_with_ctx(&mut reader, endian).unwrap(),
+        };
+        assert_eq!(expected, res_read);
+
+        let mut reader = Reader::new(&mut bit_slice);
+        let res_read = match byte_size {
+            Some(byte_size) => {
+                u32::from_reader_with_ctx(&mut reader, (endian, ByteSize(byte_size))).unwrap()
+            }
+            None => u32::from_reader_with_ctx(&mut reader, endian).unwrap(),
+        };
+        assert_eq!(expected, res_read);
+        let mut buf = vec![];
+        input.read_to_end(&mut buf).unwrap();
+        assert_eq!(expected_rest_bytes, buf);
     }
 
     #[rstest(input, endian, bit_size, expected,
@@ -673,25 +810,26 @@ mod tests {
         assert_eq!(expected, res_write.into_vec());
     }
 
-    #[rstest(input, endian, bit_size, expected, expected_rest, expected_write,
-        case::normal([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, Some(32), 0xAABB_CCDD, bits![u8, Msb0;], vec![0xDD, 0xCC, 0xBB, 0xAA]),
+    #[rstest(input, endian, bit_size, expected, expected_write,
+        case::normal([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, Some(32), 0xAABB_CCDD, vec![0xDD, 0xCC, 0xBB, 0xAA]),
     )]
     fn test_bit_read_write(
         input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         expected: u32,
-        expected_rest: &BitSlice<u8, Msb0>,
         expected_write: Vec<u8>,
     ) {
-        let bit_slice = input.view_bits::<Msb0>();
+        let mut bit_slice = input.view_bits::<Msb0>();
 
-        let (rest, res_read) = match bit_size {
-            Some(bit_size) => u32::read(bit_slice, (endian, BitSize(bit_size))).unwrap(),
-            None => u32::read(bit_slice, endian).unwrap(),
+        let mut reader = Reader::new(&mut bit_slice);
+        let res_read = match bit_size {
+            Some(bit_size) => {
+                u32::from_reader_with_ctx(&mut reader, (endian, BitSize(bit_size))).unwrap()
+            }
+            None => u32::from_reader_with_ctx(&mut reader, endian).unwrap(),
         };
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
 
         let mut res_write = bitvec![u8, Msb0;];
         match bit_size {
@@ -708,12 +846,12 @@ mod tests {
         ($test_name:ident, $typ:ty) => {
             #[test]
             fn $test_name() {
-                let bit_slice = [0b10101_000].view_bits::<Msb0>();
-
-                let (rest, res_read) = <$typ>::read(bit_slice, (Endian::Little, BitSize(5))).unwrap();
-
+                let mut slice = [0b10101_000].as_slice();
+                let mut reader = Reader::new(&mut slice);
+                let res_read =
+                    <$typ>::from_reader_with_ctx(&mut reader, (Endian::Little, BitSize(5)))
+                        .unwrap();
                 assert_eq!(-11, res_read);
-                assert_eq!(bits![u8, Msb0; 0, 0, 0], rest);
             }
         };
     }
@@ -724,4 +862,30 @@ mod tests {
     TestSignExtending!(test_sign_extend_i64, i64);
     TestSignExtending!(test_sign_extend_i128, i128);
     TestSignExtending!(test_sign_extend_isize, isize);
+
+    macro_rules! TestSignExtendingPanic {
+        ($test_name:ident, $typ:ty, $size:expr) => {
+            #[test]
+            fn $test_name() {
+                let mut slice = [0b10101_000].as_slice();
+                let mut reader = Reader::new(&mut slice);
+                let res_read =
+                    <$typ>::from_reader_with_ctx(&mut reader, (Endian::Little, BitSize($size + 1)));
+                assert_eq!(
+                    DekuError::Parse(format!(
+                        "too much data: container of {} bits cannot hold {} bits",
+                        $size,
+                        $size + 1
+                    )),
+                    res_read.err().unwrap()
+                );
+            }
+        };
+    }
+
+    TestSignExtendingPanic!(test_sign_extend_i8_panic, i8, 8);
+    TestSignExtendingPanic!(test_sign_extend_i16_panic, i16, 16);
+    TestSignExtendingPanic!(test_sign_extend_i32_panic, i32, 32);
+    TestSignExtendingPanic!(test_sign_extend_i64_panic, i64, 64);
+    TestSignExtendingPanic!(test_sign_extend_i128_panic, i128, 128);
 }

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -1,281 +1,93 @@
 //! Implementations of DekuRead and DekuWrite for [T; N] where 0 < N <= 32
 
-use crate::{ctx::Limit, DekuError, DekuRead, DekuWrite};
+use crate::{DekuError, DekuWrite};
 use bitvec::prelude::*;
-pub use deku_derive::*;
+use core::mem::MaybeUninit;
+use no_std_io::io::Read;
 
-/// Read `u8`s and returns a byte slice up until a given predicate returns true
-/// * `ctx` - The context required by `u8`. It will be passed to every `u8` when constructing.
-/// * `predicate` - the predicate that decides when to stop reading `u8`s
-/// The predicate takes two parameters: the number of bits that have been read so far,
-/// and a borrow of the latest value to have been read. It should return `true` if reading
-/// should now stop, and `false` otherwise
-fn read_slice_with_predicate<'a, Ctx: Copy, Predicate: FnMut(usize, &u8) -> bool>(
-    input: &'a BitSlice<u8, Msb0>,
-    ctx: Ctx,
-    mut predicate: Predicate,
-) -> Result<(&'a BitSlice<u8, Msb0>, &[u8]), DekuError>
+use crate::DekuReader;
+
+impl<'a, Ctx: Copy, T, const N: usize> DekuReader<'a, Ctx> for [T; N]
 where
-    u8: DekuRead<'a, Ctx>,
+    T: DekuReader<'a, Ctx>,
 {
-    let mut rest = input;
-    let mut value;
-
-    loop {
-        let (new_rest, val) = u8::read(rest, ctx)?;
-        rest = new_rest;
-
-        let read_idx = unsafe { rest.as_bitptr().offset_from(input.as_bitptr()) } as usize;
-        value = input[..read_idx].domain().region().unwrap().1;
-
-        if predicate(read_idx, &val) {
-            break;
-        }
-    }
-
-    Ok((rest, value))
-}
-
-impl<'a, Ctx: Copy, Predicate: FnMut(&u8) -> bool> DekuRead<'a, (Limit<u8, Predicate>, Ctx)>
-    for &'a [u8]
-where
-    u8: DekuRead<'a, Ctx>,
-{
-    /// Read `u8`s until the given limit
-    /// * `limit` - the limiting factor on the amount of `u8`s to read
-    /// * `inner_ctx` - The context required by `u8`. It will be passed to every `u8`s when constructing.
-    /// # Examples
-    /// ```rust
-    /// # use deku::ctx::*;
-    /// # use deku::DekuRead;
-    /// # use bitvec::view::BitView;
-    /// let input = vec![1u8, 2, 3, 4];
-    /// let (rest, v) = <&[u8]>::read(input.view_bits(), (4.into(), Endian::Little)).unwrap();
-    /// assert!(rest.is_empty());
-    /// assert_eq!(&[1u8, 2, 3, 4], v)
-    /// ```
-    fn read(
-        input: &'a BitSlice<u8, Msb0>,
-        (limit, inner_ctx): (Limit<u8, Predicate>, Ctx),
-    ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError> {
-        match limit {
-            // Read a given count of elements
-            Limit::Count(mut count) => {
-                // Handle the trivial case of reading an empty slice
-                if count == 0 {
-                    return Ok((input, &input.domain().region().unwrap().1[..0]));
-                }
-
-                // Otherwise, read until we have read `count` elements
-                read_slice_with_predicate(input, inner_ctx, move |_, _| {
-                    count -= 1;
-                    count == 0
-                })
-            }
-
-            // Read until a given predicate returns true
-            Limit::Until(mut predicate, _) => {
-                read_slice_with_predicate(input, inner_ctx, move |_, value| predicate(value))
-            }
-
-            // Read until a given quantity of bits have been read
-            Limit::BitSize(size) => {
-                let bit_size = size.0;
-
-                // Handle the trivial case of reading an empty vector
-                if bit_size == 0 {
-                    return Ok((input, &input.domain().region().unwrap().1[..0]));
-                }
-
-                read_slice_with_predicate(input, inner_ctx, move |read_bits, _| {
-                    read_bits == bit_size
-                })
-            }
-
-            // Read until a given quantity of bytes have been read
-            Limit::ByteSize(size) => {
-                let bit_size = size.0 * 8;
-
-                // Handle the trivial case of reading an empty vector
-                if bit_size == 0 {
-                    return Ok((input, &input.domain().region().unwrap().1[..0]));
-                }
-
-                read_slice_with_predicate(input, inner_ctx, move |read_bits, _| {
-                    read_bits == bit_size
-                })
-            }
-        }
-    }
-}
-
-#[cfg(not(feature = "const_generics"))]
-mod pre_const_generics_impl {
-    use super::*;
-
-    macro_rules! ImplDekuSliceTraits {
-        ($typ:ty; $($count:expr),+ $(,)?) => {
-
-            impl<Ctx: Copy> DekuWrite<Ctx> for &[$typ]
-            where
-                $typ: DekuWrite<Ctx>,
-            {
-                fn write(&self, output: &mut BitVec<u8, Msb0>, ctx: Ctx) -> Result<(), DekuError> {
-                    for v in *self {
-                        v.write(output, ctx)?;
-                    }
-                    Ok(())
-                }
-            }
-
-            $(
-                impl<'a, Ctx: Copy> DekuRead<'a, Ctx> for [$typ; $count]
-                where
-                    $typ: DekuRead<'a, Ctx>,
-                {
-                    fn read(
-                        input: &'a BitSlice<u8, Msb0>,
-                        ctx: Ctx,
-                    ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError>
-                    where
-                        Self: Sized,
-                    {
-                        let mut slice: [$typ; $count] = Default::default();
-                        let mut rest = input;
-                        for i in 0..$count {
-                            let (new_rest, value) = <$typ>::read(rest, ctx)?;
-                            slice[i] = value;
-                            rest = new_rest;
+    fn from_reader_with_ctx<R: Read>(
+        reader: &mut crate::reader::Reader<R>,
+        ctx: Ctx,
+    ) -> Result<Self, DekuError>
+    where
+        Self: Sized,
+    {
+        #[allow(clippy::uninit_assumed_init)]
+        // This is safe because we initialize the array immediately after,
+        // and never return it in case of error
+        let mut slice: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+        for (n, item) in slice.iter_mut().enumerate() {
+            let value = match T::from_reader_with_ctx(reader, ctx) {
+                Ok(it) => it,
+                Err(err) => {
+                    // For each item in the array, drop if we allocated it.
+                    for item in &mut slice[0..n] {
+                        unsafe {
+                            item.assume_init_drop();
                         }
-
-                        Ok((rest, slice))
                     }
+                    return Err(err);
                 }
+            };
+            item.write(value);
+        }
 
-                impl<Ctx: Copy> DekuWrite<Ctx> for [$typ; $count]
-                where
-                    $typ: DekuWrite<Ctx>,
-                {
-                    fn write(&self, output: &mut BitVec<u8, Msb0>, ctx: Ctx) -> Result<(), DekuError> {
-                        for v in self {
-                            v.write(output, ctx)?;
-                        }
-                        Ok(())
-                    }
-                }
-            )+
+        let val = unsafe {
+            // TODO: array_assume_init: https://github.com/rust-lang/rust/issues/80908
+            (core::ptr::addr_of!(slice) as *const [T; N]).read()
         };
+        Ok(val)
     }
-
-    ImplDekuSliceTraits!(i8; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(i16; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(i32; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(i64; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(i128; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(isize; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(u8; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(u16; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(u32; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(u64; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(u128; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(usize; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(f32; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-    ImplDekuSliceTraits!(f64; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
 }
 
-#[cfg(feature = "const_generics")]
-mod const_generics_impl {
-    use super::*;
-
-    use core::mem::MaybeUninit;
-
-    impl<'a, Ctx: Copy, T, const N: usize> DekuRead<'a, Ctx> for [T; N]
-    where
-        T: DekuRead<'a, Ctx>,
-    {
-        fn read(
-            input: &'a BitSlice<u8, Msb0>,
-            ctx: Ctx,
-        ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError>
-        where
-            Self: Sized,
-        {
-            #[allow(clippy::uninit_assumed_init)]
-            // This is safe because we initialize the array immediately after,
-            // and never return it in case of error
-            let mut slice: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
-            let mut rest = input;
-            for (n, item) in slice.iter_mut().enumerate() {
-                let (new_rest, value) = match T::read(rest, ctx) {
-                    Ok(it) => it,
-                    Err(err) => {
-                        // For each item in the array, drop if we allocated it.
-                        for item in &mut slice[0..n] {
-                            unsafe {
-                                item.assume_init_drop();
-                            }
-                        }
-                        return Err(err);
-                    }
-                };
-                item.write(value);
-                rest = new_rest;
-            }
-
-            Ok((rest, unsafe {
-                // TODO: array_assume_init: https://github.com/rust-lang/rust/issues/80908
-                (&slice as *const _ as *const [T; N]).read()
-            }))
+impl<Ctx: Copy, T, const N: usize> DekuWrite<Ctx> for [T; N]
+where
+    T: DekuWrite<Ctx>,
+{
+    fn write(&self, output: &mut BitVec<u8, Msb0>, ctx: Ctx) -> Result<(), DekuError> {
+        for v in self {
+            v.write(output, ctx)?;
         }
+        Ok(())
     }
+}
 
-    impl<Ctx: Copy, T, const N: usize> DekuWrite<Ctx> for [T; N]
-    where
-        T: DekuWrite<Ctx>,
-    {
-        fn write(&self, output: &mut BitVec<u8, Msb0>, ctx: Ctx) -> Result<(), DekuError> {
-            for v in self {
-                v.write(output, ctx)?;
-            }
-            Ok(())
+impl<Ctx: Copy, T> DekuWrite<Ctx> for &[T]
+where
+    T: DekuWrite<Ctx>,
+{
+    fn write(&self, output: &mut BitVec<u8, Msb0>, ctx: Ctx) -> Result<(), DekuError> {
+        for v in *self {
+            v.write(output, ctx)?;
         }
-    }
-
-    impl<Ctx: Copy, T> DekuWrite<Ctx> for &[T]
-    where
-        T: DekuWrite<Ctx>,
-    {
-        fn write(&self, output: &mut BitVec<u8, Msb0>, ctx: Ctx) -> Result<(), DekuError> {
-            for v in *self {
-                v.write(output, ctx)?;
-            }
-            Ok(())
-        }
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use crate::ctx::Endian;
+    use crate::DekuWrite;
+    use bitvec::prelude::*;
     use rstest::rstest;
 
-    #[rstest(input,endian,expected,expected_rest,
-        case::normal_le([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, [0xCCDD, 0xAABB], bits![u8, Msb0;]),
-        case::normal_be([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Big, [0xDDCC, 0xBBAA], bits![u8, Msb0;]),
-    )]
-    fn test_bit_read(
-        input: &[u8],
-        endian: Endian,
-        expected: [u16; 2],
-        expected_rest: &BitSlice<u8, Msb0>,
-    ) {
-        let bit_slice = input.view_bits::<Msb0>();
+    use crate::{ctx::Endian, reader::Reader, DekuReader};
 
-        let (rest, res_read) = <[u16; 2]>::read(bit_slice, endian).unwrap();
+    #[rstest(input,endian,expected,
+        case::normal_le([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, [0xCCDD, 0xAABB]),
+        case::normal_be([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Big, [0xDDCC, 0xBBAA]),
+    )]
+    fn test_bit_read(input: &[u8], endian: Endian, expected: [u16; 2]) {
+        let mut bit_slice = input.view_bits::<Msb0>();
+
+        let mut reader = Reader::new(&mut bit_slice);
+        let res_read = <[u16; 2]>::from_reader_with_ctx(&mut reader, endian).unwrap();
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
     }
 
     #[rstest(input,endian,expected,
@@ -315,11 +127,16 @@ mod tests {
         expected: [[u16; 2]; 2],
         expected_rest: &BitSlice<u8, Msb0>,
     ) {
+        use no_std_io::io::Cursor;
+
+        use crate::reader::Reader;
+
         let bit_slice = input.view_bits::<Msb0>();
 
-        let (rest, res_read) = <[[u16; 2]; 2]>::read(bit_slice, endian).unwrap();
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        let res_read = <[[u16; 2]; 2]>::from_reader_with_ctx(&mut reader, endian).unwrap();
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
     }
 
     #[cfg(feature = "const_generics")]

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -1,7 +1,9 @@
 //! Implementations of DekuRead and DekuWrite for tuples of length 1 to 11
 
-use crate::{DekuError, DekuRead, DekuWrite};
 use bitvec::prelude::*;
+use no_std_io::io::Read;
+
+use crate::{DekuError, DekuReader, DekuWrite};
 
 // Trait to help us build intermediate tuples while DekuRead'ing each element
 // from the tuple
@@ -34,23 +36,21 @@ macro_rules! ImplDekuTupleTraits {
             }
         }
 
-        impl<'a, Ctx: Copy, $($T:DekuRead<'a, Ctx>+Sized),+> DekuRead<'a, Ctx> for ($($T,)+)
+        impl<'a, Ctx: Copy, $($T:DekuReader<'a, Ctx>+Sized),+> DekuReader<'a, Ctx> for ($($T,)+)
         {
-            fn read(
-                input: &'a BitSlice<u8, Msb0>,
+            fn from_reader_with_ctx<R: Read>(
+                reader: &mut crate::reader::Reader<R>,
                 ctx: Ctx,
-            ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError>
+            ) -> Result<Self, DekuError>
             where
                 Self: Sized,
             {
                 let tuple = ();
-                let mut rest = input;
                 $(
-                    let read = <$T>::read(rest, ctx)?;
-                    rest = read.0;
-                    let tuple = tuple.append(read.1);
+                    let val = <$T>::from_reader_with_ctx(reader, ctx)?;
+                    let tuple = tuple.append(val);
                 )+
-                Ok((rest, tuple))
+                Ok(tuple)
             }
         }
 
@@ -82,27 +82,10 @@ ImplDekuTupleTraits! { A, B, C, D, E, F, G, H, I, J, K, }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::native_endian;
-    use core::fmt::Debug;
-
     use rstest::rstest;
 
-    #[rstest(input, expected, expected_rest,
-        case::length_1([0xef, 0xbe, 0xad, 0xde].as_ref(), (native_endian!(0xdeadbeef_u32),), bits![u8, Msb0;]),
-        case::length_2([1, 0x24, 0x98, 0x82, 0].as_ref(), (true, native_endian!(0x829824_u32)), bits![u8, Msb0;]),
-        case::length_11([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].as_ref(), (0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8, 10u8), bits![u8, Msb0;]),
-        case::extra_rest([1, 0x24, 0x98, 0x82, 0, 0].as_ref(), (true, native_endian!(0x829824_u32)), bits![u8, Msb0; 0, 0, 0, 0, 0, 0, 0, 0]),
-    )]
-    fn test_tuple_read<'a, T>(input: &'a [u8], expected: T, expected_rest: &BitSlice<u8, Msb0>)
-    where
-        T: DekuRead<'a> + Sized + PartialEq + Debug,
-    {
-        let bit_slice = input.view_bits::<Msb0>();
-        let (rest, res_read) = <T>::read(bit_slice, ()).unwrap();
-        assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
-    }
+    use super::*;
+    use crate::native_endian;
 
     #[rstest(input, expected,
         case::length_1((native_endian!(0xdeadbeef_u32),), vec![0xef, 0xbe, 0xad, 0xde]),

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -1,8 +1,12 @@
-use crate::{ctx::*, DekuError, DekuRead, DekuWrite};
-use bitvec::prelude::*;
+use no_std_io::io::Read;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+
+use bitvec::prelude::*;
+
+use crate::{ctx::*, DekuReader};
+use crate::{DekuError, DekuWrite};
 
 /// Read `T`s into a vec until a given predicate returns true
 /// * `capacity` - an optional capacity to pre-allocate the vector with
@@ -11,59 +15,45 @@ use alloc::vec::Vec;
 /// The predicate takes two parameters: the number of bits that have been read so far,
 /// and a borrow of the latest value to have been read. It should return `true` if reading
 /// should now stop, and `false` otherwise
-fn read_vec_with_predicate<
-    'a,
-    T: DekuRead<'a, Ctx>,
-    Ctx: Copy,
-    Predicate: FnMut(usize, &T) -> bool,
->(
-    input: &'a BitSlice<u8, Msb0>,
+fn reader_vec_with_predicate<'a, T, Ctx, Predicate, R: Read>(
+    reader: &mut crate::reader::Reader<R>,
     capacity: Option<usize>,
     ctx: Ctx,
     mut predicate: Predicate,
-) -> Result<(&'a BitSlice<u8, Msb0>, Vec<T>), DekuError> {
+) -> Result<Vec<T>, DekuError>
+where
+    T: DekuReader<'a, Ctx>,
+    Ctx: Copy,
+    Predicate: FnMut(usize, &T) -> bool,
+{
     let mut res = capacity.map_or_else(Vec::new, Vec::with_capacity);
 
-    let mut rest = input;
+    let start_read = reader.bits_read;
 
     loop {
-        let (new_rest, val) = <T>::read(rest, ctx)?;
+        let val = <T>::from_reader_with_ctx(reader, ctx)?;
         res.push(val);
-        rest = new_rest;
 
         // This unwrap is safe as we are pushing to the vec immediately before it,
         // so there will always be a last element
-        if predicate(
-            unsafe { rest.as_bitptr().offset_from(input.as_bitptr()) } as usize,
-            res.last().unwrap(),
-        ) {
+        if predicate(reader.bits_read - start_read, res.last().unwrap()) {
             break;
         }
     }
 
-    Ok((rest, res))
+    Ok(res)
 }
 
-impl<'a, T: DekuRead<'a, Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool>
-    DekuRead<'a, (Limit<T, Predicate>, Ctx)> for Vec<T>
+impl<'a, T, Ctx, Predicate> DekuReader<'a, (Limit<T, Predicate>, Ctx)> for Vec<T>
+where
+    T: DekuReader<'a, Ctx>,
+    Ctx: Copy,
+    Predicate: FnMut(&T) -> bool,
 {
-    /// Read `T`s until the given limit
-    /// * `limit` - the limiting factor on the amount of `T`s to read
-    /// * `inner_ctx` - The context required by `T`. It will be passed to every `T`s when constructing.
-    /// # Examples
-    /// ```rust
-    /// # use deku::ctx::*;
-    /// # use deku::DekuRead;
-    /// # use deku::bitvec::BitView;
-    /// let input = vec![1u8, 2, 3, 4];
-    /// let (rest, v) = Vec::<u32>::read(input.view_bits(), (1.into(), Endian::Little)).unwrap();
-    /// assert!(rest.is_empty());
-    /// assert_eq!(vec![0x04030201], v)
-    /// ```
-    fn read(
-        input: &'a BitSlice<u8, Msb0>,
+    fn from_reader_with_ctx<R: Read>(
+        reader: &mut crate::reader::Reader<R>,
         (limit, inner_ctx): (Limit<T, Predicate>, Ctx),
-    ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError>
+    ) -> Result<Self, DekuError>
     where
         Self: Sized,
     {
@@ -72,11 +62,11 @@ impl<'a, T: DekuRead<'a, Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool>
             Limit::Count(mut count) => {
                 // Handle the trivial case of reading an empty vector
                 if count == 0 {
-                    return Ok((input, Vec::new()));
+                    return Ok(Vec::new());
                 }
 
                 // Otherwise, read until we have read `count` elements
-                read_vec_with_predicate(input, Some(count), inner_ctx, move |_, _| {
+                reader_vec_with_predicate(reader, Some(count), inner_ctx, move |_, _| {
                     count -= 1;
                     count == 0
                 })
@@ -84,7 +74,7 @@ impl<'a, T: DekuRead<'a, Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool>
 
             // Read until a given predicate returns true
             Limit::Until(mut predicate, _) => {
-                read_vec_with_predicate(input, None, inner_ctx, move |_, value| predicate(value))
+                reader_vec_with_predicate(reader, None, inner_ctx, move |_, value| predicate(value))
             }
 
             // Read until a given quantity of bits have been read
@@ -93,10 +83,10 @@ impl<'a, T: DekuRead<'a, Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool>
 
                 // Handle the trivial case of reading an empty vector
                 if bit_size == 0 {
-                    return Ok((input, Vec::new()));
+                    return Ok(Vec::new());
                 }
 
-                read_vec_with_predicate(input, None, inner_ctx, move |read_bits, _| {
+                reader_vec_with_predicate(reader, None, inner_ctx, move |read_bits, _| {
                     read_bits == bit_size
                 })
             }
@@ -107,10 +97,10 @@ impl<'a, T: DekuRead<'a, Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool>
 
                 // Handle the trivial case of reading an empty vector
                 if bit_size == 0 {
-                    return Ok((input, Vec::new()));
+                    return Ok(Vec::new());
                 }
 
-                read_vec_with_predicate(input, None, inner_ctx, move |read_bits, _| {
+                reader_vec_with_predicate(reader, None, inner_ctx, move |read_bits, _| {
                     read_bits == bit_size
                 })
             }
@@ -118,18 +108,18 @@ impl<'a, T: DekuRead<'a, Ctx>, Ctx: Copy, Predicate: FnMut(&T) -> bool>
     }
 }
 
-impl<'a, T: DekuRead<'a>, Predicate: FnMut(&T) -> bool> DekuRead<'a, Limit<T, Predicate>>
+impl<'a, T: DekuReader<'a>, Predicate: FnMut(&T) -> bool> DekuReader<'a, Limit<T, Predicate>>
     for Vec<T>
 {
     /// Read `T`s until the given limit from input for types which don't require context.
-    fn read(
-        input: &'a BitSlice<u8, Msb0>,
+    fn from_reader_with_ctx<R: Read>(
+        reader: &mut crate::reader::Reader<R>,
         limit: Limit<T, Predicate>,
-    ) -> Result<(&'a BitSlice<u8, Msb0>, Self), DekuError>
+    ) -> Result<Self, DekuError>
     where
         Self: Sized,
     {
-        Vec::read(input, (limit, ()))
+        Vec::from_reader_with_ctx(reader, (limit, ()))
     }
 }
 
@@ -155,48 +145,57 @@ impl<T: DekuWrite<Ctx>, Ctx: Copy> DekuWrite<Ctx> for Vec<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rstest::rstest;
 
-    #[rstest(input,endian,bit_size,limit,expected,expected_rest,
-        case::count_0([0xAA].as_ref(), Endian::Little, Some(8), 0.into(), vec![], bits![u8, Msb0; 1, 0, 1, 0, 1, 0, 1, 0]),
-        case::count_1([0xAA, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), vec![0xAA], bits![u8, Msb0; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::count_2([0xAA, 0xBB, 0xCC].as_ref(), Endian::Little, Some(8), 2.into(), vec![0xAA, 0xBB], bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0]),
-        case::until_null([0xAA, 0, 0xBB].as_ref(), Endian::Little, None, (|v: &u8| *v == 0u8).into(), vec![0xAA, 0], bits![u8, Msb0; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::until_bits([0xAA, 0xBB].as_ref(), Endian::Little, None, BitSize(8).into(), vec![0xAA], bits![u8, Msb0; 1, 0, 1, 1, 1, 0, 1, 1]),
-        case::bits_6([0b0110_1001, 0b1110_1001].as_ref(), Endian::Little, Some(6), 2.into(), vec![0b00_011010, 0b00_011110], bits![u8, Msb0; 1, 0, 0, 1]),
+    use crate::reader::Reader;
+
+    use super::*;
+
+    #[rstest(input,endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes,
+        case::count_0([0xAA].as_ref(), Endian::Little, Some(8), 0.into(), vec![], bits![u8, Msb0;], &[0xaa]),
+        case::count_1([0xAA, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), vec![0xAA], bits![u8, Msb0;], &[0xbb]),
+        case::count_2([0xAA, 0xBB, 0xCC].as_ref(), Endian::Little, Some(8), 2.into(), vec![0xAA, 0xBB], bits![u8, Msb0;], &[0xcc]),
+        case::until_null([0xAA, 0, 0xBB].as_ref(), Endian::Little, None, (|v: &u8| *v == 0u8).into(), vec![0xAA, 0], bits![u8, Msb0;], &[0xbb]),
+        case::until_bits([0xAA, 0xBB].as_ref(), Endian::Little, None, BitSize(8).into(), vec![0xAA], bits![u8, Msb0;], &[0xbb]),
+        case::bits_6([0b0110_1001, 0b1110_1001].as_ref(), Endian::Little, Some(6), 2.into(), vec![0b00_011010, 0b00_011110], bits![u8, Msb0; 1, 0, 0, 1], &[]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::not_enough_data([].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![u8, Msb0;]),
+        case::not_enough_data([].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![u8, Msb0;]),
+        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(8), 2.into(), vec![], bits![u8, Msb0;]),
+        case::not_enough_data([0xAA].as_ref(), Endian::Little, Some(8), 2.into(), vec![], bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data_until([0xAA].as_ref(), Endian::Little, Some(8), (|_: &u8| false).into(), vec![], bits![u8, Msb0;]),
+        case::not_enough_data_until([0xAA].as_ref(), Endian::Little, Some(8), (|_: &u8| false).into(), vec![], bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
-        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (BitSize(16)).into(), vec![], bits![u8, Msb0;]),
+        case::not_enough_data_bits([0xAA].as_ref(), Endian::Little, Some(8), (BitSize(16)).into(), vec![], bits![u8, Msb0;], &[]),
         #[should_panic(expected = "Parse(\"too much data: container of 8 bits cannot hold 9 bits\")")]
-        case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![u8, Msb0;]),
+        case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![u8, Msb0;], &[]),
     )]
-    fn test_vec_read<Predicate: FnMut(&u8) -> bool>(
-        input: &[u8],
+    fn test_vec_reader<Predicate: FnMut(&u8) -> bool>(
+        mut input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         limit: Limit<u8, Predicate>,
         expected: Vec<u8>,
-        expected_rest: &BitSlice<u8, Msb0>,
+        expected_rest_bits: &BitSlice<u8, Msb0>,
+        expected_rest_bytes: &[u8],
     ) {
-        let bit_slice = input.view_bits::<Msb0>();
-
-        let (rest, res_read) = match bit_size {
+        let mut reader = Reader::new(&mut input);
+        let res_read = match bit_size {
             Some(bit_size) => {
-                Vec::<u8>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap()
+                Vec::<u8>::from_reader_with_ctx(&mut reader, (limit, (endian, BitSize(bit_size))))
+                    .unwrap()
             }
-            None => Vec::<u8>::read(bit_slice, (limit, (endian))).unwrap(),
+            None => Vec::<u8>::from_reader_with_ctx(&mut reader, (limit, (endian))).unwrap(),
         };
-
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
+        assert_eq!(
+            reader.rest(),
+            expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
+        );
+        let mut buf = vec![];
+        input.read_to_end(&mut buf).unwrap();
+        assert_eq!(expected_rest_bytes, buf);
     }
 
     #[rstest(input, endian, expected,
@@ -209,32 +208,40 @@ mod tests {
     }
 
     // Note: These tests also exist in boxed.rs
-    #[rstest(input, endian, bit_size, limit, expected, expected_rest, expected_write,
-        case::normal_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), 2.into(), vec![0xBBAA, 0xDDCC], bits![u8, Msb0;], vec![0xAA, 0xBB, 0xCC, 0xDD]),
-        case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD], bits![u8, Msb0;], vec![0xAA, 0xBB, 0xCC, 0xDD]),
-        case::predicate_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), (|v: &u16| *v == 0xBBAA).into(), vec![0xBBAA], bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::predicate_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), (|v: &u16| *v == 0xAABB).into(), vec![0xAABB], bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), BitSize(16).into(), vec![0xBBAA], bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
-        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), BitSize(16).into(), vec![0xAABB], bits![u8, Msb0; 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1], vec![0xAA, 0xBB]),
+    #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes, expected_write,
+        case::normal_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), 2.into(), vec![0xBBAA, 0xDDCC], bits![u8, Msb0;], &[], vec![0xAA, 0xBB, 0xCC, 0xDD]),
+        case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD], bits![u8, Msb0;], &[], vec![0xAA, 0xBB, 0xCC, 0xDD]),
+        case::predicate_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), (|v: &u16| *v == 0xBBAA).into(), vec![0xBBAA], bits![u8, Msb0;], &[0xcc, 0xdd], vec![0xAA, 0xBB]),
+        case::predicate_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), (|v: &u16| *v == 0xAABB).into(), vec![0xAABB], bits![u8, Msb0;], &[0xcc, 0xdd], vec![0xAA, 0xBB]),
+        case::bytes_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), BitSize(16).into(), vec![0xBBAA], bits![u8, Msb0;], &[0xcc, 0xdd], vec![0xAA, 0xBB]),
+        case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), BitSize(16).into(), vec![0xAABB], bits![u8, Msb0;], &[0xcc, 0xdd], vec![0xAA, 0xBB]),
     )]
-    fn test_vec_read_write<Predicate: FnMut(&u16) -> bool>(
-        input: &[u8],
+    fn test_vec_reader_write<Predicate: FnMut(&u16) -> bool>(
+        mut input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         limit: Limit<u16, Predicate>,
         expected: Vec<u16>,
-        expected_rest: &BitSlice<u8, Msb0>,
+        expected_rest_bits: &BitSlice<u8, Msb0>,
+        expected_rest_bytes: &[u8],
         expected_write: Vec<u8>,
     ) {
-        let bit_slice = input.view_bits::<Msb0>();
-
+        let input_clone = input;
         // Unwrap here because all test cases are `Some`.
         let bit_size = bit_size.unwrap();
 
-        let (rest, res_read) =
-            Vec::<u16>::read(bit_slice, (limit, (endian, BitSize(bit_size)))).unwrap();
+        let mut reader = Reader::new(&mut input);
+        let res_read =
+            Vec::<u16>::from_reader_with_ctx(&mut reader, (limit, (endian, BitSize(bit_size))))
+                .unwrap();
         assert_eq!(expected, res_read);
-        assert_eq!(expected_rest, rest);
+        assert_eq!(
+            reader.rest(),
+            expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
+        );
+        let mut buf = vec![];
+        input.read_to_end(&mut buf).unwrap();
+        assert_eq!(expected_rest_bytes, buf);
 
         let mut res_write = bitvec![u8, Msb0;];
         res_read
@@ -242,6 +249,6 @@ mod tests {
             .unwrap();
         assert_eq!(expected_write, res_write.into_vec());
 
-        assert_eq!(input[..expected_write.len()].to_vec(), expected_write);
+        assert_eq!(input_clone[..expected_write.len()].to_vec(), expected_write);
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,8 @@
 
 [What is a prelude?](std::prelude)
 */
+pub use crate::error::{DekuError, NeedSize};
 pub use crate::{
-    deku_derive, error::DekuError, error::NeedSize, DekuContainerRead, DekuContainerWrite,
-    DekuEnumExt, DekuRead, DekuUpdate, DekuWrite,
+    deku_derive, reader::Reader, DekuContainerRead, DekuContainerWrite, DekuEnumExt, DekuRead,
+    DekuReader, DekuUpdate, DekuWrite,
 };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,275 @@
+//! Reader for reader functions
+
+use core::cmp::Ordering;
+
+use bitvec::prelude::*;
+use no_std_io::io::{ErrorKind, Read};
+
+use crate::{prelude::NeedSize, DekuError};
+use alloc::vec::Vec;
+
+#[cfg(feature = "logging")]
+use log;
+
+/// Return from `read_bytes`
+pub enum ReaderRet {
+    /// Successfully read bytes
+    Bytes,
+    /// Successfully read bits
+    Bits(Option<BitVec<u8, Msb0>>),
+}
+
+/// Reader to use with `from_reader_with_ctx`
+pub struct Reader<'a, R: Read> {
+    inner: &'a mut R,
+    /// bits stored from previous reads that didn't read to the end of a byte size
+    leftover: BitVec<u8, Msb0>,
+    /// Amount of bits read during the use of [read_bits](Reader::read_bits) and [read_bytes](Reader::read_bytes).
+    pub bits_read: usize,
+}
+
+/// Max bits requested from [`Reader::read_bits`] during one call
+pub const MAX_BITS_AMT: usize = 128;
+
+impl<'a, R: Read> Reader<'a, R> {
+    /// Create a new `Reader`
+    #[inline]
+    pub fn new(inner: &'a mut R) -> Self {
+        Self {
+            inner,
+            leftover: BitVec::new(), // with_capacity 8?
+            bits_read: 0,
+        }
+    }
+
+    /// Return the unused bits
+    ///
+    /// Once the parsing is complete for a struct, if the total size of the field using the `bits` attribute
+    /// isn't byte aligned the returned values could be unexpected as the "Read" will always read
+    /// to a full byte.
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use deku::prelude::*;
+    ///
+    /// #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+    /// #[deku(endian = "big")]
+    /// struct DekuTest {
+    ///     #[deku(bits = "4")]
+    ///     field_a: u8,
+    ///     #[deku(bits = "2")]
+    ///     field_b: u8,
+    /// }
+    /// //                       |         | <= this entire byte is Read
+    /// let data: Vec<u8> = vec![0b0110_1101, 0xbe, 0xef];
+    /// let mut cursor = Cursor::new(data);
+    /// let mut reader = Reader::new(&mut cursor);
+    /// let val = DekuTest::from_reader_with_ctx(&mut reader, ()).unwrap();
+    /// assert_eq!(DekuTest {
+    ///     field_a: 0b0110,
+    ///     field_b: 0b11,
+    /// }, val);
+    ///
+    /// // last 2 bits in that byte
+    /// assert_eq!(reader.rest(), vec![false, true]);
+    /// ```
+    #[inline]
+    pub fn rest(&mut self) -> Vec<bool> {
+        self.leftover.iter().by_vals().collect()
+    }
+
+    /// Return true if we are at the end of a reader and there are no cached bits in the reader
+    ///
+    /// The byte that was read will be internally buffered
+    #[inline]
+    pub fn end(&mut self) -> bool {
+        if !self.leftover.is_empty() {
+            #[cfg(feature = "logging")]
+            log::trace!("not end");
+            false
+        } else {
+            let mut buf = [0; 1];
+            if let Err(e) = self.inner.read_exact(&mut buf) {
+                if e.kind() == ErrorKind::UnexpectedEof {
+                    #[cfg(feature = "logging")]
+                    log::trace!("end");
+                    return true;
+                }
+            }
+
+            // logic is best if we just turn this into bits right now
+            self.leftover = BitVec::try_from_slice(&buf).unwrap();
+            #[cfg(feature = "logging")]
+            log::trace!("not end");
+            false
+        }
+    }
+
+    /// Used at the beginning of `from_reader`.
+    /// TODO: maybe send into read_bytes() if amt >= 8
+    #[inline]
+    pub fn skip_bits(&mut self, amt: usize) -> Result<(), DekuError> {
+        #[cfg(feature = "logging")]
+        log::trace!("skip_bits: {amt}");
+        // Save, and keep the leftover bits since the read will most likely be less than a byte
+        self.read_bits(amt)?;
+
+        Ok(())
+    }
+
+    /// Attempt to read bits from `Reader`. If enough bits are already "Read", we just grab
+    /// enough bits to satisfy `amt`, but will also "Read" more from the stream and store the
+    /// leftovers if enough are not already "Read".
+    ///
+    /// # Guarantees
+    /// - if Some(bits), the returned `BitVec` will have the size of `amt` and
+    /// `self.bits_read` will increase by `amt`
+    ///
+    /// # Params
+    /// `amt`    - Amount of bits that will be read. Must be <= [`MAX_BITS_AMT`].
+    #[inline]
+    pub fn read_bits(&mut self, amt: usize) -> Result<Option<BitVec<u8, Msb0>>, DekuError> {
+        #[cfg(feature = "logging")]
+        log::trace!("read_bits: requesting {amt} bits");
+        if amt == 0 {
+            #[cfg(feature = "logging")]
+            log::trace!("read_bits: returned None");
+            return Ok(None);
+        }
+        let mut ret = BitVec::new();
+
+        match amt.cmp(&self.leftover.len()) {
+            // exact match, just use leftover
+            Ordering::Equal => {
+                core::mem::swap(&mut ret, &mut self.leftover);
+                self.leftover.clear();
+            }
+            // previous read was not enough to satisfy the amt requirement, return all previously
+            Ordering::Greater => {
+                // read bits
+                ret.extend_from_bitslice(&self.leftover);
+
+                // calculate the amount of bytes we need to read to read enough bits
+                let bits_left = amt - self.leftover.len();
+                let mut bytes_len = bits_left / 8;
+                if (bits_left % 8) != 0 {
+                    bytes_len += 1;
+                }
+
+                // read in new bytes
+                let mut buf = [0; MAX_BITS_AMT];
+                if let Err(e) = self.inner.read_exact(&mut buf[..bytes_len]) {
+                    if e.kind() == ErrorKind::UnexpectedEof {
+                        return Err(DekuError::Incomplete(NeedSize::new(amt)));
+                    }
+
+                    // TODO: other errors?
+                }
+                let read_buf = &buf[..bytes_len];
+
+                #[cfg(feature = "logging")]
+                log::trace!("read_bits: read() {:02x?}", read_buf);
+
+                // create bitslice and remove unused bits
+                let rest = BitSlice::try_from_slice(read_buf).unwrap();
+                let (rest, not_needed) = rest.split_at(bits_left);
+                core::mem::swap(&mut not_needed.to_bitvec(), &mut self.leftover);
+
+                // create return
+                ret.extend_from_bitslice(rest);
+            }
+            // The entire bits we need to return have been already read previously from bytes but
+            // not all were read, return required leftover bits
+            Ordering::Less => {
+                let used = self.leftover.split_off(amt);
+                ret.extend_from_bitslice(&self.leftover);
+                self.leftover = used;
+            }
+        }
+
+        self.bits_read += ret.len();
+        #[cfg(feature = "logging")]
+        log::trace!("read_bits: returning {ret}");
+        Ok(Some(ret))
+    }
+
+    /// Attempt to read bytes from `Reader`. This will return `ReaderRet::Bytes` with a valid
+    /// `buf` of bytes if we have no "leftover" bytes and thus are byte aligned. If we are not byte
+    /// aligned, this will call `read_bits` and return `ReaderRet::Bits(_)` of size `amt` * 8.
+    ///
+    /// # Params
+    /// `amt`    - Amount of bytes that will be read
+    #[inline]
+    pub fn read_bytes(&mut self, amt: usize, buf: &mut [u8]) -> Result<ReaderRet, DekuError> {
+        #[cfg(feature = "logging")]
+        log::trace!("read_bytes: requesting {amt} bytes");
+        if self.leftover.is_empty() {
+            if buf.len() < amt {
+                return Err(DekuError::Incomplete(NeedSize::new(amt * 8)));
+            }
+            if let Err(e) = self.inner.read_exact(&mut buf[..amt]) {
+                if e.kind() == ErrorKind::UnexpectedEof {
+                    return Err(DekuError::Incomplete(NeedSize::new(amt * 8)));
+                }
+
+                // TODO: other errors?
+            }
+
+            self.bits_read += amt * 8;
+
+            #[cfg(feature = "logging")]
+            log::trace!("read_bytes: returning {buf:02x?}");
+
+            Ok(ReaderRet::Bytes)
+        } else {
+            Ok(ReaderRet::Bits(self.read_bits(amt * 8)?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hexlit::hex;
+    use no_std_io::io::Cursor;
+
+    #[test]
+    fn test_end() {
+        let input = hex!("aa");
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        assert!(!reader.end());
+        let mut buf = [0; 1];
+        let _ = reader.read_bytes(1, &mut buf);
+        assert!(reader.end());
+
+        let input = hex!("aa");
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        assert!(!reader.end());
+        let _ = reader.read_bits(4);
+        assert!(!reader.end());
+        let _ = reader.read_bits(4);
+        assert!(reader.end());
+    }
+
+    #[test]
+    fn test_bits_less() {
+        let input = hex!("aa");
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        let _ = reader.read_bits(1);
+        let _ = reader.read_bits(4);
+        let _ = reader.read_bits(3);
+    }
+
+    #[test]
+    fn test_inner() {
+        let input = hex!("aabbcc");
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
+        let mut buf = [0; 1];
+        let _ = reader.read_bytes(1, &mut buf);
+        assert_eq!([0xaa], buf);
+    }
+}

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -38,17 +38,17 @@ struct TestDeku {
     field_e: Vec<u8>, // 1 alloc
     field_f: [u8; 3],
     #[deku(bits = "3")]
-    field_g: u8, // 1 alloc (bits read)
+    field_g: u8, // 3 allocs (read_bits(Ordering::Greater))
     #[deku(bits = "5")]
-    field_h: u8, // 1 alloc (bits read)
-    field_i: NestedEnum2,
+    field_h: u8, // 1 alloc (read_bits(Ordering::Equal))
+                 //field_i: NestedEnum2,
 }
 
 mod tests {
-    use super::*;
     use alloc_counter::count_alloc;
     use hexlit::hex;
-    use std::convert::TryFrom;
+
+    use super::*;
 
     #[test]
     #[cfg_attr(miri, ignore)]
@@ -57,10 +57,10 @@ mod tests {
 
         assert_eq!(
             count_alloc(|| {
-                let _ = TestDeku::try_from(input.as_ref()).unwrap();
+                let _ = TestDeku::from_reader((&mut input.as_slice(), 0)).unwrap();
             })
             .0,
-            (4, 0, 4)
+            (5, 0, 5)
         );
     }
 }

--- a/tests/test_attributes/test_assert.rs
+++ b/tests/test_attributes/test_assert.rs
@@ -1,7 +1,8 @@
+use std::convert::{TryFrom, TryInto};
+
 use deku::prelude::*;
 use hexlit::hex;
 use rstest::rstest;
-use std::convert::{TryFrom, TryInto};
 
 #[derive(Default, PartialEq, Debug, DekuRead, DekuWrite)]
 struct TestStruct {

--- a/tests/test_attributes/test_assert_eq.rs
+++ b/tests/test_attributes/test_assert_eq.rs
@@ -1,7 +1,8 @@
+use std::convert::{TryFrom, TryInto};
+
 use deku::prelude::*;
 use hexlit::hex;
 use rstest::rstest;
-use std::convert::{TryFrom, TryInto};
 
 #[derive(Default, PartialEq, Debug, DekuRead, DekuWrite)]
 struct TestStruct {

--- a/tests/test_attributes/test_cond.rs
+++ b/tests/test_attributes/test_cond.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 #[test]
 fn test_cond_deku() {
@@ -13,7 +14,7 @@ fn test_cond_deku() {
     // `cond` is true
     let test_data: Vec<u8> = [0x01, 0x02].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             field_a: 0x01,
@@ -28,7 +29,7 @@ fn test_cond_deku() {
     // `cond` is false
     let test_data: Vec<u8> = [0x02].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             field_a: 0x02,

--- a/tests/test_attributes/test_limits/test_bits_read.rs
+++ b/tests/test_attributes/test_limits/test_bits_read.rs
@@ -1,6 +1,7 @@
+use std::convert::{TryFrom, TryInto};
+
 use deku::prelude::*;
 use rstest::rstest;
-use std::convert::{TryFrom, TryInto};
 
 mod test_slice {
     use super::*;
@@ -8,17 +9,17 @@ mod test_slice {
     #[test]
     fn test_bits_read_static() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             #[deku(bits_read = "16")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
-                data: test_data.as_ref()
+                data: test_data.to_vec()
             },
             ret_read
         );
@@ -38,20 +39,20 @@ mod test_slice {
     )]
     fn test_bits_read_from_field(input_bits: u8) {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             bits: u8,
 
             #[deku(bits_read = "bits")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [input_bits, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [input_bits, 0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
                 bits: 16,
-                data: &test_data[1..]
+                data: test_data[1..].to_vec(),
             },
             ret_read
         );
@@ -63,9 +64,9 @@ mod test_slice {
     #[test]
     fn test_bits_read_zero() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             #[deku(bits_read = "0")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
         let test_data: Vec<u8> = [].to_vec();
@@ -73,7 +74,7 @@ mod test_slice {
         let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
         assert_eq!(
             TestStruct {
-                data: test_data.as_ref()
+                data: test_data.clone()
             },
             ret_read
         );
@@ -94,14 +95,14 @@ mod test_vec {
             data: Vec<u16>,
         }
 
-        let test_data: Vec<u8> = [0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
                 // We should read 16 bits, not 16 elements,
                 // thus resulting in a single u16 element
-                data: vec![0xBBAA]
+                data: vec![0xbbaa]
             },
             ret_read
         );
@@ -128,16 +129,16 @@ mod test_vec {
             data: Vec<u16>,
         }
 
-        let test_data: Vec<u8> = [input_bits, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [input_bits, 0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
                 bits: 16,
 
                 // We should read 16 bits, not 16 elements,
                 // thus resulting in a single u16 element
-                data: vec![0xBBAA]
+                data: vec![0xbbaa]
             },
             ret_read
         );

--- a/tests/test_attributes/test_limits/test_bytes_read.rs
+++ b/tests/test_attributes/test_limits/test_bytes_read.rs
@@ -1,6 +1,7 @@
+use std::convert::{TryFrom, TryInto};
+
 use deku::prelude::*;
 use rstest::rstest;
-use std::convert::{TryFrom, TryInto};
 
 mod test_slice {
     use super::*;
@@ -8,17 +9,17 @@ mod test_slice {
     #[test]
     fn test_bytes_read_static() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             #[deku(bytes_read = "2")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
-                data: test_data.as_ref()
+                data: test_data.to_vec(),
             },
             ret_read
         );
@@ -35,20 +36,20 @@ mod test_slice {
     )]
     fn test_bytes_read_from_field(input_bytes: u8) {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             bytes: u8,
 
             #[deku(bytes_read = "bytes")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [input_bytes, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [input_bytes, 0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
                 bytes: 0x02,
-                data: &test_data[1..]
+                data: test_data[1..].to_vec()
             },
             ret_read
         );
@@ -60,17 +61,17 @@ mod test_slice {
     #[test]
     fn test_bytes_read_zero() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             #[deku(bytes_read = "0")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
         let test_data: Vec<u8> = [].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
-                data: test_data.as_ref()
+                data: test_data.clone()
             },
             ret_read
         );
@@ -91,14 +92,14 @@ mod test_vec {
             data: Vec<u16>,
         }
 
-        let test_data: Vec<u8> = [0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
                 // We should read two bytes, not two elements,
                 // thus resulting in a single u16 element
-                data: vec![0xBBAA]
+                data: vec![0xbbaa]
             },
             ret_read
         );
@@ -122,16 +123,16 @@ mod test_vec {
             data: Vec<u16>,
         }
 
-        let test_data: Vec<u8> = [input_bytes, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [input_bytes, 0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
                 bytes: 0x02,
 
                 // We should read two bytes, not two elements,
                 // thus resulting in a single u16 element
-                data: vec![0xBBAA]
+                data: vec![0xbbaa]
             },
             ret_read
         );

--- a/tests/test_attributes/test_limits/test_count.rs
+++ b/tests/test_attributes/test_limits/test_count.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 mod test_slice {
     use super::*;
@@ -7,17 +8,17 @@ mod test_slice {
     #[test]
     fn test_count_static() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             #[deku(count = "2")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
-                data: test_data.as_ref()
+                data: test_data.to_vec()
             },
             ret_read
         );
@@ -29,19 +30,19 @@ mod test_slice {
     #[test]
     fn test_count_from_field() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             count: u8,
             #[deku(count = "count")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0x02, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0x02, 0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
                 count: 0x02,
-                data: &test_data[1..]
+                data: test_data[1..].to_vec(),
             },
             ret_read
         );
@@ -53,9 +54,9 @@ mod test_slice {
     #[test]
     fn test_count_zero() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             #[deku(count = "0")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
         let test_data: Vec<u8> = [].to_vec();
@@ -63,7 +64,7 @@ mod test_slice {
         let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
         assert_eq!(
             TestStruct {
-                data: test_data.as_ref()
+                data: test_data.clone()
             },
             ret_read
         );
@@ -76,15 +77,15 @@ mod test_slice {
     #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
     fn test_count_error() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             count: u8,
             #[deku(count = "count")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0x03, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0x03, 0xaa, 0xbb].to_vec();
 
-        let _ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let _ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     }
 }
 
@@ -99,12 +100,12 @@ mod test_vec {
             data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
-                data: vec![0xAA, 0xBB]
+                data: vec![0xaa, 0xbb]
             },
             ret_read
         );
@@ -122,13 +123,13 @@ mod test_vec {
             data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0x02, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0x02, 0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
                 count: 0x02,
-                data: vec![0xAA, 0xBB]
+                data: vec![0xaa, 0xbb]
             },
             ret_read
         );
@@ -164,8 +165,8 @@ mod test_vec {
             data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0x03, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0x03, 0xaa, 0xbb].to_vec();
 
-        let _ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let _ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     }
 }

--- a/tests/test_attributes/test_limits/test_until.rs
+++ b/tests/test_attributes/test_limits/test_until.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 mod test_slice {
     use super::*;
@@ -7,17 +8,17 @@ mod test_slice {
     #[test]
     fn test_until_static() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             #[deku(until = "|v: &u8| *v == 0xBB")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
-                data: test_data.as_ref()
+                data: test_data.to_vec()
             },
             ret_read
         );
@@ -29,20 +30,20 @@ mod test_slice {
     #[test]
     fn test_until_from_field() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             until: u8,
 
             #[deku(until = "|v: &u8| *v == *until")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xBB, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xbb, 0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
-                until: 0xBB,
-                data: &test_data[1..]
+                until: 0xbb,
+                data: test_data[1..].to_vec()
             },
             ret_read
         );
@@ -55,16 +56,16 @@ mod test_slice {
     #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
     fn test_until_error() {
         #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-        struct TestStruct<'a> {
+        struct TestStruct {
             until: u8,
 
             #[deku(until = "|v: &u8| *v == *until")]
-            data: &'a [u8],
+            data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xCC, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xcc, 0xaa, 0xbb].to_vec();
 
-        let _ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let _ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     }
 }
 
@@ -79,12 +80,12 @@ mod test_vec {
             data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
-                data: vec![0xAA, 0xBB]
+                data: vec![0xaa, 0xbb]
             },
             ret_read
         );
@@ -103,13 +104,13 @@ mod test_vec {
             data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xBB, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xbb, 0xaa, 0xbb].to_vec();
 
-        let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
         assert_eq!(
             TestStruct {
-                until: 0xBB,
-                data: vec![0xAA, 0xBB]
+                until: 0xbb,
+                data: vec![0xaa, 0xbb]
             },
             ret_read
         );
@@ -129,8 +130,8 @@ mod test_vec {
             data: Vec<u8>,
         }
 
-        let test_data: Vec<u8> = [0xCC, 0xAA, 0xBB].to_vec();
+        let test_data: Vec<u8> = [0xcc, 0xaa, 0xbb].to_vec();
 
-        let _ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+        let _ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     }
 }

--- a/tests/test_attributes/test_map.rs
+++ b/tests/test_attributes/test_map.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::TryFrom;
+
+use deku::prelude::*;
 
 #[test]
 fn test_map() {
@@ -19,7 +20,7 @@ fn test_map() {
 
     let test_data: Vec<u8> = [0x01, 0x02].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             field_a: "1".to_string(),

--- a/tests/test_attributes/test_padding/mod.rs
+++ b/tests/test_attributes/test_padding/mod.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 mod test_pad_bits_after;
 mod test_pad_bits_before;
@@ -17,20 +18,20 @@ fn test_pad_bits_before_and_pad_bytes_before() {
         field_b: u8,
     }
 
-    let data: Vec<u8> = vec![0b10_000000, 0xAA, 0xBB];
+    let data: Vec<u8> = vec![0b10_000000, 0xaa, 0xbb];
 
-    let ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 
     assert_eq!(
         TestStruct {
             field_a: 0b10,
-            field_b: 0xBB,
+            field_b: 0xbb,
         },
         ret_read
     );
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(vec![0b10_000000, 0x00, 0xBB], ret_write);
+    assert_eq!(vec![0b10_000000, 0x00, 0xbb], ret_write);
 }
 
 #[test]
@@ -42,18 +43,18 @@ fn test_pad_bits_after_and_pad_bytes_after() {
         field_b: u8,
     }
 
-    let data: Vec<u8> = vec![0b10_000000, 0xAA, 0xBB];
+    let data: Vec<u8> = vec![0b10_000000, 0xaa, 0xbb];
 
-    let ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 
     assert_eq!(
         TestStruct {
             field_a: 0b10,
-            field_b: 0xBB,
+            field_b: 0xbb,
         },
         ret_read
     );
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(vec![0b10_000000, 0x00, 0xBB], ret_write);
+    assert_eq!(vec![0b10_000000, 0x00, 0xbb], ret_write);
 }

--- a/tests/test_attributes/test_padding/test_pad_bits_after.rs
+++ b/tests/test_attributes/test_padding/test_pad_bits_after.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 #[test]
 fn test_pad_bits_after() {
@@ -13,7 +14,7 @@ fn test_pad_bits_after() {
 
     let data: Vec<u8> = vec![0b10_0110_01];
 
-    let ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 
     assert_eq!(
         TestStruct {
@@ -40,7 +41,7 @@ fn test_pad_bits_after_not_enough() {
 
     let data: Vec<u8> = vec![0b10_0110_01];
 
-    let _ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
 #[test]
@@ -58,7 +59,7 @@ fn test_pad_bits_after_read_err() {
 
     let data: Vec<u8> = vec![0b10_01_1001];
 
-    let _ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
 #[test]

--- a/tests/test_attributes/test_padding/test_pad_bits_before.rs
+++ b/tests/test_attributes/test_padding/test_pad_bits_before.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 #[test]
 fn test_pad_bits_before() {
@@ -13,7 +14,7 @@ fn test_pad_bits_before() {
 
     let data: Vec<u8> = vec![0b10_01_1001];
 
-    let ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 
     assert_eq!(
         TestStruct {
@@ -40,7 +41,7 @@ fn test_pad_bits_before_not_enough() {
 
     let data: Vec<u8> = vec![0b10_01_1001];
 
-    let _ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
 #[test]
@@ -58,7 +59,7 @@ fn test_pad_bits_before_read_err() {
 
     let data: Vec<u8> = vec![0b10_01_1001];
 
-    let _ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
 #[test]

--- a/tests/test_attributes/test_padding/test_pad_bytes_after.rs
+++ b/tests/test_attributes/test_padding/test_pad_bytes_after.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 #[test]
 fn test_pad_bytes_after() {
@@ -10,20 +11,20 @@ fn test_pad_bytes_after() {
         field_b: u8,
     }
 
-    let data: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0xDD];
+    let data: Vec<u8> = vec![0xaa, 0xbb, 0xcc, 0xdd];
 
-    let ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 
     assert_eq!(
         TestStruct {
-            field_a: 0xAA,
-            field_b: 0xDD,
+            field_a: 0xaa,
+            field_b: 0xdd,
         },
         ret_read
     );
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(vec![0xAA, 0x00, 0x00, 0xDD], ret_write);
+    assert_eq!(vec![0xaa, 0x00, 0x00, 0xdd], ret_write);
 }
 
 #[test]
@@ -36,9 +37,9 @@ fn test_pad_bytes_after_not_enough() {
         field_b: u8,
     }
 
-    let data: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0xDD];
+    let data: Vec<u8> = vec![0xaa, 0xbb, 0xcc, 0xdd];
 
-    let _ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
 #[test]
@@ -53,9 +54,9 @@ fn test_pad_bytes_after_read_err() {
         field_b: u8,
     }
 
-    let data: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0xDD];
+    let data: Vec<u8> = vec![0xaa, 0xbb, 0xcc, 0xdd];
 
-    let _ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
 #[test]
@@ -71,8 +72,8 @@ fn test_pad_bytes_after_write_err() {
     }
 
     let data = TestStruct {
-        field_a: 0xAA,
-        field_b: 0xDD,
+        field_a: 0xaa,
+        field_b: 0xdd,
     };
 
     let _ret_write: Vec<u8> = data.try_into().unwrap();

--- a/tests/test_attributes/test_padding/test_pad_bytes_before.rs
+++ b/tests/test_attributes/test_padding/test_pad_bytes_before.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 #[test]
 fn test_pad_bytes_before() {
@@ -10,20 +11,20 @@ fn test_pad_bytes_before() {
         field_b: u8,
     }
 
-    let data: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0xDD];
+    let data: Vec<u8> = vec![0xaa, 0xbb, 0xcc, 0xdd];
 
-    let ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 
     assert_eq!(
         TestStruct {
-            field_a: 0xAA,
-            field_b: 0xDD,
+            field_a: 0xaa,
+            field_b: 0xdd,
         },
         ret_read
     );
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(vec![0xAA, 0x00, 0x00, 0xDD], ret_write);
+    assert_eq!(vec![0xaa, 0x00, 0x00, 0xdd], ret_write);
 }
 
 #[test]
@@ -36,9 +37,9 @@ fn test_pad_bytes_before_not_enough() {
         field_b: u8,
     }
 
-    let data: Vec<u8> = vec![0xAA];
+    let data: Vec<u8> = vec![0xaa];
 
-    let _ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
 #[test]
@@ -53,9 +54,9 @@ fn test_pad_bytes_before_read_err() {
         field_b: u8,
     }
 
-    let data: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0xDD];
+    let data: Vec<u8> = vec![0xaa, 0xbb, 0xcc, 0xdd];
 
-    let _ret_read = TestStruct::try_from(data.as_ref()).unwrap();
+    let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
 #[test]
@@ -71,8 +72,8 @@ fn test_pad_bytes_before_write_err() {
     }
 
     let data = TestStruct {
-        field_a: 0xAA,
-        field_b: 0xDD,
+        field_a: 0xaa,
+        field_b: 0xdd,
     };
 
     let _ret_write: Vec<u8> = data.try_into().unwrap();

--- a/tests/test_attributes/test_skip.rs
+++ b/tests/test_attributes/test_skip.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 /// Skip
 #[test]
@@ -15,7 +16,7 @@ fn test_skip() {
     // Skip `field_b`
     let test_data: Vec<u8> = [0x01, 0x02].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             field_a: 0x01,
@@ -43,7 +44,7 @@ fn test_skip_default() {
     // Skip `field_b` and default it's value to 5
     let test_data: Vec<u8> = [0x01, 0x02].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             field_a: 0x01,
@@ -70,7 +71,7 @@ fn test_skip_cond() {
     // if `cond` is true, skip and default `field_b` to 5
     let test_data: Vec<u8> = [0x01].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             field_a: 0x01,
@@ -85,7 +86,7 @@ fn test_skip_cond() {
     // if `cond` is false, read `field_b` from input
     let test_data: Vec<u8> = [0x02, 0x03].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             field_a: 0x02,

--- a/tests/test_attributes/test_temp.rs
+++ b/tests/test_attributes/test_temp.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 #[test]
 fn test_temp_field_write() {
@@ -34,7 +35,7 @@ fn test_temp_field_value_ignore_on_read() {
 
     let test_data: Vec<u8> = [0x02, 0x02, 0x03].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             field_b: vec![0x02, 0x03]
@@ -56,7 +57,7 @@ fn test_temp_field() {
 
     let test_data: Vec<u8> = [0x01, 0x02].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             field_b: vec![0x02]
@@ -76,7 +77,7 @@ fn test_temp_field_unnamed() {
 
     let test_data: Vec<u8> = [0x01, 0x02].to_vec();
 
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(TestStruct(vec![0x02]), ret_read);
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
@@ -114,9 +115,9 @@ fn test_temp_enum_field() {
         },
     }
 
-    let test_data: Vec<u8> = [0xAB, 0x01, 0x02].to_vec();
+    let test_data: Vec<u8> = [0xab, 0x01, 0x02].to_vec();
 
-    let ret_read = TestEnum::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestEnum::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestEnum::VarA {
             field_b: vec![0x02]
@@ -125,7 +126,7 @@ fn test_temp_enum_field() {
     );
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(vec![0xAB, 0x02], ret_write);
+    assert_eq!(vec![0xab, 0x02], ret_write);
 }
 
 #[test]
@@ -148,7 +149,7 @@ fn test_temp_enum_field_write() {
         VarB(u8),
     }
 
-    let test_data: Vec<u8> = [0xAB, 0x01, 0x02].to_vec();
+    let test_data: Vec<u8> = [0xab, 0x01, 0x02].to_vec();
     let ret_write: Vec<u8> = TestEnum::VarA {
         field_b: vec![0x02],
     }
@@ -156,7 +157,7 @@ fn test_temp_enum_field_write() {
     .unwrap();
     assert_eq!(test_data, ret_write);
 
-    let test_data: Vec<u8> = [0xBA, 0x10].to_vec();
+    let test_data: Vec<u8> = [0xba, 0x10].to_vec();
     let ret_write: Vec<u8> = TestEnum::VarB(0x10).to_bytes().unwrap();
     assert_eq!(test_data, ret_write);
 }

--- a/tests/test_attributes/test_update.rs
+++ b/tests/test_attributes/test_update.rs
@@ -1,5 +1,6 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 /// Update field value
 #[test]
@@ -13,7 +14,7 @@ fn test_update() {
     // Update `field_a` to 5
     let test_data: Vec<u8> = [0x01].to_vec();
 
-    let mut ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let mut ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(TestStruct { field_a: 0x01 }, ret_read);
 
     // `field_a` field should now be increased
@@ -36,20 +37,20 @@ fn test_update_from_field() {
     }
 
     // Update the value of `count` to the length of `data`
-    let test_data: Vec<u8> = [0x02, 0xAA, 0xBB].to_vec();
+    let test_data: Vec<u8> = [0x02, 0xaa, 0xbb].to_vec();
 
     // Read
-    let mut ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let mut ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
             count: 0x02,
-            data: vec![0xAA, 0xBB]
+            data: vec![0xaa, 0xbb]
         },
         ret_read
     );
 
     // Add an item to the vec
-    ret_read.data.push(0xFF);
+    ret_read.data.push(0xff);
 
     // `count` field should now be increased
     ret_read.update().unwrap();
@@ -57,7 +58,7 @@ fn test_update_from_field() {
 
     // Write
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!([0x03, 0xAA, 0xBB, 0xFF].to_vec(), ret_write);
+    assert_eq!([0x03, 0xaa, 0xbb, 0xff].to_vec(), ret_write);
 }
 
 /// Update error

--- a/tests/test_catch_all.rs
+++ b/tests/test_catch_all.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod test {
+    use std::convert::{TryFrom, TryInto};
+
     use deku::prelude::*;
-    use std::convert::TryFrom;
-    use std::convert::TryInto;
 
     /// Basic test struct
     #[derive(Clone, Copy, PartialEq, Eq, Debug, DekuWrite, DekuRead)]
@@ -38,8 +38,8 @@ mod test {
 
     #[test]
     fn test_basic_a() {
-        let input = [0u8];
-        let ret_read = BasicMapping::try_from(input.as_slice()).unwrap();
+        let input: &[u8] = &[0u8];
+        let ret_read = BasicMapping::try_from(input).unwrap();
         assert_eq!(BasicMapping::A, ret_read);
         let ret_write: Vec<u8> = ret_read.try_into().unwrap();
         assert_eq!(input.to_vec(), ret_write);
@@ -47,8 +47,8 @@ mod test {
 
     #[test]
     fn test_basic_c() {
-        let input = [2u8];
-        let ret_read = BasicMapping::try_from(input.as_slice()).unwrap();
+        let input: &[u8] = &[2u8];
+        let ret_read = BasicMapping::try_from(input).unwrap();
         assert_eq!(BasicMapping::C, ret_read);
         let ret_write: Vec<u8> = ret_read.try_into().unwrap();
         assert_eq!(input.to_vec(), ret_write);
@@ -56,9 +56,9 @@ mod test {
 
     #[test]
     fn test_basic_pattern() {
-        let input = [10u8];
+        let input: &[u8] = &[10u8];
         let output = [BasicMapping::C as u8];
-        let ret_read = BasicMapping::try_from(input.as_slice()).unwrap();
+        let ret_read = BasicMapping::try_from(input).unwrap();
         assert_eq!(BasicMapping::C, ret_read);
         let ret_write: Vec<u8> = ret_read.try_into().unwrap();
         assert_eq!(output.to_vec(), ret_write);
@@ -66,9 +66,9 @@ mod test {
 
     #[test]
     fn test_advanced_remapping() {
-        let input = [1u8];
+        let input: &[u8] = &[1u8];
         let output = [1u8];
-        let ret_read = AdvancedRemapping::try_from(input.as_slice()).unwrap();
+        let ret_read = AdvancedRemapping::try_from(input).unwrap();
         assert_eq!(AdvancedRemapping::A, ret_read);
         let ret_write: Vec<u8> = ret_read.try_into().unwrap();
         assert_eq!(output.to_vec(), ret_write);
@@ -76,9 +76,9 @@ mod test {
 
     #[test]
     fn test_advanced_remapping_default_field() {
-        let input = [10u8];
+        let input: &[u8] = &[10u8];
         let output = [3u8];
-        let ret_read = AdvancedRemapping::try_from(input.as_slice()).unwrap();
+        let ret_read = AdvancedRemapping::try_from(input).unwrap();
         assert_eq!(AdvancedRemapping::C, ret_read);
         let ret_write: Vec<u8> = ret_read.try_into().unwrap();
         assert_eq!(output.to_vec(), ret_write);

--- a/tests/test_compile/cases/internal_variables.rs
+++ b/tests/test_compile/cases/internal_variables.rs
@@ -1,97 +1,93 @@
+use deku::bitvec::{BitVec, Msb0};
 use deku::prelude::*;
-use deku::bitvec::{BitVec, BitSlice, Msb0};
 
 #[derive(DekuRead, DekuWrite)]
 struct TestCount {
     field_a: u8,
     #[deku(count = "deku::byte_offset")]
-    field_b: Vec<u8>
+    field_b: Vec<u8>,
 }
 
 #[derive(DekuRead, DekuWrite)]
 struct TestBitRead {
     field_a: u8,
     #[deku(bits_read = "deku::bit_offset")]
-    field_b: Vec<u8>
+    field_b: Vec<u8>,
 }
 
 #[derive(DekuRead, DekuWrite)]
 struct TestBytesRead {
     field_a: u8,
     #[deku(bytes_read = "deku::bit_offset")]
-    field_b: Vec<u8>
+    field_b: Vec<u8>,
 }
 
 #[derive(DekuRead, DekuWrite)]
 struct TestUntil {
     field_a: u8,
     #[deku(until = "|v| *v as usize == deku::bit_offset")]
-    field_b: Vec<u8>
+    field_b: Vec<u8>,
 }
 
 #[derive(DekuRead, DekuWrite)]
 struct TestCond {
     field_a: u8,
     #[deku(cond = "deku::bit_offset == *field_a as usize")]
-    field_b: u8
+    field_b: u8,
 }
 
 #[derive(DekuRead, DekuWrite)]
 struct TestDefault {
     field_a: u8,
     #[deku(skip, default = "deku::byte_offset")]
-    field_b: usize
+    field_b: usize,
 }
 
 #[derive(DekuRead, DekuWrite)]
 struct TestMap {
     field_a: u8,
     #[deku(map = "|v: u8| -> Result<_, DekuError> { Ok(v as usize + deku::byte_offset) }")]
-    field_b: usize
+    field_b: usize,
 }
 
-fn dummy_reader(
+fn dummy_reader<R: std::io::Read>(
     offset: usize,
-    rest: &BitSlice<u8, Msb0>,
-) -> Result<(&BitSlice<u8, Msb0>, usize), DekuError> {
-    Ok((rest, offset))
+    _reader: &mut Reader<R>,
+) -> Result<usize, DekuError> {
+    Ok(0)
 }
 #[derive(DekuRead, DekuWrite)]
 struct TestReader {
     field_a: u8,
-    #[deku(reader = "dummy_reader(deku::byte_offset, deku::rest)")]
-    field_b: usize
+    #[deku(reader = "dummy_reader(deku::byte_offset, deku::reader)")]
+    field_b: usize,
 }
 
 #[derive(DekuRead, DekuWrite)]
 #[deku(ctx = "_byte_size: usize, _bit_size: usize")]
-struct ChildCtx {
-}
+struct ChildCtx {}
 #[derive(DekuRead, DekuWrite)]
 struct TestCtx {
     field_a: u8,
     #[deku(ctx = "deku::byte_offset, deku::bit_offset")]
-    field_b: ChildCtx
+    field_b: ChildCtx,
 }
 
-fn dummy_writer(
-    _offset: usize,
-    _output: &mut BitVec<u8, Msb0>,
-) -> Result<(), DekuError> {
+fn dummy_writer(_offset: usize, _output: &mut BitVec<u8, Msb0>) -> Result<(), DekuError> {
     Ok(())
 }
 #[derive(DekuRead, DekuWrite)]
 struct TestWriter {
     field_a: u8,
     #[deku(writer = "dummy_writer(deku::byte_offset, deku::output)")]
-    field_b: usize
+    field_b: usize,
 }
 
 #[derive(DekuRead, DekuWrite)]
 struct FailInternal {
     field_a: u8,
     #[deku(cond = "__deku_bit_offset == *field_a as usize")]
-    field_b: u8
+    field_b: u8,
 }
 
 fn main() {}

--- a/tests/test_compile/cases/internal_variables.stderr
+++ b/tests/test_compile/cases/internal_variables.stderr
@@ -1,5 +1,5 @@
 error: Unexpected meta-item format `attribute cannot contain `__deku_` these are internal variables. Please use the `deku::` instead.`
-  --> $DIR/internal_variables.rs:93:19
+  --> tests/test_compile/cases/internal_variables.rs:89:19
    |
-93 |     #[deku(cond = "__deku_bit_offset == *field_a as usize")]
+89 |     #[deku(cond = "__deku_bit_offset == *field_a as usize")]
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_compile/cases/unknown_endian.stderr
+++ b/tests/test_compile/cases/unknown_endian.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `variable` in this scope
- --> $DIR/unknown_endian.rs:3:10
+ --> tests/test_compile/cases/unknown_endian.rs:3:10
   |
 3 | #[derive(DekuRead)]
   |          ^^^^^^^^ not found in this scope
@@ -7,7 +7,7 @@ error[E0425]: cannot find value `variable` in this scope
   = note: this error originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `variable` in this scope
- --> $DIR/unknown_endian.rs:9:10
+ --> tests/test_compile/cases/unknown_endian.rs:9:10
   |
 9 | #[derive(DekuRead)]
   |          ^^^^^^^^ not found in this scope
@@ -15,7 +15,7 @@ error[E0425]: cannot find value `variable` in this scope
   = note: this error originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `variable` in this scope
-  --> $DIR/unknown_endian.rs:15:10
+  --> tests/test_compile/cases/unknown_endian.rs:15:10
    |
 15 | #[derive(DekuRead)]
    |          ^^^^^^^^ not found in this scope
@@ -23,27 +23,15 @@ error[E0425]: cannot find value `variable` in this scope
    = note: this error originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `variable` in this scope
-  --> $DIR/unknown_endian.rs:19:10
+  --> tests/test_compile/cases/unknown_endian.rs:19:10
    |
 19 | #[derive(DekuRead)]
    |          ^^^^^^^^ not found in this scope
    |
    = note: this error originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: unreachable statement
-  --> $DIR/unknown_endian.rs:15:10
-   |
-15 | #[derive(DekuRead)]
-   |          ^^^^^^^^
-   |          |
-   |          unreachable statement
-   |          any code following this `match` expression is unreachable, as all arms diverge
-   |
-   = note: `#[warn(unreachable_code)]` on by default
-   = note: this warning originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 warning: unreachable expression
-  --> $DIR/unknown_endian.rs:15:10
+  --> tests/test_compile/cases/unknown_endian.rs:15:10
    |
 15 | #[derive(DekuRead)]
    |          ^^^^^^^^
@@ -51,4 +39,5 @@ warning: unreachable expression
    |          unreachable expression
    |          any code following this `match` expression is unreachable, as all arms diverge
    |
+   = note: `#[warn(unreachable_code)]` on by default
    = note: this warning originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/test_from_reader.rs
+++ b/tests/test_from_reader.rs
@@ -1,0 +1,59 @@
+use deku::prelude::*;
+use no_std_io::io::Seek;
+
+#[test]
+fn test_from_reader_struct() {
+    #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+    struct TestDeku(#[deku(bits = 4)] u8);
+
+    let test_data: Vec<u8> = [0b0110_0110u8, 0b0101_1010u8].to_vec();
+    let mut c = std::io::Cursor::new(test_data);
+
+    c.rewind().unwrap();
+    let (amt_read, ret_read) = TestDeku::from_reader((&mut c, 0)).unwrap();
+    assert_eq!(amt_read, 4);
+    let mut total_read = amt_read;
+    assert_eq!(TestDeku(0b0110), ret_read);
+
+    c.rewind().unwrap();
+    let (amt_read, ret_read) = TestDeku::from_reader((&mut c, total_read)).unwrap();
+    assert_eq!(amt_read, 8);
+    total_read = amt_read;
+    assert_eq!(TestDeku(0b0110), ret_read);
+
+    env_logger::init();
+    c.rewind().unwrap();
+    let (amt_read, ret_read) = TestDeku::from_reader((&mut c, total_read)).unwrap();
+    assert_eq!(amt_read, 12);
+    total_read = amt_read;
+    assert_eq!(TestDeku(0b0101), ret_read);
+
+    c.rewind().unwrap();
+    let (amt_read, ret_read) = TestDeku::from_reader((&mut c, total_read)).unwrap();
+    assert_eq!(amt_read, 16);
+    assert_eq!(TestDeku(0b1010), ret_read);
+}
+
+#[test]
+fn test_from_reader_enum() {
+    #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+    #[deku(type = "u8", bits = "4")]
+    enum TestDeku {
+        #[deku(id = "0b0110")]
+        VariantA(#[deku(bits = "4")] u8),
+        #[deku(id = "0b0101")]
+        VariantB(#[deku(bits = "2")] u8),
+    }
+
+    let test_data = [0b0110_0110u8, 0b0101_1010u8];
+    let mut c = std::io::Cursor::new(test_data);
+
+    let (first_amt_read, ret_read) = TestDeku::from_reader((&mut c, 0)).unwrap();
+    assert_eq!(first_amt_read, 8);
+    assert_eq!(TestDeku::VariantA(0b0110), ret_read);
+    c.rewind().unwrap();
+
+    let (amt_read, ret_read) = TestDeku::from_reader((&mut c, first_amt_read)).unwrap();
+    assert_eq!(amt_read, 6 + first_amt_read);
+    assert_eq!(TestDeku::VariantB(0b10), ret_read);
+}

--- a/tests/test_generic.rs
+++ b/tests/test_generic.rs
@@ -1,19 +1,20 @@
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 #[test]
 fn test_generic_struct() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     struct TestStruct<T>
     where
-        T: deku::DekuWrite + for<'a> deku::DekuRead<'a>,
+        T: deku::DekuWrite + for<'a> deku::DekuReader<'a>,
     {
         field_a: T,
     }
 
     let test_data: Vec<u8> = [0x01].to_vec();
 
-    let ret_read = TestStruct::<u8>::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::<u8>::try_from(test_data.as_slice()).unwrap();
     assert_eq!(TestStruct::<u8> { field_a: 0x01 }, ret_read);
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
@@ -26,7 +27,7 @@ fn test_generic_enum() {
     #[deku(type = "u8")]
     enum TestEnum<T>
     where
-        T: deku::DekuWrite + for<'a> deku::DekuRead<'a>,
+        T: deku::DekuWrite + for<'a> deku::DekuReader<'a>,
     {
         #[deku(id = "1")]
         VariantT(T),
@@ -34,30 +35,8 @@ fn test_generic_enum() {
 
     let test_data: Vec<u8> = [0x01, 0x02].to_vec();
 
-    let ret_read = TestEnum::<u8>::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestEnum::<u8>::try_from(test_data.as_slice()).unwrap();
     assert_eq!(TestEnum::<u8>::VariantT(0x02), ret_read);
-
-    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(test_data, ret_write);
-}
-
-#[test]
-fn test_slice_struct() {
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    struct TestStruct<'a> {
-        #[deku(count = "2")]
-        field_a: &'a [u8],
-    }
-
-    let test_data: Vec<u8> = [0x01, 0x02].to_vec();
-
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
-    assert_eq!(
-        TestStruct {
-            field_a: test_data.as_ref()
-        },
-        ret_read
-    );
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(test_data, ret_write);

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -1,7 +1,8 @@
+use std::convert::{TryFrom, TryInto};
+
 use deku::prelude::*;
 use hexlit::hex;
 use rstest::rstest;
-use std::convert::{TryFrom, TryInto};
 
 #[rstest(input,
     case(&hex!("64656b75")),
@@ -25,8 +26,8 @@ fn test_magic_struct(input: &[u8]) {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     #[deku(magic = b"deku")]
     struct TestStruct {}
-
-    let ret_read = TestStruct::try_from(input).unwrap();
+    let input = input.to_vec();
+    let ret_read = TestStruct::try_from(input.as_slice()).unwrap();
 
     assert_eq!(TestStruct {}, ret_read);
 
@@ -62,8 +63,9 @@ fn test_magic_enum(input: &[u8]) {
         #[deku(id = "0")]
         Variant,
     }
+    let input = input.to_vec();
 
-    let ret_read = TestEnum::try_from(input).unwrap();
+    let ret_read = TestEnum::try_from(input.as_slice()).unwrap();
 
     assert_eq!(TestEnum::Variant, ret_read);
 

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::unusual_byte_groupings)]
 
-use deku::prelude::*;
 use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
 
 mod test_common;
 
@@ -34,7 +35,7 @@ fn test_read_too_much_data() {
         pub field_a: u8,
     }
 
-    let test_data = [0u8; 100].as_ref();
+    let test_data: &[u8] = &[0u8; 100];
     TestStruct::try_from(test_data).unwrap();
 }
 
@@ -53,39 +54,39 @@ fn test_unnamed_struct() {
     );
 
     let test_data: Vec<u8> = [
-        0xFF,
+        0xff,
         0b1001_0110,
-        0xAA,
-        0xBB,
-        0xCC,
-        0xDD,
+        0xaa,
+        0xbb,
+        0xcc,
+        0xdd,
         0b1001_0110,
-        0xCC,
-        0xDD,
+        0xcc,
+        0xdd,
         0x02,
-        0xBE,
-        0xEF,
+        0xbe,
+        0xef,
     ]
     .to_vec();
 
     // Read
-    let ret_read = TestUnamedStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestUnamedStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestUnamedStruct(
-            0xFF,
+            0xff,
             0b0000_0010,
             0b0001_0110,
-            native_endian!(0xBBAAu16),
-            0xCCDDu16,
+            native_endian!(0xbbaau16),
+            0xccddu16,
             NestedDeku {
                 nest_a: 0b00_100101,
                 nest_b: 0b10,
                 inner: DoubleNestedDeku {
-                    data: native_endian!(0xDDCCu16)
+                    data: native_endian!(0xddccu16)
                 }
             },
             0x02,
-            vec![0xBE, 0xEF],
+            vec![0xbe, 0xef],
         ),
         ret_read
     );
@@ -117,41 +118,41 @@ fn test_named_struct() {
     }
 
     let test_data: Vec<u8> = [
-        0xFF,
+        0xff,
         0b1001_0110,
-        0xAA,
-        0xBB,
-        0xCC,
-        0xDD,
+        0xaa,
+        0xbb,
+        0xcc,
+        0xdd,
         0b1001_0110,
-        0xCC,
-        0xDD,
+        0xcc,
+        0xdd,
         0x02,
-        0xBE,
-        0xEF,
-        0xFF,
+        0xbe,
+        0xef,
+        0xff,
     ]
     .to_vec();
 
     // Read
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
     assert_eq!(
         TestStruct {
-            field_a: 0xFF,
+            field_a: 0xff,
             field_b: 0b0000_0010,
             field_c: 0b0001_0110,
-            field_d: native_endian!(0xBBAAu16),
-            field_e: 0xCCDDu16,
+            field_d: native_endian!(0xbbaau16),
+            field_e: 0xccddu16,
             field_f: NestedDeku {
                 nest_a: 0b00_100101,
                 nest_b: 0b10,
                 inner: DoubleNestedDeku {
-                    data: native_endian!(0xDDCCu16)
+                    data: native_endian!(0xddccu16)
                 }
             },
             vec_len: 0x02,
-            vec_data: vec![0xBE, 0xEF],
-            rest: 0xFF
+            vec_data: vec![0xbe, 0xef],
+            rest: 0xff
         },
         ret_read
     );
@@ -168,11 +169,11 @@ fn test_raw_identifiers_struct() {
         pub r#type: u8,
     }
 
-    let test_data: Vec<u8> = [0xFF].to_vec();
+    let test_data: Vec<u8> = [0xff].to_vec();
 
     // Read
-    let ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
-    assert_eq!(TestStruct { r#type: 0xFF }, ret_read);
+    let ret_read = TestStruct::try_from(test_data.as_slice()).unwrap();
+    assert_eq!(TestStruct { r#type: 0xff }, ret_read);
 
     // Write
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();

--- a/tests/test_tuple.rs
+++ b/tests/test_tuple.rs
@@ -1,0 +1,24 @@
+use std::convert::{TryFrom, TryInto};
+
+use deku::prelude::*;
+use hexlit::hex;
+use rstest::*;
+
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+#[deku(type = "u8")]
+enum TestEnum {
+    #[deku(id = "1")]
+    VarA((u8, u16)),
+}
+
+#[rstest(input,expected,
+    case(&mut hex!("01ABFFAA"), TestEnum::VarA((0xAB, 0xAAFF))),
+)]
+fn test_enum(input: &mut [u8], expected: TestEnum) {
+    let input = input.to_vec();
+    let ret_read = TestEnum::try_from(input.as_slice()).unwrap();
+    assert_eq!(expected, ret_read);
+
+    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+    assert_eq!(input, ret_write);
+}


### PR DESCRIPTION
Builds upon #345 and #342. Truly fixing #44 and #344. And #252, #105. And somewhat #290.

Ok that's enough. This adds `from_reader` which can take in a Read! I also went ahead and implemented some long standing issues with this crates and _actually_ make a `Container` that can properly specialize on aligned byte reads.

There's more when I have time to review, many TODOs are still standing. But the benchmarks look good!

### benchmarks
I updated the benchmarks, so you can't just compare against master:
```
> critcmp before after
group                  after                                  before
-----                  -----                                  ------
deku_read_bits         1.24   845.8±14.29ns        ? ?/sec    1.00   679.5±11.83ns        ? ?/sec
deku_read_byte         1.00     17.8±0.25ns        ? ?/sec    2.12     37.8±3.35ns        ? ?/sec
deku_read_enum         1.00     15.3±0.15ns        ? ?/sec    2.04     31.2±0.81ns        ? ?/sec
deku_read_vec          1.00    676.8±7.04ns        ? ?/sec    2.16  1459.5±40.22ns        ? ?/sec
deku_read_vec_perf     1.00   640.6±34.63ns        ? ?/sec    2.54  1627.4±31.78ns        ? ?/sec
deku_write_bits        1.00    125.3±3.10ns        ? ?/sec    1.04   130.2±11.12ns        ? ?/sec
deku_write_byte        1.00    161.6±4.86ns        ? ?/sec    1.02    165.0±5.91ns        ? ?/sec
deku_write_enum        1.00    105.6±1.06ns        ? ?/sec    1.03    109.0±7.20ns        ? ?/sec
deku_write_vec         1.00      4.6±0.04µs        ? ?/sec    1.06      4.9±0.07µs        ? ?/sec
deku_write_vec_perf    1.00      4.6±0.08µs        ? ?/sec    1.06      4.9±0.06µs        ? ?/sec
```



### todo
- [x] Add example of using new `from_reader` to read from file
- [x] Add MSRV
- [x] Using `--engine = llvm` on tarpulin might produce more accurate coverage results? Update: still inaccurate. https://github.com/taiki-e/cargo-llvm-cov seems to be more accurate. `cargo +nightly llvm-cov --doctests --release --html --ignore-filename-regex attributes` produces very good results.
- [x] Fix/Enhance "logging" feature
- [x] I think I need to keep around the old derives that gives `read(..)` for `no_std` enviroments
- [x] A ton of testing. I'll test out with my own crates and make sure this whole API works.
- [x] Conversation about things like `#[deku(cond = "!deku::rest.is_empty()")]` not working. not sure the solution on this since there is no way of knowing if `Read` is done except trying to read [u8; 1] and seeing it it errors and buffer the results
- [x] BufRead impl should __really__ be encouraged for most big reads. Results may vary but a PERFORMANCE.md might be good.

### Example usage
- UBI: :heavy_check_mark:  https://github.com/wcampbell0x2a/income 
- SquashFS: :heavy_check_mark: https://github.com/wcampbell0x2a/backhand/pull/286 [<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/wcampbell0x2a/backhand/main.yml?branch=deku-update&style=for-the-badge" height="20">](https://github.com/wcampbell0x2a/backhand/actions?query=branch%3Adeku-update)
- WIP: :heavy_check_mark: adsb: https://github.com/rsadsb/adsb_deku/pull/212 [<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/wcampbell0x2a/backhand/main.yml?branch=update-deku&style=for-the-badge" height="20">](https://github.com/wcampbell0x2a/backhand/actions?query=branch%3Aupdate-deku)
- CPIO: :heavy_check_mark: https://github.com/wcampbell0x2a/cpio-deku
- asterix: https://github.com/wcampbell0x2a/asterix-rs/pull/9
- grain of salt benchmarks: https://github.com/wcampbell0x2a/deku-bench/pull/1
