### PR TITLE
Update to syn 2.0, darling 0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ This also disallows using tuples for storing the id:
 old:
 ```rust
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum DekuTest {
     #[deku(id_pat = "_")]
     VariantC((u8, u8)),
@@ -119,7 +119,7 @@ enum DekuTest {
 new:
 ```rust
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum DekuTest {
     #[deku(id_pat = "_")]
     VariantC {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ log = { version = "0.4.17", optional = true }
 no_std_io = { version = "0.5.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-rstest = "0.16.0"
+rstest = "0.18.0"
 hexlit = "0.5.5"
 criterion = "0.4.0"
 alloc_counter = "0.0.4"

--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -21,7 +21,7 @@ struct DekuBytes {
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum DekuEnum {
     #[deku(id = "0x01")]
     VariantA(u8),

--- a/deku-derive/Cargo.toml
+++ b/deku-derive/Cargo.toml
@@ -25,4 +25,4 @@ darling = "0.20"
 proc-macro-crate = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
-rstest = "0.16"
+rstest = "0.18"

--- a/deku-derive/Cargo.toml
+++ b/deku-derive/Cargo.toml
@@ -17,11 +17,11 @@ logging = []
 
 [dependencies]
 quote = "1.0"
-syn = "1.0"
+syn = "2.0"
 # extra-traits gives us Debug
 # syn = {version = "1.0", features = ["extra-traits"]}
 proc-macro2 = "1.0"
-darling = "0.14"
+darling = "0.20"
 proc-macro-crate = { version = "1.3.0", optional = true }
 
 [dev-dependencies]

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -12,7 +12,6 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::AttributeArgs;
 
 use crate::macros::deku_read::emit_deku_read;
 use crate::macros::deku_write::emit_deku_write;
@@ -205,7 +204,10 @@ impl DekuData {
             ast::Data::Struct(_) => {
                 // Validate id_* attributes are being used on an enum
                 if data.id_type.is_some() {
-                    Err(cerror(data.id_type.span(), "`type` only supported on enum"))
+                    Err(cerror(
+                        data.id_type.span(),
+                        "`id_type` only supported on enum",
+                    ))
                 } else if data.id.is_some() {
                     Err(cerror(data.id.span(), "`id` only supported on enum"))
                 } else if data.bytes.is_some() {
@@ -217,19 +219,19 @@ impl DekuData {
                 }
             }
             ast::Data::Enum(_) => {
-                // Validate `type` or `id` is specified
+                // Validate `id_type` or `id` is specified
                 if data.id_type.is_none() && data.id.is_none() {
                     return Err(cerror(
                         data.ident.span(),
-                        "`type` or `id` must be specified on enum",
+                        "`id_type` or `id` must be specified on enum",
                     ));
                 }
 
-                // Validate either `type` or `id` is specified
+                // Validate either `id_type` or `id` is specified
                 if data.id_type.is_some() && data.id.is_some() {
                     return Err(cerror(
                         data.ident.span(),
-                        "conflicting: both `type` and `id` specified on enum",
+                        "conflicting: both `id_type` and `id` specified on enum",
                     ));
                 }
 
@@ -635,11 +637,7 @@ struct DekuReceiver {
     id: Option<Id>,
 
     /// enum only: type of the enum `id`
-    #[darling(
-        rename = "type",
-        default = "default_res_opt",
-        map = "map_litstr_as_tokenstream"
-    )]
+    #[darling(default = "default_res_opt", map = "map_litstr_as_tokenstream")]
     id_type: Result<Option<TokenStream>, ReplacementError>,
 
     /// enum only: bit size of the enum `id`
@@ -875,7 +873,7 @@ pub fn proc_deku_write(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 }
 
 fn is_not_deku(attr: &syn::Attribute) -> bool {
-    attr.path
+    attr.path()
         .get_ident()
         .map(|ident| ident != "deku" && ident != "deku_derive")
         .unwrap_or(true)
@@ -939,8 +937,8 @@ pub fn deku_derive(
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     // Parse `deku_derive` attribute
-    let attr_args = syn::parse_macro_input!(attr as AttributeArgs);
-    let args = match DekuDerive::from_list(&attr_args) {
+    let nested_meta = darling::ast::NestedMeta::parse_meta_list(attr.into()).unwrap();
+    let args = match DekuDerive::from_list(&nested_meta) {
         Ok(v) => v,
         Err(e) => {
             return proc_macro::TokenStream::from(e.write_errors());
@@ -1039,9 +1037,9 @@ mod tests {
         }"#),
 
         // Valid Enum
-        case::enum_empty(r#"#[deku(type = "u8")] enum Test {}"#),
+        case::enum_empty(r#"#[deku(id_type = "u8")] enum Test {}"#),
         case::enum_all(r#"
-        #[deku(type = "u8")]
+        #[deku(id_type = "u8")]
         enum Test {
             #[deku(id = "1")]
             A,

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -4,7 +4,7 @@ use deku::{prelude::*, reader::Reader};
 use hexlit::hex;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum DekuTest {
     #[deku(id = "0")]
     Var1,

--- a/examples/enums_catch_all.rs
+++ b/examples/enums_catch_all.rs
@@ -4,7 +4,7 @@ use deku::prelude::*;
 use hexlit::hex;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, DekuWrite, DekuRead)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum DekuTest {

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1019,7 +1019,7 @@ Example:
 # use std::io::Cursor;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum DekuTest {
     #[deku(id = "0x01")]
     VariantA(u8),
@@ -1057,7 +1057,7 @@ Example discriminant
 # use std::io::Cursor;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum DekuTest {
     VariantA = 0x01,
     VariantB,
@@ -1099,7 +1099,7 @@ Example:
 # use std::io::Cursor;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum DekuTest {
     #[deku(id = "0x01")]
     VariantA(u8),
@@ -1151,7 +1151,7 @@ Example:
 # use std::io::Cursor;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8", bits = "4")]
+#[deku(id_type = "u8", bits = "4")]
 enum DekuTest {
     #[deku(id = "0b1001")]
     VariantA( #[deku(bits = "4")] u8, u8),
@@ -1182,7 +1182,7 @@ Example:
 # use deku::prelude::*;
 # use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u32", bytes = "2")]
+#[deku(id_type = "u32", bytes = "2")]
 enum DekuTest {
     #[deku(id = "0xBEEF")]
     VariantA(u8),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ Example:
 use deku::prelude::*;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum DekuTest {
     #[deku(id = "0x01")]
     VariantA,

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -14,14 +14,14 @@ struct NestedStruct {
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-#[deku(type = "u8", ctx = "_endian: Endian")]
+#[deku(id_type = "u8", ctx = "_endian: Endian")]
 enum NestedEnum {
     #[deku(id = "0x01")]
     VarA(u8),
 }
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-#[deku(type = "u32", bytes = "2", ctx = "_endian: Endian")]
+#[deku(id_type = "u32", bytes = "2", ctx = "_endian: Endian")]
 enum NestedEnum2 {
     #[deku(id = "0x01")]
     VarA(u8),

--- a/tests/test_attributes/test_ctx.rs
+++ b/tests/test_attributes/test_ctx.rs
@@ -51,7 +51,7 @@ fn test_ctx_struct() {
 #[test]
 fn test_top_level_ctx_enum() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(type = "u8", ctx = "a: u8, b: u8")]
+    #[deku(id_type = "u8", ctx = "a: u8, b: u8")]
     enum TopLevelCtxEnum {
         #[deku(id = "1")]
         VariantA(
@@ -80,7 +80,7 @@ fn test_top_level_ctx_enum() {
 #[test]
 fn test_top_level_ctx_enum_default() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(type = "u8", ctx = "a: u8, b: u8", ctx_default = "1,2")]
+    #[deku(id_type = "u8", ctx = "a: u8, b: u8", ctx_default = "1,2")]
     enum TopLevelCtxEnumDefault {
         #[deku(id = "1")]
         VariantA(
@@ -240,7 +240,7 @@ fn test_ctx_default_struct() {
 #[test]
 fn test_enum_endian_ctx() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(type = "u32", endian = "endian", ctx = "endian: deku::ctx::Endian")]
+    #[deku(id_type = "u32", endian = "endian", ctx = "endian: deku::ctx::Endian")]
     enum EnumTypeEndianCtx {
         #[deku(id = "0xDEADBEEF")]
         VarA(u8),

--- a/tests/test_attributes/test_temp.rs
+++ b/tests/test_attributes/test_temp.rs
@@ -104,7 +104,7 @@ fn test_temp_field_unnamed_write() {
 fn test_temp_enum_field() {
     #[deku_derive(DekuRead, DekuWrite)]
     #[derive(PartialEq, Debug)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     enum TestEnum {
         #[deku(id = "0xAB")]
         VarA {
@@ -133,7 +133,7 @@ fn test_temp_enum_field() {
 fn test_temp_enum_field_write() {
     #[deku_derive(DekuRead, DekuWrite)]
     #[derive(PartialEq, Debug)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     enum TestEnum {
         #[deku(id = "0xAB")]
         VarA {

--- a/tests/test_catch_all.rs
+++ b/tests/test_catch_all.rs
@@ -6,7 +6,7 @@ mod test {
 
     /// Basic test struct
     #[derive(Clone, Copy, PartialEq, Eq, Debug, DekuWrite, DekuRead)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     #[non_exhaustive]
     #[repr(u8)]
     pub enum BasicMapping {
@@ -21,7 +21,7 @@ mod test {
 
     /// Advanced test struct
     #[derive(Clone, Copy, PartialEq, Eq, Debug, DekuWrite, DekuRead)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     #[non_exhaustive]
     #[repr(u8)]
     pub enum AdvancedRemapping {

--- a/tests/test_compile/cases/bits_bytes_conflict.rs
+++ b/tests/test_compile/cases/bits_bytes_conflict.rs
@@ -1,11 +1,11 @@
 use deku::prelude::*;
 
 #[derive(DekuRead)]
-#[deku(type = "u8", bits = "1", bytes = "2")]
+#[deku(id_type = "u8", bits = "1", bytes = "2")]
 enum Test1 {}
 
 #[derive(DekuRead)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum Test2 {
     A(#[deku(bits = "1", bytes = "2")] u8),
     B {

--- a/tests/test_compile/cases/bits_bytes_conflict.stderr
+++ b/tests/test_compile/cases/bits_bytes_conflict.stderr
@@ -1,8 +1,8 @@
 error: conflicting: both `bits` and `bytes` specified on enum
- --> $DIR/bits_bytes_conflict.rs:4:28
+ --> $DIR/bits_bytes_conflict.rs:4:31
   |
-4 | #[deku(type = "u8", bits = "1", bytes = "2")]
-  |                            ^^^
+4 | #[deku(id_type = "u8", bits = "1", bytes = "2")]
+  |                               ^^^
 
 error: conflicting: both `bits` and `bytes` specified on field
   --> $DIR/bits_bytes_conflict.rs:10:21

--- a/tests/test_compile/cases/catch_all_multiple.rs
+++ b/tests/test_compile/cases/catch_all_multiple.rs
@@ -1,7 +1,7 @@
 use deku::prelude::*;
 
 #[derive(DekuRead)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum Test1 {
     #[deku(default)]
     A = 1,

--- a/tests/test_compile/cases/enum_validation.rs
+++ b/tests/test_compile/cases/enum_validation.rs
@@ -4,75 +4,76 @@ use deku::prelude::*;
 #[derive(DekuRead)]
 enum Test1 {}
 
-// test conflict `type` and `id`
+// test conflict `type` and `id_type`
 #[derive(DekuRead)]
-#[deku(type = "u8", id = "test")]
+#[deku(id_type = "u8", id = "test")]
 enum Test2 {}
 
-// test conflict `id` and `id_pat`
+// test conflict `id_type` and `id_pat`
 #[derive(DekuRead)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum Test3 {
-    #[deku(id = "1", id_pat = "2..=3")] A(u8),
+    #[deku(id = "1", id_pat = "2..=3")]
+    A(u8),
 }
 
-// test `type` only allowed on enum
+// test `id_type` only allowed on enum
 #[derive(DekuRead)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 struct Test4 {
-    a: u8
+    a: u8,
 }
 
 // test `bits` only allowed on enum
 #[derive(DekuRead)]
 #[deku(bits = "1")]
 struct Test5 {
-    a: u8
+    a: u8,
 }
 
 // test `bytes` only allowed on enum
 #[derive(DekuRead)]
 #[deku(bits = "1")]
 struct Test6 {
-    a: u8
+    a: u8,
 }
 
-// test `id` only allowed on enum
+// test `id_type` only allowed on enum
 #[derive(DekuRead)]
-#[deku(id = "test")]
+#[deku(id_type = "test")]
 struct Test7 {
-    a: u8
+    a: u8,
 }
 
-// test `bits` cannot be used with `id`
+// test `bits` cannot be used with `id_type`
 #[derive(DekuRead)]
-#[deku(id = "test", bits = "4")]
+#[deku(id_type = "test", bits = "4")]
 enum Test8 {
-    A
+    A,
 }
 
-// test `bytes` cannot be used with `id`
+// test `bytes` cannot be used with `id_type`
 #[derive(DekuRead)]
-#[deku(id = "test", bytes = "4")]
+#[deku(id_type = "test", bytes = "4")]
 enum Test9 {
-    A
+    A,
 }
 
-// test `id` cannot be `_`
+// test `type_id` cannot be `_`
 #[derive(DekuRead)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum Test10 {
     #[deku(id = "_")]
-    A
+    A,
 }
 
-// test missing `id`
+// test missing `id_type`
 #[derive(DekuRead)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum Test11 {
     #[deku(id = "1")]
     A,
-    B(u8)
+    B(u8),
 }
 
 fn main() {}

--- a/tests/test_compile/cases/enum_validation.stderr
+++ b/tests/test_compile/cases/enum_validation.stderr
@@ -1,10 +1,10 @@
-error: `type` or `id` must be specified on enum
+error: `id_type` or `id` must be specified on enum
  --> $DIR/enum_validation.rs:5:6
   |
 5 | enum Test1 {}
   |      ^^^^^
 
-error: conflicting: both `type` and `id` specified on enum
+error: conflicting: both `id_type` and `id` specified on enum
   --> $DIR/enum_validation.rs:10:6
    |
 10 | enum Test2 {}
@@ -13,53 +13,53 @@ error: conflicting: both `type` and `id` specified on enum
 error: conflicting: both `id` and `id_pat` specified on variant
   --> $DIR/enum_validation.rs:16:17
    |
-16 |     #[deku(id = "1", id_pat = "2..=3")] A(u8),
+16 |     #[deku(id = "1", id_pat = "2..=3")]
    |                 ^^^
 
-error: `type` only supported on enum
-  --> $DIR/enum_validation.rs:21:15
+error: `id_type` only supported on enum
+  --> $DIR/enum_validation.rs:22:18
    |
-21 | #[deku(type = "u8")]
-   |               ^^^^
+22 | #[deku(id_type = "u8")]
+   |                  ^^^^
 
 error: `bits` only supported on enum
-  --> $DIR/enum_validation.rs:28:15
+  --> $DIR/enum_validation.rs:29:15
    |
-28 | #[deku(bits = "1")]
+29 | #[deku(bits = "1")]
    |               ^^^
 
 error: `bits` only supported on enum
-  --> $DIR/enum_validation.rs:35:15
+  --> $DIR/enum_validation.rs:36:15
    |
-35 | #[deku(bits = "1")]
+36 | #[deku(bits = "1")]
    |               ^^^
 
-error: `id` only supported on enum
-  --> $DIR/enum_validation.rs:42:13
+error: `id_type` only supported on enum
+  --> $DIR/enum_validation.rs:43:18
    |
-42 | #[deku(id = "test")]
-   |             ^^^^^^
+43 | #[deku(id_type = "test")]
+   |                  ^^^^^^
 
-error: error: cannot use `bits` with `id`
-  --> $DIR/enum_validation.rs:50:6
+error: DekuRead: `id` must be specified on non-unit variants
+  --> $DIR/enum_validation.rs:52:5
    |
-50 | enum Test8 {
-   |      ^^^^^
-
-error: error: cannot use `bytes` with `id`
-  --> $DIR/enum_validation.rs:57:6
-   |
-57 | enum Test9 {
-   |      ^^^^^
-
-error: error: `id_pat` should be used for `_`
-  --> $DIR/enum_validation.rs:66:5
-   |
-66 |     A
+52 |     A,
    |     ^
 
 error: DekuRead: `id` must be specified on non-unit variants
-  --> $DIR/enum_validation.rs:75:5
+  --> $DIR/enum_validation.rs:59:5
    |
-75 |     B(u8)
+59 |     A,
+   |     ^
+
+error: error: `id_pat` should be used for `_`
+  --> $DIR/enum_validation.rs:67:5
+   |
+67 |     A,
+   |     ^
+
+error: DekuRead: `id` must be specified on non-unit variants
+  --> $DIR/enum_validation.rs:76:5
+   |
+76 |     B(u8),
    |     ^

--- a/tests/test_compile/cases/unknown_endian.rs
+++ b/tests/test_compile/cases/unknown_endian.rs
@@ -13,11 +13,11 @@ struct Test2 {
 }
 
 #[derive(DekuRead)]
-#[deku(type = "u8", endian = "variable")]
+#[deku(id_type = "u8", endian = "variable")]
 enum Test3 {}
 
 #[derive(DekuRead)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum Test4 {
     #[deku(id = "1")]
     A(#[deku(endian = "variable")] u8),

--- a/tests/test_deku_id.rs
+++ b/tests/test_deku_id.rs
@@ -3,7 +3,7 @@ use deku::prelude::*;
 #[test]
 fn test_regular() {
     #[derive(Debug, DekuRead, DekuWrite)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     enum Request1 {
         #[deku(id = "0x01")]
         Cats { toy: u8 },
@@ -19,7 +19,7 @@ fn test_regular() {
 #[test]
 fn test_custom_type() {
     #[derive(Debug, DekuRead, PartialEq, DekuWrite)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     enum Request2 {
         #[deku(id = "0x01")]
         Cats,
@@ -29,7 +29,7 @@ fn test_custom_type() {
     }
 
     #[derive(Debug, DekuRead, DekuWrite)]
-    #[deku(type = "Request2")]
+    #[deku(id_type = "Request2")]
     enum Request3 {
         #[deku(id = "Request2::Cats")]
         Cats,
@@ -56,7 +56,7 @@ fn test_ctx() {
     assert_eq!(Ok(1), EnumId::VarA(0).deku_id());
 
     #[derive(Copy, Clone, PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     enum Nice {
         True = 0x00,
         False = 0x01,
@@ -78,7 +78,7 @@ fn test_ctx() {
 #[test]
 fn test_ctx_and_type() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(type = "u8", ctx = "_a: u8, _b: u8")]
+    #[deku(id_type = "u8", ctx = "_a: u8, _b: u8")]
     enum TopLevelCtxEnum {
         #[deku(id = "1")]
         VariantA(u8),
@@ -90,7 +90,7 @@ fn test_ctx_and_type() {
 #[test]
 fn test_litbytestr() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(type = "[u8; 3]")]
+    #[deku(id_type = "[u8; 3]")]
     enum TestEnumArray {
         #[deku(id = b"123")]
         VarA,
@@ -105,7 +105,7 @@ fn test_litbytestr() {
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: IdVariantNotFound")]
 fn test_no_id_discriminant() {
     #[derive(Debug, DekuRead, PartialEq, DekuWrite)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     enum Discriminant {
         Cats = 0x01,
         Dogs,

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -8,7 +8,7 @@ use rstest::*;
 /// TODO: These should be divided into smaller tests
 
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum TestEnum {
     #[deku(id = "1")]
     VarA(u8),
@@ -54,7 +54,7 @@ fn test_enum(input: &[u8], expected: TestEnum) {
 #[should_panic(expected = "Parse(\"Could not match enum variant id = 2 on enum `TestEnum`\")")]
 fn test_enum_error() {
     #[derive(DekuRead)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     enum TestEnum {
         #[deku(id = "1")]
         VarA(u8),
@@ -65,7 +65,7 @@ fn test_enum_error() {
 }
 
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum TestEnumDiscriminant {
     VarA = 0x00,
     VarB,
@@ -92,7 +92,7 @@ fn test_enum_discriminant(input: &[u8], expected: TestEnumDiscriminant) {
 #[test]
 fn test_enum_array_type() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(type = "[u8; 3]")]
+    #[deku(id_type = "[u8; 3]")]
     enum TestEnumArray {
         #[deku(id = b"123")]
         VarA,

--- a/tests/test_from_bytes.rs
+++ b/tests/test_from_bytes.rs
@@ -31,7 +31,7 @@ fn test_from_bytes_struct() {
 #[test]
 fn test_from_bytes_enum() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-    #[deku(type = "u8", bits = "4")]
+    #[deku(id_type = "u8", bits = "4")]
     enum TestDeku {
         #[deku(id = "0b0110")]
         VariantA(#[deku(bits = "4")] u8),

--- a/tests/test_from_reader.rs
+++ b/tests/test_from_reader.rs
@@ -37,7 +37,7 @@ fn test_from_reader_struct() {
 #[test]
 fn test_from_reader_enum() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-    #[deku(type = "u8", bits = "4")]
+    #[deku(id_type = "u8", bits = "4")]
     enum TestDeku {
         #[deku(id = "0b0110")]
         VariantA(#[deku(bits = "4")] u8),

--- a/tests/test_generic.rs
+++ b/tests/test_generic.rs
@@ -24,7 +24,7 @@ fn test_generic_struct() {
 #[test]
 fn test_generic_enum() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(type = "u8")]
+    #[deku(id_type = "u8")]
     enum TestEnum<T>
     where
         T: deku::DekuWriter + for<'a> deku::DekuReader<'a>,

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -58,7 +58,7 @@ fn test_magic_struct(input: &[u8]) {
 )]
 fn test_magic_enum(input: &[u8]) {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(magic = b"deku", type = "u8")]
+    #[deku(magic = b"deku", id_type = "u8")]
     enum TestEnum {
         #[deku(id = "0")]
         Variant,

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -18,7 +18,7 @@ fn issue_224() {
     }
 
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-    #[deku(type = "u8", bits = "2")]
+    #[deku(id_type = "u8", bits = "2")]
     pub enum One {
         Start = 0,
         Go = 1,
@@ -26,7 +26,7 @@ fn issue_224() {
     }
 
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
-    #[deku(type = "u8", bits = "4")]
+    #[deku(id_type = "u8", bits = "4")]
     pub enum Two {
         #[deku(id = "0b0000")]
         Put(Op1),

--- a/tests/test_to_bits.rs
+++ b/tests/test_to_bits.rs
@@ -38,7 +38,7 @@ fn test_to_bits_correct_over() {
 }
 
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8", bits = "4")]
+#[deku(id_type = "u8", bits = "4")]
 enum TestEnum {
     #[deku(id = "0b1010")]
     VarA,

--- a/tests/test_tuple.rs
+++ b/tests/test_tuple.rs
@@ -5,7 +5,7 @@ use hexlit::hex;
 use rstest::*;
 
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 enum TestEnum {
     #[deku(id = "1")]
     VarA((u8, u16)),


### PR DESCRIPTION
- Change `type` for enums into `id_type`, as this is no longer accepted through the syn parser library
- Update `rstest` to `0.18.0` to rid of another syn1 depend.

Closes https://github.com/sharksforarms/deku/issues/351

`syn` is still built for `dev-dependencies`, of which `alloc_counter` hasn't been update in a while:
```
  39   │ [dev-dependencies]
  40   │ ├── alloc_counter v0.0.4
  41   │ │   ├── alloc_counter_macro v0.0.2 (proc-macro)
  42   │ │   │   ├── proc-macro2 v1.0.69 (*)
  43   │ │   │   ├── quote v1.0.33 (*)
  44   │ │   │   └── syn v1.0.109
```