### PR TITLE
Impl reader+writer seek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Add attributes `seek_from_start`, `seek_from_current`, `seek_from_end`, and `seek_rewind` to control the position of the reader before reading a field ([#360](https://github.com/sharksforarms/deku/pull/360))
 
 ## [0.17.0] - 2024-04-23
 
@@ -21,7 +22,6 @@
      VariantC((u8, u8)),
  }
 ```
-- Add attributes `seek_from_start`, `seek_from_current`, `seek_from_end`, and `seek_rewind` to control the position of the reader before reading a field ([#360](https://github.com/sharksforarms/deku/pull/360))
 
 ### Updated Reader API
 - Changed API of reading to use `io::Read`, bringing massive performance and usability improvements ([#352](https://github.com/sharksforarms/deku/pull/352))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
      VariantC((u8, u8)),
  }
 ```
+- Add attributes `seek_from_start`, `seek_from_current`, `seek_from_end`, and `seek_rewind` to control the position of the reader before reading a field ([#360](https://github.com/sharksforarms/deku/pull/360))
 
 ### Updated Reader API
 - Changed API of reading to use `io::Read`, bringing massive performance and usability improvements ([#352](https://github.com/sharksforarms/deku/pull/352))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ error_in_core = []
 deku_derive = { version = "^0.17.0", path = "deku-derive", default-features = false}
 bitvec = { version = "1.0.1", default-features = false }
 log = { version = "0.4.21", optional = true }
-no_std_io = { version = "0.6.0", default-features = false, features = ["alloc"] }
+no_std_io = { version = "0.8.0", default-features = false, features = ["alloc"], package = "no_std_io2" }
 rustversion = "1.0.16"
 
 [dev-dependencies]

--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read};
+use std::io::{Cursor, Read, Seek};
 
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use deku::prelude::*;
@@ -38,7 +38,7 @@ fn deku_write<T: DekuContainerWrite>(input: &T) {
     let _v = input.to_bytes().unwrap();
 }
 
-fn deku_read<T: for<'a> DekuContainerRead<'a>>(mut reader: impl Read) {
+fn deku_read<T: for<'a> DekuContainerRead<'a>>(mut reader: impl Read + Seek) {
     let mut reader = Reader::new(&mut reader);
     let _v = T::from_reader_with_ctx(&mut reader, ()).unwrap();
 }

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -140,6 +140,9 @@ struct DekuData {
 
     /// enum only: byte size of the enum `id`
     bytes: Option<Num>,
+
+    /// struct only: seek from current position
+    seek_from_current: Option<Num>,
 }
 
 impl DekuData {
@@ -188,6 +191,7 @@ impl DekuData {
             id_type: receiver.id_type?,
             bits: receiver.bits,
             bytes: receiver.bytes,
+            seek_from_current: receiver.seek_from_current,
         };
 
         DekuData::validate(&data)?;
@@ -444,6 +448,12 @@ struct FieldData {
 
     // assert value of field
     assert_eq: Option<TokenStream>,
+
+    //seek_rewind: Option<Num>,
+    seek_from_current: Option<TokenStream>,
+    //seek_from_end: Option<Num>,
+    //seek_from_start: Option<Num>,
+    //seek_position: Option<Num>,
 }
 
 impl FieldData {
@@ -481,6 +491,11 @@ impl FieldData {
             cond: receiver.cond?,
             assert: receiver.assert?,
             assert_eq: receiver.assert_eq?,
+            //seek_rewind: receiver.seek_rewind?,
+            seek_from_current: receiver.seek_from_current?,
+            //seek_from_end: receiver.seek_from_end?,
+            //seek_from_start: receiver.seek_from_start?,
+            //seek_position: receiver.seek_position?,
         };
 
         FieldData::validate(&data)?;
@@ -668,6 +683,9 @@ struct DekuReceiver {
     /// enum only: byte size of the enum `id`
     #[darling(default)]
     bytes: Option<Num>,
+
+    #[darling(default)]
+    seek_from_current: Option<Num>,
 }
 
 type ReplacementError = TokenStream;
@@ -848,6 +866,10 @@ struct DekuFieldReceiver {
     // assert value of field
     #[darling(default = "default_res_opt", map = "map_litstr_as_tokenstream")]
     assert_eq: Result<Option<TokenStream>, ReplacementError>,
+
+    /// seek from current position
+    #[darling(default = "default_res_opt", map = "map_litstr_as_tokenstream")]
+    seek_from_current: Result<Option<TokenStream>, ReplacementError>,
 }
 
 /// Receiver for the variant-level attributes inside a enum

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -118,7 +118,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
     tokens.extend(quote! {
         impl #imp ::#crate_::DekuReader<#lifetime, #ctx_types> for #ident #wher {
             #[inline]
-            fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, #ctx_arg) -> core::result::Result<Self, ::#crate_::DekuError> {
+            fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read + ::#crate_::no_std_io::Seek>(__deku_reader: &mut ::#crate_::reader::Reader<R>, #ctx_arg) -> core::result::Result<Self, ::#crate_::DekuError> {
                 #read_body
             }
         }
@@ -130,7 +130,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             impl #imp ::#crate_::DekuReader<#lifetime> for #ident #wher {
                 #[inline]
-                fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, _: ()) -> core::result::Result<Self, ::#crate_::DekuError> {
+                fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read + ::#crate_::no_std_io::Seek>(__deku_reader: &mut ::#crate_::reader::Reader<R>, _: ()) -> core::result::Result<Self, ::#crate_::DekuError> {
                     #read_body
                 }
             }
@@ -381,7 +381,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         #[allow(non_snake_case)]
         impl #imp ::#crate_::DekuReader<#lifetime, #ctx_types> for #ident #wher {
             #[inline]
-            fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, #ctx_arg) -> core::result::Result<Self, ::#crate_::DekuError> {
+            fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read + ::#crate_::no_std_io::Seek>(__deku_reader: &mut ::#crate_::reader::Reader<R>, #ctx_arg) -> core::result::Result<Self, ::#crate_::DekuError> {
                 #read_body
             }
         }
@@ -394,7 +394,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             #[allow(non_snake_case)]
             impl #imp ::#crate_::DekuReader<#lifetime> for #ident #wher {
                 #[inline]
-                fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, _: ()) -> core::result::Result<Self, ::#crate_::DekuError> {
+                fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read + ::#crate_::no_std_io::Seek>(__deku_reader: &mut ::#crate_::reader::Reader<R>, _: ()) -> core::result::Result<Self, ::#crate_::DekuError> {
                     #read_body
                 }
             }
@@ -795,7 +795,7 @@ pub fn emit_container_read(
         impl #imp ::#crate_::DekuContainerRead<#lifetime> for #ident #wher {
             #[allow(non_snake_case)]
             #[inline]
-            fn from_reader<'a, R: ::#crate_::no_std_io::Read>(__deku_input: (&'a mut R, usize)) -> core::result::Result<(usize, Self), ::#crate_::DekuError> {
+            fn from_reader<'a, R: ::#crate_::no_std_io::Read + ::#crate_::no_std_io::Seek>(__deku_input: (&'a mut R, usize)) -> core::result::Result<(usize, Self), ::#crate_::DekuError> {
                 #from_reader_body
             }
 

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -568,6 +568,17 @@ fn emit_field_read(
         &f.assert_eq,
     ];
 
+    let seek = if let Some(num) = &f.seek_from_current {
+        quote! {
+            use ::#crate_::no_std_io::Seek;
+            use ::#crate_::no_std_io::SeekFrom;
+            // TODO: use ?
+            __deku_reader.seek(SeekFrom::Current(i64::try_from(#num).unwrap())).unwrap();
+        }
+    } else {
+        quote! {}
+    };
+
     let (bit_offset, byte_offset) = emit_bit_byte_offsets(&field_check_vars);
 
     let field_map = f
@@ -761,6 +772,7 @@ fn emit_field_read(
     };
 
     let field_read = quote! {
+        #seek
         #pad_bits_before
 
         #bit_offset

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -570,10 +570,42 @@ fn emit_field_read(
 
     let seek = if let Some(num) = &f.seek_from_current {
         quote! {
-            use ::#crate_::no_std_io::Seek;
-            use ::#crate_::no_std_io::SeekFrom;
-            // TODO: use ?
-            __deku_reader.seek(SeekFrom::Current(i64::try_from(#num).unwrap())).unwrap();
+            {
+                use ::#crate_::no_std_io::Seek;
+                use ::#crate_::no_std_io::SeekFrom;
+                if let Err(e) = __deku_reader.seek(SeekFrom::Current(i64::try_from(#num).unwrap())) {
+                    return Err(DekuError::Io(e.kind()));
+                }
+            }
+        }
+    } else if let Some(num) = &f.seek_from_end {
+        quote! {
+            {
+                use ::#crate_::no_std_io::Seek;
+                use ::#crate_::no_std_io::SeekFrom;
+                if let Err(e) = __deku_reader.seek(SeekFrom::End(i64::try_from(#num).unwrap())) {
+                    return Err(DekuError::Io(e.kind()));
+                }
+            }
+        }
+    } else if let Some(num) = &f.seek_from_start {
+        quote! {
+            {
+                use ::#crate_::no_std_io::Seek;
+                use ::#crate_::no_std_io::SeekFrom;
+                if let Err(e) = __deku_reader.seek(SeekFrom::Start(u64::try_from(#num).unwrap())) {
+                    return Err(DekuError::Io(e.kind()));
+                }
+            }
+        }
+    } else if f.seek_rewind {
+        quote! {
+            {
+                use ::#crate_::no_std_io::Seek;
+                if let Err(e) = __deku_reader.rewind() {
+                    return Err(DekuError::Io(e.kind()));
+                }
+            }
         }
     } else {
         quote! {}

--- a/examples/custom_reader_and_writer.rs
+++ b/examples/custom_reader_and_writer.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use deku::ctx::BitSize;
 use deku::writer::Writer;
 use deku::{prelude::*, DekuWriter};
-use no_std_io::io::Write;
+use no_std_io::io::{Seek, Write};
 
 fn bit_flipper_read<R: std::io::Read + std::io::Seek>(
     field_a: u8,
@@ -25,7 +25,7 @@ fn bit_flipper_read<R: std::io::Read + std::io::Seek>(
     Ok(value)
 }
 
-fn bit_flipper_write<W: Write>(
+fn bit_flipper_write<W: Write + Seek>(
     field_a: u8,
     field_b: u8,
     writer: &mut Writer<W>,

--- a/examples/custom_reader_and_writer.rs
+++ b/examples/custom_reader_and_writer.rs
@@ -5,7 +5,7 @@ use deku::writer::Writer;
 use deku::{prelude::*, DekuWriter};
 use no_std_io::io::Write;
 
-fn bit_flipper_read<R: std::io::Read>(
+fn bit_flipper_read<R: std::io::Read + std::io::Seek>(
     field_a: u8,
     reader: &mut Reader<R>,
     bit_size: BitSize,
@@ -59,8 +59,9 @@ struct DekuTest {
 
 fn main() {
     let test_data = [0x01, 0b1001_0110];
+    let mut cursor = std::io::Cursor::new(test_data);
 
-    let (_read_amt, ret_read) = DekuTest::from_reader((&mut test_data.as_slice(), 0)).unwrap();
+    let (_read_amt, ret_read) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 
     assert_eq!(
         ret_read,

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -53,9 +53,6 @@ enum DekuEnum {
 | [pad_bits_after](#pad_bits_after) | field | Skip bits after reading, pad after writing
 | [cond](#cond) | field | Conditional expression for the field
 | [default](#default) | field | Provide default value. Used with [skip](#skip) or [cond](#cond)
-| [seek_from_current](#seek_from_current) | field | Sets the offset of reader to the current position plus the specified number of bytes
-| [seek_from_end](#seek_from_end) | field | Sets the offset to the size of reader plus the specified number of bytes
-| [seek_from_start](#seek_from_start) | field | Sets the offset to provided number of bytes
 | [bits](#bits) | field | Set the bit-size of the field
 | [reader](#readerwriter) | variant, field | Custom reader code
 | [writer](#readerwriter) | variant, field | Custom writer code
@@ -791,89 +788,6 @@ let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { field_a: 0x01, field_b: Some(0x01), field_c: 0x02 },
-    value
-);
-```
-
-# seek_from_current
-
-Using the internal reader, seek to current position plus offset before reading field.
-
-Example:
-
-```rust
-# use deku::prelude::*;
-# use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
-#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-struct DekuTest {
-    // how many following bytes to skip
-    skip_u8: u8,
-    #[deku(seek_from_current = "*skip_u8")]
-    byte: u8,
-}
-
-let data: &[u8] = &[0x01, 0x00, 0x02];
-let mut cursor = Cursor::new(data);
-
-let (_amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
-
-assert_eq!(
-    DekuTest { skip_u8: 0x01, byte: 0x02 },
-    value
-);
-```
-
-# seek_from_end
-
-Using the internal reader, seek to size of reader plus offset before reading field.
-
-Example:
-
-```rust
-# use deku::prelude::*;
-# use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
-#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-struct DekuTest {
-    #[deku(seek_from_end = "-2")]
-    byte: u8,
-}
-
-let data: &[u8] = &[0x01, 0xff, 0x02];
-let mut cursor = Cursor::new(data);
-
-let (_amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
-
-assert_eq!(
-    DekuTest { byte: 0xff },
-    value
-);
-```
-
-# seek_from_start
-
-Using the internal reader, seek from reader start plus offset before reading field.
-
-Example:
-
-```rust
-# use deku::prelude::*;
-# use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
-#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-struct DekuTest {
-    #[deku(seek_from_start = "2")]
-    byte: u8,
-}
-
-let data: &[u8] = &[0x01, 0xff, 0x02];
-let mut cursor = Cursor::new(data);
-
-let (_amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
-
-assert_eq!(
-    DekuTest { byte: 0x02 },
     value
 );
 ```

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -848,7 +848,7 @@ struct DekuTest {
 
 impl DekuTest {
     /// Read and convert to String
-    fn read<R: std::io::Read>(
+    fn read<R: std::io::Read + std::io::Seek>(
         reader: &mut deku::reader::Reader<R>,
     ) -> Result<String, DekuError> {
         let value = u8::from_reader_with_ctx(reader, ())?;

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -53,7 +53,10 @@ enum DekuEnum {
 | [pad_bits_after](#pad_bits_after) | field | Skip bits after reading, pad after writing
 | [cond](#cond) | field | Conditional expression for the field
 | [default](#default) | field | Provide default value. Used with [skip](#skip) or [cond](#cond)
-| [map](#map) | field | Apply a function over the result of reading
+| [seek_from_current](#seek_from_current) | field | Sets the offset of reader to the current position plus the specified number of bytes
+| [seek_from_end](#seek_from_end) | field | Sets the offset to the size of reader plus the specified number of bytes
+| [seek_from_start](#seek_from_start) | field | Sets the offset to provided number of bytes
+| [bits](#bits) | field | Set the bit-size of the field
 | [reader](#readerwriter) | variant, field | Custom reader code
 | [writer](#readerwriter) | variant, field | Custom writer code
 | [ctx](#ctx) | top-level, field| Context list for context sensitive parsing
@@ -788,6 +791,89 @@ let value = DekuTest::try_from(data).unwrap();
 
 assert_eq!(
     DekuTest { field_a: 0x01, field_b: Some(0x01), field_c: 0x02 },
+    value
+);
+```
+
+# seek_from_current
+
+Using the internal reader, seek to current position plus offset before reading field.
+
+Example:
+
+```rust
+# use deku::prelude::*;
+# use std::io::Cursor;
+# use std::convert::{TryInto, TryFrom};
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+struct DekuTest {
+    // how many following bytes to skip
+    skip_u8: u8,
+    #[deku(seek_from_current = "*skip_u8")]
+    byte: u8,
+}
+
+let data: &[u8] = &[0x01, 0x00, 0x02];
+let mut cursor = Cursor::new(data);
+
+let (_amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
+
+assert_eq!(
+    DekuTest { skip_u8: 0x01, byte: 0x02 },
+    value
+);
+```
+
+# seek_from_end
+
+Using the internal reader, seek to size of reader plus offset before reading field.
+
+Example:
+
+```rust
+# use deku::prelude::*;
+# use std::io::Cursor;
+# use std::convert::{TryInto, TryFrom};
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+struct DekuTest {
+    #[deku(seek_from_end = "-2")]
+    byte: u8,
+}
+
+let data: &[u8] = &[0x01, 0xff, 0x02];
+let mut cursor = Cursor::new(data);
+
+let (_amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
+
+assert_eq!(
+    DekuTest { byte: 0xff },
+    value
+);
+```
+
+# seek_from_start
+
+Using the internal reader, seek from reader start plus offset before reading field.
+
+Example:
+
+```rust
+# use deku::prelude::*;
+# use std::io::Cursor;
+# use std::convert::{TryInto, TryFrom};
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+struct DekuTest {
+    #[deku(seek_from_start = "2")]
+    byte: u8,
+}
+
+let data: &[u8] = &[0x01, 0xff, 0x02];
+let mut cursor = Cursor::new(data);
+
+let (_amt_read, value) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
+
+assert_eq!(
+    DekuTest { byte: 0x02 },
     value
 );
 ```

--- a/src/impls/bool.rs
+++ b/src/impls/bool.rs
@@ -37,7 +37,11 @@ where
     u8: DekuWriter<Ctx>,
 {
     /// wrapper around u8::write with consideration to context, such as bit size
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, inner_ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        inner_ctx: Ctx,
+    ) -> Result<(), DekuError> {
         match self {
             true => (0x01u8).to_writer(writer, inner_ctx),
             false => (0x00u8).to_writer(writer, inner_ctx),
@@ -81,16 +85,16 @@ mod tests {
 
     #[test]
     fn test_writer() {
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         true.to_writer(&mut writer, BitSize(1)).unwrap();
         assert_eq!(vec![true], writer.rest());
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         true.to_writer(&mut writer, ()).unwrap();
-        assert_eq!(vec![1], writer.inner);
+        assert_eq!(vec![1], writer.inner.into_inner());
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         false.to_writer(&mut writer, ()).unwrap();
-        assert_eq!(vec![0], writer.inner);
+        assert_eq!(vec![0], writer.inner.into_inner());
     }
 }

--- a/src/impls/bool.rs
+++ b/src/impls/bool.rs
@@ -1,4 +1,4 @@
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 #[cfg(feature = "alloc")]
 use alloc::borrow::Cow;
@@ -14,7 +14,7 @@ where
     Ctx: Copy,
     u8: DekuReader<'a, Ctx>,
 {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         inner_ctx: Ctx,
     ) -> Result<bool, DekuError> {
@@ -62,8 +62,9 @@ mod tests {
         #[should_panic(expected = "Parse(\"cannot parse bool value: 2\")")]
         case(&hex!("02"), false),
     )]
-    fn test_bool(mut input: &[u8], expected: bool) {
-        let mut reader = Reader::new(&mut input);
+    fn test_bool(input: &[u8], expected: bool) {
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
         let res_read = bool::from_reader_with_ctx(&mut reader, ()).unwrap();
         assert_eq!(expected, res_read);
     }

--- a/src/impls/boxed.rs
+++ b/src/impls/boxed.rs
@@ -1,4 +1,4 @@
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -13,7 +13,7 @@ where
     T: DekuReader<'a, Ctx>,
     Ctx: Copy,
 {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         inner_ctx: Ctx,
     ) -> Result<Self, DekuError> {
@@ -28,7 +28,7 @@ where
     Ctx: Copy,
     Predicate: FnMut(&T) -> bool,
 {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         (limit, inner_ctx): (Limit<T, Predicate>, Ctx),
     ) -> Result<Self, DekuError> {

--- a/src/impls/boxed.rs
+++ b/src/impls/boxed.rs
@@ -44,7 +44,11 @@ where
     Ctx: Copy,
 {
     /// Write all `T`s to bits
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        ctx: Ctx,
+    ) -> Result<(), DekuError> {
         for v in self.as_ref() {
             v.to_writer(writer, ctx)?;
         }
@@ -58,7 +62,11 @@ where
     Ctx: Copy,
 {
     /// Write all `T`s to bits
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        ctx: Ctx,
+    ) -> Result<(), DekuError> {
         self.as_ref().to_writer(writer, ctx)?;
         Ok(())
     }
@@ -87,9 +95,9 @@ mod tests {
         let res_read = <Box<u16>>::from_reader_with_ctx(&mut reader, ()).unwrap();
         assert_eq!(expected, res_read);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read.to_writer(&mut writer, ()).unwrap();
-        assert_eq!(input.to_vec(), writer.inner);
+        assert_eq!(input.to_vec(), writer.inner.into_inner());
     }
 
     // Note: Copied tests from vec.rs impl
@@ -130,11 +138,11 @@ mod tests {
 
         assert_eq!(input[..expected_write.len()].to_vec(), expected_write);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read
             .to_writer(&mut writer, (endian, BitSize(bit_size)))
             .unwrap();
-        assert_eq!(expected_write, writer.inner);
+        assert_eq!(expected_write, writer.inner.into_inner());
 
         assert_eq!(input[..expected_write.len()].to_vec(), expected_write);
     }

--- a/src/impls/cow.rs
+++ b/src/impls/cow.rs
@@ -1,6 +1,6 @@
 use std::borrow::{Borrow, Cow};
 
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::reader::Reader;
 use crate::writer::Writer;
@@ -11,7 +11,7 @@ where
     T: DekuReader<'a, Ctx> + Clone,
     Ctx: Copy,
 {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         inner_ctx: Ctx,
     ) -> Result<Self, DekuError> {

--- a/src/impls/cow.rs
+++ b/src/impls/cow.rs
@@ -26,7 +26,11 @@ where
     Ctx: Copy,
 {
     /// Write T from Cow<T>
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, inner_ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        inner_ctx: Ctx,
+    ) -> Result<(), DekuError> {
         (self.borrow() as &T).to_writer(writer, inner_ctx)
     }
 }
@@ -51,8 +55,8 @@ mod tests {
         let res_read = <Cow<u16>>::from_reader_with_ctx(&mut reader, ()).unwrap();
         assert_eq!(expected, res_read);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read.to_writer(&mut writer, ()).unwrap();
-        assert_eq!(input.to_vec(), writer.inner);
+        assert_eq!(input.to_vec(), writer.inner.into_inner());
     }
 }

--- a/src/impls/cstring.rs
+++ b/src/impls/cstring.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 use std::ffi::CString;
 
 use crate::reader::Reader;
@@ -21,7 +21,7 @@ impl<'a, Ctx: Copy> DekuReader<'a, Ctx> for CString
 where
     u8: DekuReader<'a, Ctx>,
 {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         inner_ctx: Ctx,
     ) -> Result<Self, DekuError> {

--- a/src/impls/cstring.rs
+++ b/src/impls/cstring.rs
@@ -11,7 +11,11 @@ impl<Ctx: Copy> DekuWriter<Ctx> for CString
 where
     u8: DekuWriter<Ctx>,
 {
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        ctx: Ctx,
+    ) -> Result<(), DekuError> {
         let bytes = self.as_bytes_with_nul();
         bytes.to_writer(writer, ctx)
     }
@@ -69,8 +73,11 @@ mod tests {
         cursor.read_to_end(&mut buf).unwrap();
         assert_eq!(expected_rest, buf);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read.to_writer(&mut writer, ()).unwrap();
-        assert_eq!(vec![b't', b'e', b's', b't', b'\0'], writer.inner);
+        assert_eq!(
+            vec![b't', b'e', b's', b't', b'\0'],
+            writer.inner.into_inner()
+        );
     }
 }

--- a/src/impls/hashmap.rs
+++ b/src/impls/hashmap.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::ctx::*;
 use crate::writer::Writer;
@@ -15,7 +15,7 @@ use crate::{DekuError, DekuReader, DekuWriter};
 /// and a borrow of the latest value to have been read. It should return `true` if reading
 /// should now stop, and `false` otherwise
 #[allow(clippy::type_complexity)]
-fn from_reader_with_ctx_hashmap_with_predicate<'a, K, V, S, Ctx, Predicate, R: Read>(
+fn from_reader_with_ctx_hashmap_with_predicate<'a, K, V, S, Ctx, Predicate, R: Read + Seek>(
     reader: &mut crate::reader::Reader<R>,
     capacity: Option<usize>,
     ctx: Ctx,
@@ -42,7 +42,7 @@ where
     Ok(res)
 }
 
-fn from_reader_with_ctx_hashmap_to_end<'a, K, V, S, Ctx, R: Read>(
+fn from_reader_with_ctx_hashmap_to_end<'a, K, V, S, Ctx, R: Read + Seek>(
     reader: &mut crate::reader::Reader<R>,
     capacity: Option<usize>,
     ctx: Ctx,
@@ -92,7 +92,7 @@ where
     /// expected.insert(100, 0x04030201);
     /// assert_eq!(expected, map)
     /// ```
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut crate::reader::Reader<R>,
         (limit, inner_ctx): (Limit<(K, V), Predicate>, Ctx),
     ) -> Result<Self, DekuError>
@@ -175,7 +175,7 @@ where
     Predicate: FnMut(&(K, V)) -> bool,
 {
     /// Read `K, V`s until the given limit from input for types which don't require context.
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut crate::reader::Reader<R>,
         limit: Limit<(K, V), Predicate>,
     ) -> Result<Self, DekuError>

--- a/src/impls/hashmap.rs
+++ b/src/impls/hashmap.rs
@@ -198,15 +198,21 @@ impl<K: DekuWriter<Ctx>, V: DekuWriter<Ctx>, S, Ctx: Copy> DekuWriter<Ctx> for H
     /// # use deku::writer::Writer;
     /// # use deku::bitvec::{Msb0, bitvec};
     /// # use std::collections::HashMap;
+    /// # use std::io::Cursor;
     /// let mut out_buf = vec![];
-    /// let mut writer = Writer::new(&mut out_buf);
+    /// let mut cursor = Cursor::new(&mut out_buf);
+    /// let mut writer = Writer::new(&mut cursor);
     /// let mut map = HashMap::<u8, u32>::default();
     /// map.insert(100, 0x04030201);
     /// map.to_writer(&mut writer, Endian::Big).unwrap();
     /// let expected: Vec<u8> = vec![100, 4, 3, 2, 1];
     /// assert_eq!(expected, out_buf);
     /// ```
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, inner_ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        inner_ctx: Ctx,
+    ) -> Result<(), DekuError> {
         for kv in self {
             kv.to_writer(writer, inner_ctx)?;
         }
@@ -302,8 +308,8 @@ mod tests {
         case::normal(fxhashmap!{0x11u8 => 0xAABBu16, 0x23u8 => 0xCCDDu16}, Endian::Little, vec![0x11, 0xBB, 0xAA, 0x23, 0xDD, 0xCC]),
     )]
     fn test_hashmap_write(input: FxHashMap<u8, u16>, endian: Endian, expected: Vec<u8>) {
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         input.to_writer(&mut writer, endian).unwrap();
-        assert_eq!(expected, writer.inner);
+        assert_eq!(expected, writer.inner.into_inner());
     }
 }

--- a/src/impls/hashset.rs
+++ b/src/impls/hashset.rs
@@ -188,13 +188,19 @@ impl<T: DekuWriter<Ctx>, S, Ctx: Copy> DekuWriter<Ctx> for HashSet<T, S> {
     /// # use deku::writer::Writer;
     /// # use deku::bitvec::{Msb0, bitvec};
     /// # use std::collections::HashSet;
+    /// # use std::io::Cursor;
     /// let mut out_buf = vec![];
-    /// let mut writer = Writer::new(&mut out_buf);
+    /// let mut cursor = Cursor::new(&mut out_buf);
+    /// let mut writer = Writer::new(&mut cursor);
     /// let set: HashSet<u8> = vec![1].into_iter().collect();
     /// set.to_writer(&mut writer, Endian::Big).unwrap();
     /// assert_eq!(out_buf, vec![1]);
     /// ```
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, inner_ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        inner_ctx: Ctx,
+    ) -> Result<(), DekuError> {
         for v in self {
             v.to_writer(writer, inner_ctx)?;
         }
@@ -271,9 +277,9 @@ mod tests {
         case::normal(vec![0xAABB, 0xCCDD].into_iter().collect(), Endian::Little, vec![0xDD, 0xCC, 0xBB, 0xAA]),
     )]
     fn test_hashset_write(input: FxHashSet<u16>, endian: Endian, expected: Vec<u8>) {
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         input.to_writer(&mut writer, endian).unwrap();
-        assert_eq!(expected, writer.inner);
+        assert_eq!(expected, writer.inner.into_inner());
     }
 
     // Note: These tests also exist in boxed.rs
@@ -314,10 +320,10 @@ mod tests {
         cursor.read_to_end(&mut buf).unwrap();
         assert_eq!(expected_rest_bytes, buf);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read
             .to_writer(&mut writer, (endian, BitSize(bit_size)))
             .unwrap();
-        assert_eq!(expected_write, writer.inner);
+        assert_eq!(expected_write, writer.inner.into_inner());
     }
 }

--- a/src/impls/hashset.rs
+++ b/src/impls/hashset.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::hash::{BuildHasher, Hash};
 
 use crate::writer::Writer;
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::ctx::*;
 use crate::{DekuError, DekuReader, DekuWriter};
@@ -15,7 +15,7 @@ use crate::{DekuError, DekuReader, DekuWriter};
 /// and a borrow of the latest value to have been read. It should return `true` if reading
 /// should now stop, and `false` otherwise
 #[allow(clippy::type_complexity)]
-fn from_reader_with_ctx_hashset_with_predicate<'a, T, S, Ctx, Predicate, R: Read>(
+fn from_reader_with_ctx_hashset_with_predicate<'a, T, S, Ctx, Predicate, R: Read + Seek>(
     reader: &mut crate::reader::Reader<R>,
     capacity: Option<usize>,
     ctx: Ctx,
@@ -41,7 +41,7 @@ where
     Ok(res)
 }
 
-fn from_reader_with_ctx_hashset_to_end<'a, T, S, Ctx, R: Read>(
+fn from_reader_with_ctx_hashset_to_end<'a, T, S, Ctx, R: Read + Seek>(
     reader: &mut crate::reader::Reader<R>,
     capacity: Option<usize>,
     ctx: Ctx,
@@ -86,7 +86,7 @@ where
     /// let set = HashSet::<u32>::from_reader_with_ctx(&mut reader, (1.into(), Endian::Little)).unwrap();
     /// assert_eq!(expected, set)
     /// ```
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut crate::reader::Reader<R>,
         (limit, inner_ctx): (Limit<T, Predicate>, Ctx),
     ) -> Result<Self, DekuError>
@@ -165,7 +165,7 @@ impl<'a, T: DekuReader<'a> + Eq + Hash, S: BuildHasher + Default, Predicate: FnM
     DekuReader<'a, Limit<T, Predicate>> for HashSet<T, S>
 {
     /// Read `T`s until the given limit from input for types which don't require context.
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut crate::reader::Reader<R>,
         limit: Limit<T, Predicate>,
     ) -> Result<Self, DekuError>

--- a/src/impls/ipaddr.rs
+++ b/src/impls/ipaddr.rs
@@ -23,7 +23,11 @@ impl<Ctx> DekuWriter<Ctx> for Ipv4Addr
 where
     u32: DekuWriter<Ctx>,
 {
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        ctx: Ctx,
+    ) -> Result<(), DekuError> {
         let ip: u32 = (*self).into();
         ip.to_writer(writer, ctx)
     }
@@ -46,7 +50,11 @@ impl<Ctx> DekuWriter<Ctx> for Ipv6Addr
 where
     u128: DekuWriter<Ctx>,
 {
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        ctx: Ctx,
+    ) -> Result<(), DekuError> {
         let ip: u128 = (*self).into();
         ip.to_writer(writer, ctx)
     }
@@ -57,7 +65,11 @@ where
     Ipv6Addr: DekuWriter<Ctx>,
     Ipv4Addr: DekuWriter<Ctx>,
 {
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        ctx: Ctx,
+    ) -> Result<(), DekuError> {
         match self {
             IpAddr::V4(ipv4) => ipv4.to_writer(writer, ctx),
             IpAddr::V6(ipv6) => ipv6.to_writer(writer, ctx),
@@ -83,9 +95,9 @@ mod tests {
         let res_read = Ipv4Addr::from_reader_with_ctx(&mut reader, endian).unwrap();
         assert_eq!(expected, res_read);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read.to_writer(&mut writer, endian).unwrap();
-        assert_eq!(input.to_vec(), writer.inner);
+        assert_eq!(input.to_vec(), writer.inner.into_inner());
     }
 
     #[rstest(input, endian, expected,
@@ -98,28 +110,28 @@ mod tests {
         let res_read = Ipv6Addr::from_reader_with_ctx(&mut reader, endian).unwrap();
         assert_eq!(expected, res_read);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read.to_writer(&mut writer, endian).unwrap();
-        assert_eq!(input.to_vec(), writer.inner);
+        assert_eq!(input.to_vec(), writer.inner.into_inner());
     }
 
     #[test]
     fn test_ip_addr_write() {
         let ip_addr = IpAddr::V4(Ipv4Addr::new(145, 254, 160, 237));
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         ip_addr.to_writer(&mut writer, Endian::Little).unwrap();
-        assert_eq!(vec![237, 160, 254, 145], writer.inner);
+        assert_eq!(vec![237, 160, 254, 145], writer.inner.into_inner());
 
         let ip_addr = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x02ff));
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         ip_addr.to_writer(&mut writer, Endian::Little).unwrap();
         assert_eq!(
             vec![
                 0xff, 0x02, 0x0a, 0xc0, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 0x00, 0x00
             ],
-            writer.inner
+            writer.inner.into_inner()
         );
     }
 }

--- a/src/impls/ipaddr.rs
+++ b/src/impls/ipaddr.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::reader::Reader;
 use crate::writer::Writer;
@@ -10,7 +10,7 @@ impl<'a, Ctx> DekuReader<'a, Ctx> for Ipv4Addr
 where
     u32: DekuReader<'a, Ctx>,
 {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         inner_ctx: Ctx,
     ) -> Result<Self, DekuError> {
@@ -33,7 +33,7 @@ impl<'a, Ctx> DekuReader<'a, Ctx> for Ipv6Addr
 where
     u128: DekuReader<'a, Ctx>,
 {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         inner_ctx: Ctx,
     ) -> Result<Self, DekuError> {

--- a/src/impls/nonzero.rs
+++ b/src/impls/nonzero.rs
@@ -28,7 +28,7 @@ macro_rules! ImplDekuTraitsCtx {
         }
 
         impl DekuWriter<$ctx_type> for $typ {
-            fn to_writer<W: Write>(
+            fn to_writer<W: Write + Seek>(
                 &self,
                 writer: &mut Writer<W>,
                 $ctx_arg: $ctx_type,
@@ -66,6 +66,7 @@ ImplDekuTraits!(NonZeroIsize, isize);
 mod tests {
     use hexlit::hex;
     use rstest::rstest;
+    use std::io::Cursor;
 
     use crate::reader::Reader;
 
@@ -84,8 +85,8 @@ mod tests {
         let res_read = NonZeroU8::from_reader_with_ctx(&mut reader, ()).unwrap();
         assert_eq!(expected, res_read);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read.to_writer(&mut writer, ()).unwrap();
-        assert_eq!(input.to_vec(), writer.inner);
+        assert_eq!(input.to_vec(), writer.inner.into_inner());
     }
 }

--- a/src/impls/nonzero.rs
+++ b/src/impls/nonzero.rs
@@ -3,7 +3,7 @@ use alloc::borrow::Cow;
 #[cfg(feature = "alloc")]
 use alloc::format;
 use core::num::*;
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::ctx::*;
 use crate::reader::Reader;
@@ -13,7 +13,7 @@ use crate::{DekuError, DekuReader, DekuWriter};
 macro_rules! ImplDekuTraitsCtx {
     ($typ:ty, $readtype:ty, $ctx_arg:tt, $ctx_type:tt) => {
         impl DekuReader<'_, $ctx_type> for $typ {
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut Reader<R>,
                 $ctx_arg: $ctx_type,
             ) -> Result<Self, DekuError> {
@@ -79,9 +79,8 @@ mod tests {
         case(&hex!("00"), NonZeroU8::new(0xFF).unwrap()),
     )]
     fn test_non_zero(input: &[u8], expected: NonZeroU8) {
-        let mut bit_slice = input.view_bits::<Msb0>();
-
-        let mut reader = Reader::new(&mut bit_slice);
+        let mut cursor = std::io::Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
         let res_read = NonZeroU8::from_reader_with_ctx(&mut reader, ()).unwrap();
         assert_eq!(expected, res_read);
 

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -1,9 +1,9 @@
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::{writer::Writer, DekuError, DekuReader, DekuWriter};
 
 impl<'a, T: DekuReader<'a, Ctx>, Ctx: Copy> DekuReader<'a, Ctx> for Option<T> {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut crate::reader::Reader<R>,
         inner_ctx: Ctx,
     ) -> Result<Self, DekuError> {

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -13,7 +13,11 @@ impl<'a, T: DekuReader<'a, Ctx>, Ctx: Copy> DekuReader<'a, Ctx> for Option<T> {
 }
 
 impl<T: DekuWriter<Ctx>, Ctx: Copy> DekuWriter<Ctx> for Option<T> {
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, inner_ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        inner_ctx: Ctx,
+    ) -> Result<(), DekuError> {
         self.as_ref()
             .map_or(Ok(()), |v| v.to_writer(writer, inner_ctx))
     }
@@ -38,8 +42,8 @@ mod tests {
 
     #[test]
     fn test_option_write() {
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         Some(true).to_writer(&mut writer, ()).unwrap();
-        assert_eq!(vec![1], writer.inner);
+        assert_eq!(vec![1], writer.inner.into_inner());
     }
 }

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -74,7 +74,7 @@ impl DekuReader<'_, (Endian, ByteSize)> for u8 {
 impl DekuWriter<(Endian, BitSize)> for u8 {
     /// Ignore endian, as this is a `u8`
     #[inline(always)]
-    fn to_writer<W: Write>(
+    fn to_writer<W: Write + Seek>(
         &self,
         writer: &mut Writer<W>,
         (_, size): (Endian, BitSize),
@@ -113,7 +113,7 @@ impl DekuWriter<(Endian, BitSize)> for u8 {
 impl DekuWriter<(Endian, ByteSize)> for u8 {
     /// Ignore endian and byte_size, as this is a `u8`
     #[inline(always)]
-    fn to_writer<W: Write>(
+    fn to_writer<W: Write + Seek>(
         &self,
         writer: &mut Writer<W>,
         (_, _): (Endian, ByteSize),
@@ -465,7 +465,7 @@ macro_rules! ImplDekuWrite {
     ($typ:ty) => {
         impl DekuWriter<(Endian, BitSize)> for $typ {
             #[inline(always)]
-            fn to_writer<W: Write>(
+            fn to_writer<W: Write + Seek>(
                 &self,
                 writer: &mut Writer<W>,
                 (endian, size): (Endian, BitSize),
@@ -536,7 +536,7 @@ macro_rules! ImplDekuWrite {
 
         impl DekuWriter<(Endian, ByteSize)> for $typ {
             #[inline(always)]
-            fn to_writer<W: Write>(
+            fn to_writer<W: Write + Seek>(
                 &self,
                 writer: &mut Writer<W>,
                 (endian, size): (Endian, ByteSize),
@@ -571,7 +571,7 @@ macro_rules! ImplDekuWriteOnlyEndian {
     ($typ:ty) => {
         impl DekuWriter<Endian> for $typ {
             #[inline(always)]
-            fn to_writer<W: Write>(
+            fn to_writer<W: Write + Seek>(
                 &self,
                 writer: &mut Writer<W>,
                 endian: Endian,
@@ -591,7 +591,7 @@ macro_rules! ForwardDekuWrite {
     ($typ:ty) => {
         impl DekuWriter<BitSize> for $typ {
             #[inline(always)]
-            fn to_writer<W: Write>(
+            fn to_writer<W: Write + Seek>(
                 &self,
                 writer: &mut Writer<W>,
                 bit_size: BitSize,
@@ -602,7 +602,7 @@ macro_rules! ForwardDekuWrite {
 
         impl DekuWriter<ByteSize> for $typ {
             #[inline(always)]
-            fn to_writer<W: Write>(
+            fn to_writer<W: Write + Seek>(
                 &self,
                 writer: &mut Writer<W>,
                 byte_size: ByteSize,
@@ -613,7 +613,11 @@ macro_rules! ForwardDekuWrite {
 
         impl DekuWriter for $typ {
             #[inline(always)]
-            fn to_writer<W: Write>(&self, writer: &mut Writer<W>, _: ()) -> Result<(), DekuError> {
+            fn to_writer<W: Write + Seek>(
+                &self,
+                writer: &mut Writer<W>,
+                _: (),
+            ) -> Result<(), DekuError> {
                 <$typ>::to_writer(self, writer, Endian::default())
             }
         }
@@ -685,6 +689,7 @@ ImplDekuTraitsBytes!(f64, u64);
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use std::io::Cursor;
 
     use super::*;
     use crate::{native_endian, reader::Reader};
@@ -700,9 +705,9 @@ mod tests {
                 let res_read = <$typ>::from_reader_with_ctx(&mut reader, ENDIAN).unwrap();
                 assert_eq!($expected, res_read);
 
-                let mut writer = Writer::new(vec![]);
+                let mut writer = Writer::new(Cursor::new(vec![]));
                 res_read.to_writer(&mut writer, ENDIAN).unwrap();
-                assert_eq!($input, writer.inner);
+                assert_eq!($input, writer.inner.into_inner());
             }
         };
     }
@@ -884,7 +889,7 @@ mod tests {
         expected: Vec<u8>,
         expected_leftover: Vec<bool>,
     ) {
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         match bit_size {
             Some(bit_size) => input
                 .to_writer(&mut writer, (endian, BitSize(bit_size)))
@@ -892,7 +897,7 @@ mod tests {
             None => input.to_writer(&mut writer, endian).unwrap(),
         };
         assert_eq!(expected_leftover, writer.rest());
-        assert_eq!(expected, writer.inner);
+        assert_eq!(expected, writer.inner.into_inner());
     }
 
     #[rstest(input, endian, byte_size, expected,
@@ -903,14 +908,14 @@ mod tests {
         case::byte_size_le_bigger(0x03AB, Endian::Little, Some(10), vec![0xAB, 0b11_000000]),
     )]
     fn test_byte_writer(input: u32, endian: Endian, byte_size: Option<usize>, expected: Vec<u8>) {
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         match byte_size {
             Some(byte_size) => input
                 .to_writer(&mut writer, (endian, ByteSize(byte_size)))
                 .unwrap(),
             None => input.to_writer(&mut writer, endian).unwrap(),
         };
-        assert_hex::assert_eq_hex!(expected, writer.inner);
+        assert_hex::assert_eq_hex!(expected, writer.inner.into_inner());
     }
 
     #[rstest(input, endian, bit_size, expected, expected_write,
@@ -933,14 +938,14 @@ mod tests {
         };
         assert_eq!(expected, res_read);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         match bit_size {
             Some(bit_size) => res_read
                 .to_writer(&mut writer, (endian, BitSize(bit_size)))
                 .unwrap(),
             None => res_read.to_writer(&mut writer, endian).unwrap(),
         };
-        assert_hex::assert_eq_hex!(expected_write, writer.inner);
+        assert_hex::assert_eq_hex!(expected_write, writer.inner.into_inner());
     }
 
     macro_rules! TestSignExtending {

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -4,7 +4,7 @@ use alloc::format;
 use core::convert::TryInto;
 
 use bitvec::prelude::*;
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::ctx::*;
 use crate::reader::{Reader, ReaderRet};
@@ -50,7 +50,7 @@ impl DekuRead<'_, (Endian, ByteSize)> for u8 {
 impl DekuReader<'_, (Endian, ByteSize)> for u8 {
     /// Ignore endian, as this is a `u8`
     #[inline(always)]
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         (endian, size): (Endian, ByteSize),
     ) -> Result<u8, DekuError> {
@@ -204,7 +204,7 @@ macro_rules! ImplDekuReadBits {
 
         impl DekuReader<'_, (Endian, BitSize)> for $typ {
             #[inline(always)]
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut Reader<R>,
                 (endian, size): (Endian, BitSize),
             ) -> Result<$typ, DekuError> {
@@ -253,7 +253,7 @@ macro_rules! ImplDekuReadBytes {
 
         impl DekuReader<'_, (Endian, ByteSize)> for $typ {
             #[inline(always)]
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut Reader<R>,
                 (endian, size): (Endian, ByteSize),
             ) -> Result<$typ, DekuError> {
@@ -314,7 +314,7 @@ macro_rules! ImplDekuReadSignExtend {
 
         impl DekuReader<'_, (Endian, ByteSize)> for $typ {
             #[inline(always)]
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut Reader<R>,
                 (endian, size): (Endian, ByteSize),
             ) -> Result<$typ, DekuError> {
@@ -364,7 +364,7 @@ macro_rules! ImplDekuReadSignExtend {
 
         impl DekuReader<'_, (Endian, BitSize)> for $typ {
             #[inline(always)]
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut Reader<R>,
                 (endian, size): (Endian, BitSize),
             ) -> Result<$typ, DekuError> {
@@ -391,7 +391,7 @@ macro_rules! ForwardDekuRead {
         // Only have `endian`, specialize and use read_bytes_const
         impl DekuReader<'_, Endian> for $typ {
             #[inline(always)]
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut Reader<R>,
                 endian: Endian,
             ) -> Result<$typ, DekuError> {
@@ -421,7 +421,7 @@ macro_rules! ForwardDekuRead {
         // Only have `byte_size`, set `endian` to `Endian::default`.
         impl DekuReader<'_, ByteSize> for $typ {
             #[inline(always)]
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut Reader<R>,
                 byte_size: ByteSize,
             ) -> Result<$typ, DekuError> {
@@ -435,7 +435,7 @@ macro_rules! ForwardDekuRead {
         //// Only have `bit_size`, set `endian` to `Endian::default`.
         impl DekuReader<'_, BitSize> for $typ {
             #[inline(always)]
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut Reader<R>,
                 bit_size: BitSize,
             ) -> Result<$typ, DekuError> {
@@ -451,7 +451,7 @@ macro_rules! ForwardDekuRead {
 
         impl DekuReader<'_> for $typ {
             #[inline(always)]
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut Reader<R>,
                 _: (),
             ) -> Result<$typ, DekuError> {
@@ -807,15 +807,15 @@ mod tests {
         case::too_much_data([0xAA, 0xBB, 0xCC, 0xDD, 0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(63), 0xFF, bits![u8, Msb0;], &[]),
     )]
     fn test_bit_read(
-        mut input: &[u8],
+        input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         expected: u32,
         expected_rest_bits: &BitSlice<u8, Msb0>,
         expected_rest_bytes: &[u8],
     ) {
-        // test both Read &[u8] and Read BitVec
-        let mut reader = Reader::new(&mut input);
+        let mut cursor = std::io::Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
         let res_read = match bit_size {
             Some(bit_size) => {
                 u32::from_reader_with_ctx(&mut reader, (endian, BitSize(bit_size))).unwrap()
@@ -828,7 +828,7 @@ mod tests {
             expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
         );
         let mut buf = vec![];
-        input.read_to_end(&mut buf).unwrap();
+        cursor.read_to_end(&mut buf).unwrap();
         assert_eq!(expected_rest_bytes, buf);
     }
 
@@ -845,16 +845,16 @@ mod tests {
         case::too_much_data([0xAA, 0xBB, 0xCC, 0xDD, 0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(8), 0xFF, &[]),
     )]
     fn test_byte_read(
-        mut input: &[u8],
+        input: &[u8],
         endian: Endian,
         byte_size: Option<usize>,
         expected: u32,
         expected_rest_bytes: &[u8],
     ) {
-        let mut bit_slice = input.view_bits::<Msb0>();
+        let mut cursor = std::io::Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
 
         // test both Read &[u8] and Read BitVec
-        let mut reader = Reader::new(&mut input);
         let res_read = match byte_size {
             Some(byte_size) => {
                 u32::from_reader_with_ctx(&mut reader, (endian, ByteSize(byte_size))).unwrap()
@@ -863,16 +863,8 @@ mod tests {
         };
         assert_eq!(expected, res_read);
 
-        let mut reader = Reader::new(&mut bit_slice);
-        let res_read = match byte_size {
-            Some(byte_size) => {
-                u32::from_reader_with_ctx(&mut reader, (endian, ByteSize(byte_size))).unwrap()
-            }
-            None => u32::from_reader_with_ctx(&mut reader, endian).unwrap(),
-        };
-        assert_eq!(expected, res_read);
         let mut buf = vec![];
-        input.read_to_end(&mut buf).unwrap();
+        cursor.read_to_end(&mut buf).unwrap();
         assert_eq!(expected_rest_bytes, buf);
     }
 
@@ -931,9 +923,8 @@ mod tests {
         expected: u32,
         expected_write: Vec<u8>,
     ) {
-        let mut bit_slice = input.view_bits::<Msb0>();
-
-        let mut reader = Reader::new(&mut bit_slice);
+        let mut cursor = std::io::Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
         let res_read = match bit_size {
             Some(bit_size) => {
                 u32::from_reader_with_ctx(&mut reader, (endian, BitSize(bit_size))).unwrap()
@@ -956,8 +947,9 @@ mod tests {
         ($test_name:ident, $typ:ty) => {
             #[test]
             fn $test_name() {
-                let mut slice = [0b10101_000].as_slice();
-                let mut reader = Reader::new(&mut slice);
+                let slice = [0b10101_000].as_slice();
+                let mut cursor = std::io::Cursor::new(slice);
+                let mut reader = Reader::new(&mut cursor);
                 let res_read =
                     <$typ>::from_reader_with_ctx(&mut reader, (Endian::Little, BitSize(5)))
                         .unwrap();
@@ -977,8 +969,9 @@ mod tests {
         ($test_name:ident, $typ:ty, $size:expr) => {
             #[test]
             fn $test_name() {
-                let mut slice = [0b10101_000].as_slice();
-                let mut reader = Reader::new(&mut slice);
+                let slice = [0b10101_000].as_slice();
+                let mut cursor = std::io::Cursor::new(slice);
+                let mut reader = Reader::new(&mut cursor);
                 let res_read =
                     <$typ>::from_reader_with_ctx(&mut reader, (Endian::Little, BitSize($size + 1)));
                 assert_eq!(

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -58,7 +58,7 @@ macro_rules! ImplDekuTupleTraits {
         impl<Ctx: Copy, $($T:DekuWriter<Ctx>),+> DekuWriter<Ctx> for ($($T,)+)
         {
             #[allow(non_snake_case)]
-            fn to_writer<W: Write>(&self, writer: &mut Writer<W>, ctx: Ctx) -> Result<(), DekuError> {
+            fn to_writer<W: Write + Seek>(&self, writer: &mut Writer<W>, ctx: Ctx) -> Result<(), DekuError> {
                 let ($(ref $T,)+) = *self;
                 $(
                     $T.to_writer(writer, ctx)?;
@@ -97,8 +97,10 @@ mod tests {
     where
         T: DekuWriter,
     {
-        let mut writer = Writer::new(vec![]);
+        use std::io::Cursor;
+
+        let mut writer = Writer::new(Cursor::new(vec![]));
         input.to_writer(&mut writer, ()).unwrap();
-        assert_eq!(expected, writer.inner);
+        assert_eq!(expected, writer.inner.into_inner());
     }
 }

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -2,7 +2,7 @@
 
 use crate::writer::Writer;
 
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::{DekuError, DekuReader, DekuWriter};
 
@@ -39,7 +39,7 @@ macro_rules! ImplDekuTupleTraits {
 
         impl<'a, Ctx: Copy, $($T:DekuReader<'a, Ctx>+Sized),+> DekuReader<'a, Ctx> for ($($T,)+)
         {
-            fn from_reader_with_ctx<R: Read>(
+            fn from_reader_with_ctx<R: Read + Seek>(
                 reader: &mut crate::reader::Reader<R>,
                 ctx: Ctx,
             ) -> Result<Self, DekuError>

--- a/src/impls/unit.rs
+++ b/src/impls/unit.rs
@@ -1,9 +1,9 @@
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::{reader::Reader, writer::Writer, DekuError, DekuReader, DekuWriter};
 
 impl<Ctx: Copy> DekuReader<'_, Ctx> for () {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         _reader: &mut Reader<R>,
         _inner_ctx: Ctx,
     ) -> Result<Self, DekuError> {

--- a/src/impls/unit.rs
+++ b/src/impls/unit.rs
@@ -13,7 +13,7 @@ impl<Ctx: Copy> DekuReader<'_, Ctx> for () {
 
 impl<Ctx: Copy> DekuWriter<Ctx> for () {
     /// NOP on write
-    fn to_writer<W: Write>(
+    fn to_writer<W: Write + Seek>(
         &self,
         _writer: &mut Writer<W>,
         _inner_ctx: Ctx,
@@ -40,8 +40,8 @@ mod tests {
         let res_read = <()>::from_reader_with_ctx(&mut reader, ()).unwrap();
         assert_eq!((), res_read);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read.to_writer(&mut writer, ()).unwrap();
-        assert!(writer.inner.is_empty());
+        assert!(writer.inner.into_inner().is_empty());
     }
 }

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -1,4 +1,4 @@
-use no_std_io::io::{Read, Write};
+use no_std_io::io::{Read, Seek, Write};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -15,7 +15,7 @@ use crate::{DekuError, DekuWriter};
 /// The predicate takes two parameters: the number of bits that have been read so far,
 /// and a borrow of the latest value to have been read. It should return `true` if reading
 /// should now stop, and `false` otherwise
-fn reader_vec_with_predicate<'a, T, Ctx, Predicate, R: Read>(
+fn reader_vec_with_predicate<'a, T, Ctx, Predicate, R: Read + Seek>(
     reader: &mut Reader<R>,
     capacity: Option<usize>,
     ctx: Ctx,
@@ -44,7 +44,7 @@ where
     Ok(res)
 }
 
-fn reader_vec_to_end<'a, T, Ctx, R: Read>(
+fn reader_vec_to_end<'a, T, Ctx, R: Read + Seek>(
     reader: &mut crate::reader::Reader<R>,
     capacity: Option<usize>,
     ctx: Ctx,
@@ -71,7 +71,7 @@ where
     Ctx: Copy,
     Predicate: FnMut(&T) -> bool,
 {
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         (limit, inner_ctx): (Limit<T, Predicate>, Ctx),
     ) -> Result<Self, DekuError>
@@ -135,7 +135,7 @@ impl<'a, T: DekuReader<'a>, Predicate: FnMut(&T) -> bool> DekuReader<'a, Limit<T
     for Vec<T>
 {
     /// Read `T`s until the given limit from input for types which don't require context.
-    fn from_reader_with_ctx<R: Read>(
+    fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
         limit: Limit<T, Predicate>,
     ) -> Result<Self, DekuError>
@@ -191,7 +191,8 @@ mod tests {
         expected_rest_bits: &BitSlice<u8, Msb0>,
         expected_rest_bytes: &[u8],
     ) {
-        let mut reader = Reader::new(&mut input);
+        let mut cursor = Cursor::new(&mut input);
+        let mut reader = Reader::new(&mut cursor);
         let res_read = Vec::<u8>::from_reader_with_ctx(&mut reader, limit).unwrap();
         assert_eq!(expected, res_read);
         assert_eq!(
@@ -199,7 +200,7 @@ mod tests {
             expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
         );
         let mut buf = vec![];
-        input.read_to_end(&mut buf).unwrap();
+        cursor.read_to_end(&mut buf).unwrap();
         assert_eq!(expected_rest_bytes, buf);
     }
 
@@ -226,7 +227,7 @@ mod tests {
         case::too_much_data([0xAA, 0xBB].as_ref(), Endian::Little, Some(9), 1.into(), vec![], bits![u8, Msb0;], &[]),
     )]
     fn test_vec_reader<Predicate: FnMut(&u8) -> bool>(
-        mut input: &[u8],
+        input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         limit: Limit<u8, Predicate>,
@@ -234,7 +235,8 @@ mod tests {
         expected_rest_bits: &BitSlice<u8, Msb0>,
         expected_rest_bytes: &[u8],
     ) {
-        let mut reader = Reader::new(&mut input);
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
         let res_read = match bit_size {
             Some(bit_size) => {
                 Vec::<u8>::from_reader_with_ctx(&mut reader, (limit, (endian, BitSize(bit_size))))
@@ -248,7 +250,7 @@ mod tests {
             expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
         );
         let mut buf = vec![];
-        input.read_to_end(&mut buf).unwrap();
+        cursor.read_to_end(&mut buf).unwrap();
         assert_eq!(expected_rest_bytes, buf);
     }
 
@@ -271,7 +273,7 @@ mod tests {
         case::bytes_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), BitSize(16).into(), vec![0xAABB], bits![u8, Msb0;], &[0xcc, 0xdd], vec![0xAA, 0xBB]),
     )]
     fn test_vec_reader_write<Predicate: FnMut(&u16) -> bool>(
-        mut input: &[u8],
+        input: &[u8],
         endian: Endian,
         bit_size: Option<usize>,
         limit: Limit<u16, Predicate>,
@@ -284,7 +286,8 @@ mod tests {
         // Unwrap here because all test cases are `Some`.
         let bit_size = bit_size.unwrap();
 
-        let mut reader = Reader::new(&mut input);
+        let mut cursor = Cursor::new(input);
+        let mut reader = Reader::new(&mut cursor);
         let res_read =
             Vec::<u16>::from_reader_with_ctx(&mut reader, (limit, (endian, BitSize(bit_size))))
                 .unwrap();
@@ -294,7 +297,7 @@ mod tests {
             expected_rest_bits.iter().by_vals().collect::<Vec<bool>>()
         );
         let mut buf = vec![];
-        input.read_to_end(&mut buf).unwrap();
+        cursor.read_to_end(&mut buf).unwrap();
         assert_eq!(expected_rest_bytes, buf);
 
         let mut writer = Writer::new(vec![]);

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -178,6 +178,7 @@ impl<T: DekuWriter<Ctx>, Ctx: Copy> DekuWriter<Ctx> for Vec<T> {
 mod tests {
     use crate::bitvec::{bits, BitSlice, Msb0};
     use rstest::rstest;
+    use std::io::Cursor;
 
     use crate::reader::Reader;
 

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -154,13 +154,19 @@ impl<T: DekuWriter<Ctx>, Ctx: Copy> DekuWriter<Ctx> for Vec<T> {
     /// # use deku::{ctx::Endian, DekuWriter};
     /// # use deku::writer::Writer;
     /// # use deku::bitvec::{Msb0, bitvec};
+    /// # use std::io::Cursor;
     /// let data = vec![1u8];
     /// let mut out_buf = vec![];
-    /// let mut writer = Writer::new(&mut out_buf);
+    /// let mut cursor = Cursor::new(&mut out_buf);
+    /// let mut writer = Writer::new(&mut cursor);
     /// data.to_writer(&mut writer, Endian::Big).unwrap();
     /// assert_eq!(data, out_buf.to_vec());
     /// ```
-    fn to_writer<W: Write>(&self, writer: &mut Writer<W>, inner_ctx: Ctx) -> Result<(), DekuError> {
+    fn to_writer<W: Write + Seek>(
+        &self,
+        writer: &mut Writer<W>,
+        inner_ctx: Ctx,
+    ) -> Result<(), DekuError> {
         for v in self {
             v.to_writer(writer, inner_ctx)?;
         }
@@ -258,9 +264,9 @@ mod tests {
         case::normal(vec![0xAABB, 0xCCDD], Endian::Little, vec![0xBB, 0xAA, 0xDD, 0xCC]),
     )]
     fn test_vec_write(input: Vec<u16>, endian: Endian, expected: Vec<u8>) {
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         input.to_writer(&mut writer, endian).unwrap();
-        assert_eq!(expected, writer.inner);
+        assert_eq!(expected, writer.inner.into_inner());
     }
 
     // Note: These tests also exist in boxed.rs
@@ -300,11 +306,11 @@ mod tests {
         cursor.read_to_end(&mut buf).unwrap();
         assert_eq!(expected_rest_bytes, buf);
 
-        let mut writer = Writer::new(vec![]);
+        let mut writer = Writer::new(Cursor::new(vec![]));
         res_read
             .to_writer(&mut writer, (endian, BitSize(bit_size)))
             .unwrap();
-        assert_eq!(expected_write, writer.inner);
+        assert_eq!(expected_write, writer.inner.into_inner());
 
         assert_eq!(input_clone[..expected_write.len()].to_vec(), expected_write);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,8 @@ pub mod no_std_io {
     pub use no_std_io::io::Cursor;
     pub use no_std_io::io::Read;
     pub use no_std_io::io::Result;
+    pub use no_std_io::io::Seek;
+    pub use no_std_io::io::SeekFrom;
     pub use no_std_io::io::Write;
 }
 
@@ -406,7 +408,7 @@ pub trait DekuReader<'a, Ctx = ()> {
     /// let mut reader = Reader::new(&mut file);
     /// let ec = EcHdr::from_reader_with_ctx(&mut reader, Endian::Big).unwrap();
     /// ```
-    fn from_reader_with_ctx<R: no_std_io::Read>(
+    fn from_reader_with_ctx<R: no_std_io::Read + no_std_io::Seek>(
         reader: &mut Reader<R>,
         ctx: Ctx,
     ) -> Result<Self, DekuError>
@@ -443,12 +445,12 @@ pub trait DekuContainerRead<'a>: DekuReader<'a, ()> {
     ///     magic: [u8; 4],
     ///     version: u8,
     /// }
-    ///
+    /// ```
     /// let mut file = File::options().read(true).open("file").unwrap();
     /// file.seek(SeekFrom::Start(0)).unwrap();
     /// let ec = EcHdr::from_reader((&mut file, 0)).unwrap();
     /// ```
-    fn from_reader<R: no_std_io::Read>(
+    fn from_reader<R: no_std_io::Read + no_std_io::Seek>(
         input: (&'a mut R, usize),
     ) -> Result<(usize, Self), DekuError>
     where

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -39,6 +39,12 @@ impl<R: Read + Seek> Seek for Reader<'_, R> {
     }
 }
 
+impl<R: Read + Seek> AsMut<R> for Reader<'_, R> {
+    fn as_mut(&mut self) -> &mut R {
+        self.inner
+    }
+}
+
 impl<'a, R: Read + Seek> Reader<'a, R> {
     /// Create a new `Reader`
     #[inline]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -31,6 +31,14 @@ pub struct Reader<'a, R: Read + Seek> {
     pub bits_read: usize,
 }
 
+impl<R: Read + Seek> Seek for Reader<'_, R> {
+    fn seek(&mut self, pos: SeekFrom) -> no_std_io::io::Result<u64> {
+        // clear leftover
+        self.leftover = BitVec::new();
+        self.inner.seek(pos)
+    }
+}
+
 impl<'a, R: Read + Seek> Reader<'a, R> {
     /// Create a new `Reader`
     #[inline]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -33,6 +33,8 @@ pub struct Reader<'a, R: Read + Seek> {
 
 impl<R: Read + Seek> Seek for Reader<'_, R> {
     fn seek(&mut self, pos: SeekFrom) -> no_std_io::io::Result<u64> {
+        #[cfg(feature = "logging")]
+        log::trace!("seek: {pos:?}");
         // clear leftover
         self.leftover = BitVec::new();
         self.inner.seek(pos)

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,7 +3,7 @@
 use core::cmp::Ordering;
 
 use bitvec::prelude::*;
-use no_std_io::io::{ErrorKind, Read};
+use no_std_io::io::{ErrorKind, Read, Seek, SeekFrom};
 
 use crate::{prelude::NeedSize, DekuError};
 use alloc::vec::Vec;
@@ -23,7 +23,7 @@ pub enum ReaderRet {
 pub const MAX_BITS_AMT: usize = 128;
 
 /// Reader to use with `from_reader_with_ctx`
-pub struct Reader<'a, R: Read> {
+pub struct Reader<'a, R: Read + Seek> {
     inner: &'a mut R,
     /// bits stored from previous reads that didn't read to the end of a byte size
     leftover: BitVec<u8, Msb0>,
@@ -31,7 +31,7 @@ pub struct Reader<'a, R: Read> {
     pub bits_read: usize,
 }
 
-impl<'a, R: Read> Reader<'a, R> {
+impl<'a, R: Read + Seek> Reader<'a, R> {
     /// Create a new `Reader`
     #[inline]
     pub fn new(inner: &'a mut R) -> Self {

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -54,10 +54,11 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_simple() {
         let input = hex!("aa_bbbb_cc_0102_dd_ffffff_aa_0100ff");
+        let mut cursor = std::io::Cursor::new(input);
 
         assert_eq!(
             count_alloc(|| {
-                let _ = TestDeku::from_reader((&mut input.as_slice(), 0)).unwrap();
+                let _ = TestDeku::from_reader((&mut cursor, 0)).unwrap();
             })
             .0,
             (5, 0, 5)
@@ -68,7 +69,8 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_simple_write() {
         let input = hex!("aa_bbbb_cc_0102_dd_ffffff_aa_0100ff");
-        let t = TestDeku::from_reader((&mut input.as_slice(), 0)).unwrap().1;
+        let mut cursor = std::io::Cursor::new(input);
+        let t = TestDeku::from_reader((&mut cursor, 0)).unwrap().1;
 
         assert_eq!(
             count_alloc(|| {

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -85,7 +85,8 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_to_slice() {
         let input = hex!("aa_bbbb_cc_0102_dd_ffffff_aa_0100ff");
-        let t = TestDeku::from_reader((&mut input.as_slice(), 0)).unwrap().1;
+        let mut cursor = std::io::Cursor::new(input);
+        let t = TestDeku::from_reader((&mut cursor, 0)).unwrap().1;
 
         let mut out = [0x00; 100];
 

--- a/tests/test_attributes/test_ctx.rs
+++ b/tests/test_attributes/test_ctx.rs
@@ -181,7 +181,8 @@ fn test_struct_enum_ctx_id() {
 
     // VarC
     let test_data = [0x02_u8, 0x03, 0xcc];
-    let (_, ret_read) = StructEnumId::from_reader((&mut test_data.as_slice(), 0)).unwrap();
+    let mut cursor = Cursor::new(test_data);
+    let (_, ret_read) = StructEnumId::from_reader((&mut cursor, 0)).unwrap();
 
     assert_eq!(
         StructEnumId {

--- a/tests/test_attributes/test_ctx.rs
+++ b/tests/test_attributes/test_ctx.rs
@@ -70,7 +70,8 @@ fn test_top_level_ctx_enum() {
     assert_eq!(ret_read, TopLevelCtxEnum::VariantA(0x06));
 
     let mut out_buf = vec![];
-    let mut writer = Writer::new(&mut out_buf);
+    let mut cursor = Cursor::new(&mut out_buf);
+    let mut writer = Writer::new(&mut cursor);
     ret_read.to_writer(&mut writer, (1, 2)).unwrap();
     assert_eq!(out_buf.to_vec(), &test_data[..]);
 }
@@ -107,7 +108,8 @@ fn test_top_level_ctx_enum_default() {
     .unwrap();
     assert_eq!(ret_read, TopLevelCtxEnumDefault::VariantA(0x06));
     let mut out_buf = vec![];
-    let mut writer = Writer::new(&mut out_buf);
+    let mut cursor = Cursor::new(&mut out_buf);
+    let mut writer = Writer::new(&mut cursor);
     ret_read.to_writer(&mut writer, (1, 2)).unwrap();
     assert_eq!(test_data.to_vec(), out_buf.to_vec());
 }
@@ -230,7 +232,8 @@ fn test_ctx_default_struct() {
     .unwrap();
     assert_eq!(expected, ret_read);
     let mut out_buf = vec![];
-    let mut writer = Writer::new(&mut out_buf);
+    let mut cursor = Cursor::new(&mut out_buf);
+    let mut writer = Writer::new(&mut cursor);
     ret_read.to_writer(&mut writer, (1, 2)).unwrap();
     assert_eq!(test_data.to_vec(), out_buf.to_vec());
 }

--- a/tests/test_compile/cases/internal_variables.rs
+++ b/tests/test_compile/cases/internal_variables.rs
@@ -49,7 +49,7 @@ struct TestMap {
     field_b: usize,
 }
 
-fn dummy_reader<R: std::io::Read>(
+fn dummy_reader<R: std::io::Read + std::io::Seek>(
     offset: usize,
     _reader: &mut Reader<R>,
 ) -> Result<usize, DekuError> {

--- a/tests/test_compile/cases/internal_variables.stderr
+++ b/tests/test_compile/cases/internal_variables.stderr
@@ -4,6 +4,22 @@ error: Unexpected meta-item format `attribute cannot contain `__deku_` these are
 88 |     #[deku(cond = "__deku_bit_offset == *field_a as usize")]
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error[E0277]: the trait bound `W: Seek` is not satisfied
+  --> tests/test_compile/cases/internal_variables.rs:75:66
+   |
+75 | fn dummy_writer<W: std::io::Write>(_offset: usize, _writer: &mut deku::writer::Writer<W>) -> Result<(), DekuError> {
+   |                                                                  ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Seek` is not implemented for `W`
+   |
+note: required by a bound in `Writer`
+  --> src/writer.rs
+   |
+   | pub struct Writer<W: Write + Seek> {
+   |                              ^^^^ required by this bound in `Writer`
+help: consider further restricting this bound
+   |
+75 | fn dummy_writer<W: std::io::Write + std::io::Seek>(_offset: usize, _writer: &mut deku::writer::Writer<W>) -> Result<(), DekuError> {
+   |                                   +++++++++++++++
+
 warning: unused variable: `offset`
   --> tests/test_compile/cases/internal_variables.rs:53:5
    |

--- a/tests/test_compile/cases/seek_conflict.rs
+++ b/tests/test_compile/cases/seek_conflict.rs
@@ -1,0 +1,11 @@
+use deku::prelude::*;
+
+#[derive(DekuRead, Debug, PartialEq, Eq)]
+pub struct Test {
+    #[deku(seek_rewind, seek_from_current = "0")]
+    byte_a: u8,
+    #[deku(seek_from_current = "1", seek_from_end = "-1")]
+    byte_b: u8,
+}
+
+fn main() {}

--- a/tests/test_compile/cases/seek_conflict.stderr
+++ b/tests/test_compile/cases/seek_conflict.stderr
@@ -1,0 +1,7 @@
+error: conflicting: only one `seek` attribute can be used at one time
+ --> tests/test_compile/cases/seek_conflict.rs:3:10
+  |
+3 | #[derive(DekuRead, Debug, PartialEq, Eq)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -1,4 +1,5 @@
 use std::convert::{TryFrom, TryInto};
+use std::io::Cursor;
 
 use deku::prelude::*;
 use hexlit::hex;
@@ -131,7 +132,8 @@ fn test_id_pat_with_id() {
     }
 
     let input = [0x01, 0x02];
-    let (_, v) = DekuTest::from_reader((&mut input.as_slice(), 0)).unwrap();
+    let mut cursor = Cursor::new(input);
+    let (_, v) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
     assert_eq!(
         v,
         DekuTest {
@@ -142,7 +144,8 @@ fn test_id_pat_with_id() {
     assert_eq!(input, &*v.to_bytes().unwrap());
 
     let input = [0x05];
-    let (_, v) = DekuTest::from_reader((&mut input.as_slice(), 0)).unwrap();
+    let mut cursor = Cursor::new(input);
+    let (_, v) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
     assert_eq!(
         v,
         DekuTest {

--- a/tests/test_own_impl.rs
+++ b/tests/test_own_impl.rs
@@ -1,0 +1,29 @@
+#[test]
+fn test_own_impl() {
+    use deku::prelude::*;
+    use std::io::{Read, Seek, SeekFrom};
+    pub trait ReadSeek: Read + Seek {}
+    pub enum Data {
+        /// On read: Save current stream_position() as `Offset`, seek `header.filesize`
+        /// This will be used to seek this this position if we want to extract *just* this file
+        Offset(u64),
+    }
+
+    impl DekuReader<'_, u32> for Data {
+        fn from_reader_with_ctx<R: Read + Seek>(
+            reader: &mut Reader<R>,
+            filesize: u32,
+        ) -> Result<Data, DekuError> {
+            let reader = reader.as_mut();
+
+            // Save the current offset, this is where the file exists for reading later
+            let current_pos = reader.stream_position().unwrap();
+
+            // Seek past that file
+            let position = filesize as i64;
+            let _ = reader.seek(SeekFrom::Current(position));
+
+            Ok(Self::Offset(current_pos))
+        }
+    }
+}

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -1,4 +1,5 @@
 use deku::prelude::*;
+use std::io::Cursor;
 
 // Invalid alignment assumptions when converting
 // BitSlice to type
@@ -90,8 +91,8 @@ mod issue_282 {
         assert_eq!(zero, 0);
 
         let data = [a, b, c, a, b, c];
-        let (_, BitsBytes { bits, bytes }) =
-            BitsBytes::from_reader((&mut data.as_slice(), 0)).unwrap();
+        let mut cursor = Cursor::new(data);
+        let (_, BitsBytes { bits, bytes }) = BitsBytes::from_reader((&mut cursor, 0)).unwrap();
 
         assert_eq!(bits, expected);
         assert_eq!(bytes, expected);
@@ -116,8 +117,8 @@ mod issue_282 {
         assert_eq!(zero, 0);
 
         let data = [a, b, c, a, b, c];
-        let (_, BitsBytes { bits, bytes }) =
-            BitsBytes::from_reader((&mut data.as_slice(), 0)).unwrap();
+        let mut cursor = Cursor::new(data);
+        let (_, BitsBytes { bits, bytes }) = BitsBytes::from_reader((&mut cursor, 0)).unwrap();
 
         assert_eq!(bits, expected);
         assert_eq!(bytes, expected);
@@ -141,10 +142,9 @@ fn test_regression_292() {
         field3: u8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        Reader::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        Reader::from_reader((&mut cursor, 0)).unwrap().1,
         Reader {
             field1: 0,
             field2: 0xff,
@@ -163,10 +163,9 @@ fn test_regression_292() {
         field3: u8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        ReaderBits::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        ReaderBits::from_reader((&mut cursor, 0)).unwrap().1,
         ReaderBits {
             field1: 0,
             field2: 0xff,
@@ -183,10 +182,9 @@ fn test_regression_292() {
         field3: u8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        ReaderByteNoEndian::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        ReaderByteNoEndian::from_reader((&mut cursor, 0)).unwrap().1,
         ReaderByteNoEndian {
             field1: 0,
             field2: 0xff,
@@ -202,10 +200,9 @@ fn test_regression_292() {
         field3: u8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        ReaderBitPadding::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        ReaderBitPadding::from_reader((&mut cursor, 0)).unwrap().1,
         ReaderBitPadding {
             field2: 0xff,
             field3: 0,
@@ -222,10 +219,9 @@ fn test_regression_292() {
         field3: u8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        ReaderBitPadding1::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        ReaderBitPadding1::from_reader((&mut cursor, 0)).unwrap().1,
         ReaderBitPadding1 {
             field1: 0,
             field2: 0xff,
@@ -245,10 +241,9 @@ fn test_regression_292() {
         field3: u8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        ReaderTwo::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        ReaderTwo::from_reader((&mut cursor, 0)).unwrap().1,
         ReaderTwo {
             field1: 0b11,
             field2: 0,
@@ -268,10 +263,9 @@ fn test_regression_292() {
         field3: u8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        ReaderU16Le::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        ReaderU16Le::from_reader((&mut cursor, 0)).unwrap().1,
         ReaderU16Le {
             field1: 0b11,
             field2: 0,
@@ -291,10 +285,9 @@ fn test_regression_292() {
         field3: u8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        ReaderU16Be::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        ReaderU16Be::from_reader((&mut cursor, 0)).unwrap().1,
         ReaderU16Be {
             field1: 0b11,
             field2: 0,
@@ -314,10 +307,9 @@ fn test_regression_292() {
         field3: i8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        ReaderI16Le::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        ReaderI16Le::from_reader((&mut cursor, 0)).unwrap().1,
         ReaderI16Le {
             field1: -0b01,
             field2: 1,
@@ -337,10 +329,9 @@ fn test_regression_292() {
         field3: i8,
     }
 
+    let mut cursor = Cursor::new(test_data);
     assert_eq!(
-        ReaderI16Be::from_reader((&mut test_data.as_slice(), 0))
-            .unwrap()
-            .1,
+        ReaderI16Be::from_reader((&mut cursor, 0)).unwrap().1,
         ReaderI16Be {
             field1: -0b01,
             field2: 1,

--- a/tests/test_seek.rs
+++ b/tests/test_seek.rs
@@ -8,15 +8,19 @@ pub struct Test {
     skip_u8: u8,
     #[deku(seek_from_current = "*skip_u8")]
     byte: u8,
+    #[deku(seek_from_current = "0")]
+    byte_after: u8,
+    #[deku(seek_rewind)]
+    byte_after_rewind: u8,
+    #[deku(seek_from_start = "2")]
+    byte_again: u8,
 }
 
 #[rstest(input, expected,
-    case(&hex!("010020"), Test{ skip_u8: 1, byte: 0x20 }),
+    case(&hex!("01002030"), Test{ skip_u8: 1, byte: 0x20, byte_after: 0x30, byte_after_rewind: 0x01, byte_again: 0x20 }),
 )]
-fn test_seek_from_current(input: &[u8], expected: Test) {
+fn test_seek(input: &[u8], expected: Test) {
     let input = input.to_vec();
-    // TODO: fix, "too much data"
-    //let ret_read = Test::try_from(input.as_slice()).unwrap();
 
     let mut cursor = std::io::Cursor::new(input.clone());
     let (_, ret_read) = Test::from_reader((&mut cursor, 0)).unwrap();

--- a/tests/test_seek.rs
+++ b/tests/test_seek.rs
@@ -1,0 +1,109 @@
+use deku::prelude::*;
+use hexlit::hex;
+use rstest::*;
+
+#[derive(DekuRead, DekuWrite, Debug, PartialEq, Eq)]
+pub struct Test {
+    // how many following bytes to skip
+    skip_u8: u8,
+    #[deku(seek_from_current = "*skip_u8")]
+    byte: u8,
+}
+
+#[rstest(input, expected,
+    case(&hex!("010020"), Test{ skip_u8: 1, byte: 0x20 }),
+)]
+fn test_seek_from_current(input: &[u8], expected: Test) {
+    let input = input.to_vec();
+    // TODO: fix, "too much data"
+    //let ret_read = Test::try_from(input.as_slice()).unwrap();
+
+    let mut cursor = std::io::Cursor::new(input.clone());
+    let (_, ret_read) = Test::from_reader((&mut cursor, 0)).unwrap();
+
+    assert_eq!(ret_read, expected);
+
+    let bytes = ret_read.to_bytes().unwrap();
+    assert_eq!(bytes, input);
+}
+
+#[derive(DekuRead, DekuWrite, Debug, PartialEq, Eq)]
+#[deku(seek_from_current = "skip", ctx = "skip: usize")]
+pub struct SeekCtxBefore {
+    byte: u8,
+}
+
+#[rstest(input, ctx, expected,
+    case(&hex!("0003"), 1, SeekCtxBefore{ byte: 0x03 }),
+    case(&hex!("000004"), 2, SeekCtxBefore{ byte: 0x04 }),
+)]
+fn test_seek_ctx_before(input: &[u8], ctx: usize, expected: SeekCtxBefore) {
+    use std::io::Cursor;
+    let input = input.to_vec();
+
+    let mut cursor = std::io::Cursor::new(input.clone());
+    let mut reader = Reader::new(&mut cursor);
+    let ret_read = SeekCtxBefore::from_reader_with_ctx(&mut reader, ctx).unwrap();
+
+    assert_eq!(ret_read, expected);
+
+    let mut buf = vec![];
+    let mut cursor = Cursor::new(&mut buf);
+    let mut writer = Writer::new(&mut cursor);
+    let _ = ret_read.to_writer(&mut writer, ctx).unwrap();
+    assert_eq!(buf, input);
+}
+
+#[derive(DekuRead, DekuWrite, Debug, PartialEq, Eq)]
+#[deku(seek_from_start = "1")]
+pub struct SeekCtxBeforeStart {
+    byte: u8,
+}
+
+#[rstest(input, expected,
+    case(&hex!("0003"), SeekCtxBeforeStart{ byte: 0x03 }),
+    case(&hex!("00ff"), SeekCtxBeforeStart{ byte: 0xff }),
+)]
+fn test_seek_ctx_start(input: &[u8], expected: SeekCtxBeforeStart) {
+    use std::io::Cursor;
+    let input = input.to_vec();
+
+    let mut cursor = std::io::Cursor::new(input.clone());
+    let mut reader = Reader::new(&mut cursor);
+    let ret_read = SeekCtxBeforeStart::from_reader_with_ctx(&mut reader, ()).unwrap();
+
+    assert_eq!(ret_read, expected);
+
+    let mut buf = vec![];
+    let mut cursor = Cursor::new(&mut buf);
+    let mut writer = Writer::new(&mut cursor);
+    let _ = ret_read.to_writer(&mut writer, ()).unwrap();
+    assert_eq!(buf, input);
+}
+
+#[derive(DekuRead, DekuWrite, Debug, PartialEq, Eq)]
+#[deku(seek_from_end = "-2")]
+pub struct SeekCtxBeforeEnd {
+    byte: u8,
+}
+
+#[rstest(input, expected,
+    case(&hex!("000300"), SeekCtxBeforeEnd{ byte: 0x03 }),
+    case(&hex!("00ff00"), SeekCtxBeforeEnd{ byte: 0xff }),
+)]
+fn test_seek_ctx_end(input: &[u8], expected: SeekCtxBeforeEnd) {
+    use std::io::Cursor;
+    let input = input.to_vec();
+
+    let mut cursor = std::io::Cursor::new(input.clone());
+    let mut reader = Reader::new(&mut cursor);
+    let ret_read = SeekCtxBeforeEnd::from_reader_with_ctx(&mut reader, ()).unwrap();
+
+    assert_eq!(ret_read, expected);
+
+    let mut buf = vec![0, 0, 0];
+    let mut cursor = Cursor::new(&mut buf);
+    let mut writer = Writer::new(&mut cursor);
+    let _ = ret_read.to_writer(&mut writer, ()).unwrap();
+    assert_eq!(buf, input);
+}

--- a/tests/test_seek.rs
+++ b/tests/test_seek.rs
@@ -14,10 +14,14 @@ pub struct Test {
     byte_after_rewind: u8,
     #[deku(seek_from_start = "2")]
     byte_again: u8,
+    #[deku(seek_from_end = "-1")]
+    another: u8,
 }
 
 #[rstest(input, expected,
-    case(&hex!("01002030"), Test{ skip_u8: 1, byte: 0x20, byte_after: 0x30, byte_after_rewind: 0x01, byte_again: 0x20 }),
+    case(&hex!("01002030"), Test{ skip_u8: 1, byte: 0x20, byte_after: 0x30, byte_after_rewind: 0x01, byte_again: 0x20, another: 0x30 }),
+    case(&hex!("0200002030"), Test{ skip_u8: 2, byte: 0x20, byte_after: 0x30, byte_after_rewind: 0x02, byte_again: 0x00, another: 0x30 }),
+    case(&hex!("00ffaa"), Test{ skip_u8: 0, byte: 0xff, byte_after: 0xaa, byte_after_rewind: 0x00, byte_again: 0xaa, another: 0xaa }),
 )]
 fn test_seek(input: &[u8], expected: Test) {
     let input = input.to_vec();


### PR DESCRIPTION
- Add `Seek` to `Reader` and `Writer`
- Add `as_mut` to `Reader`, and tests
- Add: `seek_rewind`, `seek_from_current`, `seek_from_end`,  `seek_from_start`,

See https://github.com/sharksforarms/deku/issues/105

Currently being used in https://github.com/wcampbell0x2a/cpio-deku