### PR TITLE
Fix hygiene in gen_internal_field_ident

### DIFF
--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -117,7 +117,7 @@ fn gen_internal_field_ident(ident: &TokenStream) -> TokenStream {
     // Concat token: https://github.com/rust-lang/rust/issues/29599
     let span = ident.span();
     let s = ident.to_string();
-    let mut name = "__deku_".to_owned();
+    let mut name = "__deku___".to_owned();
     // If its a raw identifier, we must remove 'r#'
     name.push_str(s.strip_prefix("r#").unwrap_or(&s));
 

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -113,6 +113,7 @@ fn test_named_struct() {
         pub vec_len: u8,
         #[deku(count = "vec_len")]
         pub vec_data: Vec<u8>,
+        pub rest: u8,
     }
 
     let test_data: Vec<u8> = [
@@ -128,6 +129,7 @@ fn test_named_struct() {
         0x02,
         0xBE,
         0xEF,
+        0xFF,
     ]
     .to_vec();
 
@@ -148,7 +150,8 @@ fn test_named_struct() {
                 }
             },
             vec_len: 0x02,
-            vec_data: vec![0xBE, 0xEF]
+            vec_data: vec![0xBE, 0xEF],
+            rest: 0xFF
         },
         ret_read
     );


### PR DESCRIPTION
- Change generated ident prefix to `__deku___` (three underscores) so that emitted field reads are immediately obvious in expanded code, although I think two underscores would be valid as well.
- Also add a field to `test_named_struct`.