### PR TITLE
read_with_predicate: stop when empty

### DIFF
--- a/src/impls/hashmap.rs
+++ b/src/impls/hashmap.rs
@@ -29,7 +29,7 @@ fn read_hashmap_with_predicate<
     let mut rest = input;
     let mut found_predicate = false;
 
-    while !found_predicate {
+    while !found_predicate && !rest.is_empty(){
         let (new_rest, kv) = <(K, V)>::read(rest, ctx)?;
         found_predicate = predicate(
             unsafe { new_rest.as_bitptr().offset_from(input.as_bitptr()) } as usize,

--- a/src/impls/hashset.rs
+++ b/src/impls/hashset.rs
@@ -28,7 +28,7 @@ fn read_hashset_with_predicate<
     let mut rest = input;
     let mut found_predicate = false;
 
-    while !found_predicate {
+    while !found_predicate && !rest.is_empty() {
         let (new_rest, val) = <T>::read(rest, ctx)?;
         found_predicate = predicate(
             unsafe { new_rest.as_bitptr().offset_from(input.as_bitptr()) } as usize,

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -28,7 +28,7 @@ where
         let read_idx = unsafe { rest.as_bitptr().offset_from(input.as_bitptr()) } as usize;
         value = input[..read_idx].domain().region().unwrap().1;
 
-        if predicate(read_idx, &val) {
+        if predicate(read_idx, &val) || rest.is_empty() {
             break;
         }
     }

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -36,7 +36,7 @@ fn read_vec_with_predicate<
         if predicate(
             unsafe { rest.as_bitptr().offset_from(input.as_bitptr()) } as usize,
             res.last().unwrap(),
-        ) {
+        ) || rest.is_empty() {
             break;
         }
     }

--- a/tests/test_attributes/test_limits/test_until.rs
+++ b/tests/test_attributes/test_limits/test_until.rs
@@ -133,4 +133,17 @@ mod test_vec {
 
         let _ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
     }
+
+    #[test]
+    fn test_until_empty() {
+        #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+        struct TestStruct {
+            #[deku(until = "|v: &u8| *v == 0xDD")]
+            data: Vec<u8>,
+        }
+
+        let test_data: Vec<u8> = [0xCC, 0xAA, 0xBB].to_vec();
+
+        let _ret_read = TestStruct::try_from(test_data.as_ref()).unwrap();
+    }
 }


### PR DESCRIPTION
When setting a predicate, I have a situation where the bitvec is empty, yet it still attempts to start reading the next element.
It seems not too weird to assume that we should stop reading when the last element completed successfully and there's nothing more to process left.