### PR TITLE
Improve performance after `impl-writer` and `impl-reader`

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -117,6 +117,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp ::#crate_::DekuReader<#lifetime, #ctx_types> for #ident #wher {
+            #[inline(always)]
             fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, #ctx_arg) -> core::result::Result<Self, ::#crate_::DekuError> {
                 #read_body
             }

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -377,7 +377,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     tokens.extend(quote! {
         #[allow(non_snake_case)]
         impl #imp ::#crate_::DekuReader<#lifetime, #ctx_types> for #ident #wher {
-                #[inline(always)]
+            #[inline(always)]
             fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, #ctx_arg) -> core::result::Result<Self, ::#crate_::DekuError> {
                 #read_body
             }
@@ -410,6 +410,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     if let Some(deku_id_type) = deku_id_type {
         tokens.extend(quote! {
             impl #imp DekuEnumExt<#lifetime, (#deku_id_type)> for #ident #wher {
+                #[inline(always)]
                 fn deku_id(&self) -> core::result::Result<(#deku_id_type), DekuError> {
                     match self {
                         #(#deku_ids ,)*
@@ -781,11 +782,13 @@ pub fn emit_container_read(
     quote! {
         impl #imp ::#crate_::DekuContainerRead<#lifetime> for #ident #wher {
             #[allow(non_snake_case)]
+            #[inline(always)]
             fn from_reader<'a, R: ::#crate_::no_std_io::Read>(__deku_input: (&'a mut R, usize)) -> core::result::Result<(usize, Self), ::#crate_::DekuError> {
                 #from_reader_body
             }
 
             #[allow(non_snake_case)]
+            #[inline(always)]
             fn from_bytes(__deku_input: (&#lifetime [u8], usize)) -> core::result::Result<((&#lifetime [u8], usize), Self), ::#crate_::DekuError> {
                 #from_bytes_body
             }
@@ -805,6 +808,7 @@ pub fn emit_try_from(
         impl #imp core::convert::TryFrom<&#lifetime [u8]> for #ident #wher {
             type Error = ::#crate_::DekuError;
 
+            #[inline(always)]
             fn try_from(input: &#lifetime [u8]) -> core::result::Result<Self, Self::Error> {
                 let total_len = input.len();
                 let mut cursor = ::#crate_::no_std_io::Cursor::new(input);

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -117,7 +117,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp ::#crate_::DekuReader<#lifetime, #ctx_types> for #ident #wher {
-            #[inline(always)]
+            #[inline]
             fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, #ctx_arg) -> core::result::Result<Self, ::#crate_::DekuError> {
                 #read_body
             }
@@ -129,7 +129,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         tokens.extend(quote! {
             impl #imp ::#crate_::DekuReader<#lifetime> for #ident #wher {
-                #[inline(always)]
+                #[inline]
                 fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, _: ()) -> core::result::Result<Self, ::#crate_::DekuError> {
                     #read_body
                 }
@@ -378,7 +378,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     tokens.extend(quote! {
         #[allow(non_snake_case)]
         impl #imp ::#crate_::DekuReader<#lifetime, #ctx_types> for #ident #wher {
-            #[inline(always)]
+            #[inline]
             fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, #ctx_arg) -> core::result::Result<Self, ::#crate_::DekuError> {
                 #read_body
             }
@@ -391,7 +391,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             #[allow(non_snake_case)]
             impl #imp ::#crate_::DekuReader<#lifetime> for #ident #wher {
-                #[inline(always)]
+                #[inline]
                 fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, _: ()) -> core::result::Result<Self, ::#crate_::DekuError> {
                     #read_body
                 }
@@ -411,7 +411,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     if let Some(deku_id_type) = deku_id_type {
         tokens.extend(quote! {
             impl #imp DekuEnumExt<#lifetime, (#deku_id_type)> for #ident #wher {
-                #[inline(always)]
+                #[inline]
                 fn deku_id(&self) -> core::result::Result<(#deku_id_type), DekuError> {
                     match self {
                         #(#deku_ids ,)*
@@ -783,13 +783,13 @@ pub fn emit_container_read(
     quote! {
         impl #imp ::#crate_::DekuContainerRead<#lifetime> for #ident #wher {
             #[allow(non_snake_case)]
-            #[inline(always)]
+            #[inline]
             fn from_reader<'a, R: ::#crate_::no_std_io::Read>(__deku_input: (&'a mut R, usize)) -> core::result::Result<(usize, Self), ::#crate_::DekuError> {
                 #from_reader_body
             }
 
             #[allow(non_snake_case)]
-            #[inline(always)]
+            #[inline]
             fn from_bytes(__deku_input: (&#lifetime [u8], usize)) -> core::result::Result<((&#lifetime [u8], usize), Self), ::#crate_::DekuError> {
                 #from_bytes_body
             }
@@ -809,7 +809,7 @@ pub fn emit_try_from(
         impl #imp core::convert::TryFrom<&#lifetime [u8]> for #ident #wher {
             type Error = ::#crate_::DekuError;
 
-            #[inline(always)]
+            #[inline]
             fn try_from(input: &#lifetime [u8]) -> core::result::Result<Self, Self::Error> {
                 let total_len = input.len();
                 let mut cursor = ::#crate_::no_std_io::Cursor::new(input);

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -128,6 +128,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         tokens.extend(quote! {
             impl #imp ::#crate_::DekuReader<#lifetime> for #ident #wher {
+                #[inline(always)]
                 fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, _: ()) -> core::result::Result<Self, ::#crate_::DekuError> {
                     #read_body
                 }
@@ -376,6 +377,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     tokens.extend(quote! {
         #[allow(non_snake_case)]
         impl #imp ::#crate_::DekuReader<#lifetime, #ctx_types> for #ident #wher {
+                #[inline(always)]
             fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, #ctx_arg) -> core::result::Result<Self, ::#crate_::DekuError> {
                 #read_body
             }
@@ -388,6 +390,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             #[allow(non_snake_case)]
             impl #imp ::#crate_::DekuReader<#lifetime> for #ident #wher {
+                #[inline(always)]
                 fn from_reader_with_ctx<R: ::#crate_::no_std_io::Read>(__deku_reader: &mut ::#crate_::reader::Reader<R>, _: ()) -> core::result::Result<Self, ::#crate_::DekuError> {
                     #read_body
                 }

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -51,6 +51,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
              impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> #wher {
                 type Error = ::#crate_::DekuError;
 
+                #[inline(always)]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     input.to_bits()
                 }
@@ -59,6 +60,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
                 type Error = ::#crate_::DekuError;
 
+                #[inline(always)]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     ::#crate_::DekuContainerWrite::to_bytes(&input)
                 }
@@ -86,6 +88,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
+            #[inline(always)]
             fn update(&mut self) -> core::result::Result<(), ::#crate_::DekuError> {
                 #update_use
                 #(#field_updates)*
@@ -96,6 +99,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         impl #imp ::#crate_::DekuWriter<#ctx_types> for #ident #wher {
             #[allow(unused_variables)]
+            #[inline(always)]
             fn to_writer<W: ::#crate_::no_std_io::Write>(&self, __deku_writer: &mut ::#crate_::writer::Writer<W>, #ctx_arg) -> core::result::Result<(), ::#crate_::DekuError> {
                 #write_body
             }
@@ -108,6 +112,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             impl #imp ::#crate_::DekuWriter for #ident #wher {
                 #[allow(unused_variables)]
+                #[inline(always)]
                 fn to_writer<W: ::#crate_::no_std_io::Write>(&self, __deku_writer: &mut ::#crate_::writer::Writer<W>, _: ()) -> core::result::Result<(), ::#crate_::DekuError> {
                     #write_body
                 }
@@ -242,6 +247,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
              impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> #wher {
                 type Error = ::#crate_::DekuError;
 
+                #[inline(always)]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     input.to_bits()
                 }
@@ -250,6 +256,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
                 type Error = ::#crate_::DekuError;
 
+                #[inline(always)]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     ::#crate_::DekuContainerWrite::to_bytes(&input)
                 }
@@ -276,6 +283,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
+            #[inline(always)]
             fn update(&mut self) -> core::result::Result<(), ::#crate_::DekuError> {
                 #update_use
 
@@ -289,6 +297,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         impl #imp ::#crate_::DekuWriter<#ctx_types> for #ident #wher {
             #[allow(unused_variables)]
+            #[inline(always)]
             fn to_writer<W: ::#crate_::no_std_io::Write>(&self, __deku_writer: &mut ::#crate_::writer::Writer<W>, #ctx_arg) -> core::result::Result<(), ::#crate_::DekuError> {
                 #write_body
             }
@@ -301,6 +310,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             impl #imp ::#crate_::DekuWriter for #ident #wher {
                 #[allow(unused_variables)]
+                #[inline(always)]
                 fn to_writer<W: ::#crate_::no_std_io::Write>(&self, __deku_writer: &mut ::#crate_::writer::Writer<W>, _: ()) -> core::result::Result<(), ::#crate_::DekuError> {
                     #write_body
                 }

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -51,7 +51,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
              impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> #wher {
                 type Error = ::#crate_::DekuError;
 
-                #[inline(always)]
+                #[inline]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     input.to_bits()
                 }
@@ -60,7 +60,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
                 type Error = ::#crate_::DekuError;
 
-                #[inline(always)]
+                #[inline]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     ::#crate_::DekuContainerWrite::to_bytes(&input)
                 }
@@ -88,7 +88,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
-            #[inline(always)]
+            #[inline]
             fn update(&mut self) -> core::result::Result<(), ::#crate_::DekuError> {
                 #update_use
                 #(#field_updates)*
@@ -99,7 +99,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         impl #imp ::#crate_::DekuWriter<#ctx_types> for #ident #wher {
             #[allow(unused_variables)]
-            #[inline(always)]
+            #[inline]
             fn to_writer<W: ::#crate_::no_std_io::Write>(&self, __deku_writer: &mut ::#crate_::writer::Writer<W>, #ctx_arg) -> core::result::Result<(), ::#crate_::DekuError> {
                 #write_body
             }
@@ -112,7 +112,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             impl #imp ::#crate_::DekuWriter for #ident #wher {
                 #[allow(unused_variables)]
-                #[inline(always)]
+                #[inline]
                 fn to_writer<W: ::#crate_::no_std_io::Write>(&self, __deku_writer: &mut ::#crate_::writer::Writer<W>, _: ()) -> core::result::Result<(), ::#crate_::DekuError> {
                     #write_body
                 }
@@ -247,7 +247,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
              impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> #wher {
                 type Error = ::#crate_::DekuError;
 
-                #[inline(always)]
+                #[inline]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     input.to_bits()
                 }
@@ -256,7 +256,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
                 type Error = ::#crate_::DekuError;
 
-                #[inline(always)]
+                #[inline]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
                     ::#crate_::DekuContainerWrite::to_bytes(&input)
                 }
@@ -283,7 +283,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     tokens.extend(quote! {
         impl #imp DekuUpdate for #ident #wher {
-            #[inline(always)]
+            #[inline]
             fn update(&mut self) -> core::result::Result<(), ::#crate_::DekuError> {
                 #update_use
 
@@ -297,7 +297,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         impl #imp ::#crate_::DekuWriter<#ctx_types> for #ident #wher {
             #[allow(unused_variables)]
-            #[inline(always)]
+            #[inline]
             fn to_writer<W: ::#crate_::no_std_io::Write>(&self, __deku_writer: &mut ::#crate_::writer::Writer<W>, #ctx_arg) -> core::result::Result<(), ::#crate_::DekuError> {
                 #write_body
             }
@@ -310,7 +310,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         tokens.extend(quote! {
             impl #imp ::#crate_::DekuWriter for #ident #wher {
                 #[allow(unused_variables)]
-                #[inline(always)]
+                #[inline]
                 fn to_writer<W: ::#crate_::no_std_io::Write>(&self, __deku_writer: &mut ::#crate_::writer::Writer<W>, _: ()) -> core::result::Result<(), ::#crate_::DekuError> {
                     #write_body
                 }

--- a/examples/ipv4.rs
+++ b/examples/ipv4.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::net::Ipv4Addr;
 
 use deku::prelude::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,16 +13,19 @@ pub struct NeedSize {
 
 impl NeedSize {
     /// Create new [NeedSize] from bits
+    #[inline]
     pub fn new(bits: usize) -> Self {
         Self { bits }
     }
 
     /// Number of bits needed
+    #[inline]
     pub fn bit_size(&self) -> usize {
         self.bits
     }
 
     /// Number of bytes needed
+    #[inline]
     pub fn byte_size(&self) -> usize {
         (self.bits + 7) / 8
     }

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -60,7 +60,7 @@ where
 
 // specialize u8 for ByteSize
 impl DekuRead<'_, (Endian, ByteSize)> for u8 {
-    #[inline(always)]
+    #[inline]
     fn read(
         input: &BitSlice<u8, Msb0>,
         (_, _): (Endian, ByteSize),
@@ -98,7 +98,7 @@ impl DekuReader<'_, (Endian, ByteSize)> for u8 {
 macro_rules! ImplDekuReadBits {
     ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, BitSize)> for $typ {
-            #[inline(always)]
+            #[inline(never)]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, BitSize),
@@ -200,7 +200,7 @@ macro_rules! ImplDekuReadBits {
 macro_rules! ImplDekuReadBytes {
     ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, ByteSize)> for $typ {
-            #[inline(always)]
+            #[inline(never)]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, ByteSize),
@@ -235,7 +235,7 @@ macro_rules! ImplDekuReadBytes {
                         size.0
                     )));
                 }
-                let mut buf = [0; core::mem::size_of::<$typ>()];
+                let mut buf = [0; MAX_TYPE_BYTES];
                 let ret = reader.read_bytes(size.0, &mut buf)?;
                 let a = match ret {
                     ReaderRet::Bytes => {
@@ -267,7 +267,7 @@ macro_rules! ImplDekuReadBytes {
 macro_rules! ImplDekuReadSignExtend {
     ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, ByteSize)> for $typ {
-            #[inline(always)]
+            #[inline(never)]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, ByteSize),
@@ -317,7 +317,7 @@ macro_rules! ImplDekuReadSignExtend {
         }
 
         impl DekuRead<'_, (Endian, BitSize)> for $typ {
-            #[inline(always)]
+            #[inline(never)]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, BitSize),
@@ -368,9 +368,9 @@ macro_rules! ForwardDekuRead {
                 reader: &mut Reader<R>,
                 endian: Endian,
             ) -> Result<$typ, DekuError> {
-                let byte_size = core::mem::size_of::<$typ>();
+                const BYTE_SIZE: usize = core::mem::size_of::<$typ>();
 
-                <$typ>::from_reader_with_ctx(reader, (endian, ByteSize(byte_size)))
+                <$typ>::from_reader_with_ctx(reader, (endian, ByteSize(BYTE_SIZE)))
             }
         }
 

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -60,7 +60,7 @@ where
 
 // specialize u8 for ByteSize
 impl DekuRead<'_, (Endian, ByteSize)> for u8 {
-    #[inline]
+    #[inline(always)]
     fn read(
         input: &BitSlice<u8, Msb0>,
         (_, _): (Endian, ByteSize),
@@ -74,7 +74,7 @@ impl DekuRead<'_, (Endian, ByteSize)> for u8 {
 }
 
 impl DekuReader<'_, (Endian, ByteSize)> for u8 {
-    #[inline]
+    #[inline(always)]
     fn from_reader_with_ctx<R: Read>(
         reader: &mut Reader<R>,
         (endian, size): (Endian, ByteSize),
@@ -98,7 +98,7 @@ impl DekuReader<'_, (Endian, ByteSize)> for u8 {
 macro_rules! ImplDekuReadBits {
     ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, BitSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, BitSize),
@@ -174,7 +174,7 @@ macro_rules! ImplDekuReadBits {
         }
 
         impl DekuReader<'_, (Endian, BitSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn from_reader_with_ctx<R: Read>(
                 reader: &mut Reader<R>,
                 (endian, size): (Endian, BitSize),
@@ -200,7 +200,7 @@ macro_rules! ImplDekuReadBits {
 macro_rules! ImplDekuReadBytes {
     ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, ByteSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, ByteSize),
@@ -223,7 +223,7 @@ macro_rules! ImplDekuReadBytes {
         }
 
         impl DekuReader<'_, (Endian, ByteSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn from_reader_with_ctx<R: Read>(
                 reader: &mut Reader<R>,
                 (endian, size): (Endian, ByteSize),
@@ -267,7 +267,7 @@ macro_rules! ImplDekuReadBytes {
 macro_rules! ImplDekuReadSignExtend {
     ($typ:ty, $inner:ty) => {
         impl DekuRead<'_, (Endian, ByteSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, ByteSize),
@@ -284,7 +284,7 @@ macro_rules! ImplDekuReadSignExtend {
         }
 
         impl DekuReader<'_, (Endian, ByteSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn from_reader_with_ctx<R: Read>(
                 reader: &mut Reader<R>,
                 (endian, size): (Endian, ByteSize),
@@ -317,7 +317,7 @@ macro_rules! ImplDekuReadSignExtend {
         }
 
         impl DekuRead<'_, (Endian, BitSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn read(
                 input: &BitSlice<u8, Msb0>,
                 (endian, size): (Endian, BitSize),
@@ -334,7 +334,7 @@ macro_rules! ImplDekuReadSignExtend {
         }
 
         impl DekuReader<'_, (Endian, BitSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn from_reader_with_ctx<R: Read>(
                 reader: &mut Reader<R>,
                 (endian, size): (Endian, BitSize),
@@ -363,7 +363,7 @@ macro_rules! ForwardDekuRead {
     ($typ:ty) => {
         // Only have `endian`, set `bit_size` to `Size::of::<Type>()`
         impl DekuReader<'_, Endian> for $typ {
-            #[inline]
+            #[inline(always)]
             fn from_reader_with_ctx<R: Read>(
                 reader: &mut Reader<R>,
                 endian: Endian,
@@ -376,7 +376,7 @@ macro_rules! ForwardDekuRead {
 
         // Only have `byte_size`, set `endian` to `Endian::default`.
         impl DekuReader<'_, ByteSize> for $typ {
-            #[inline]
+            #[inline(always)]
             fn from_reader_with_ctx<R: Read>(
                 reader: &mut Reader<R>,
                 byte_size: ByteSize,
@@ -390,7 +390,7 @@ macro_rules! ForwardDekuRead {
 
         //// Only have `bit_size`, set `endian` to `Endian::default`.
         impl DekuReader<'_, BitSize> for $typ {
-            #[inline]
+            #[inline(always)]
             fn from_reader_with_ctx<R: Read>(
                 reader: &mut Reader<R>,
                 bit_size: BitSize,
@@ -406,7 +406,7 @@ macro_rules! ForwardDekuRead {
         }
 
         impl DekuReader<'_> for $typ {
-            #[inline]
+            #[inline(always)]
             fn from_reader_with_ctx<R: Read>(
                 reader: &mut Reader<R>,
                 _: (),
@@ -420,7 +420,7 @@ macro_rules! ForwardDekuRead {
 macro_rules! ImplDekuWrite {
     ($typ:ty) => {
         impl DekuWriter<(Endian, BitSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn to_writer<W: Write>(
                 &self,
                 writer: &mut Writer<W>,
@@ -466,7 +466,7 @@ macro_rules! ImplDekuWrite {
         }
 
         impl DekuWriter<(Endian, ByteSize)> for $typ {
-            #[inline]
+            #[inline(always)]
             fn to_writer<W: Write>(
                 &self,
                 writer: &mut Writer<W>,
@@ -517,7 +517,7 @@ macro_rules! ImplDekuWrite {
 macro_rules! ForwardDekuWrite {
     ($typ:ty) => {
         impl DekuWriter<BitSize> for $typ {
-            #[inline]
+            #[inline(always)]
             fn to_writer<W: Write>(
                 &self,
                 writer: &mut Writer<W>,
@@ -528,7 +528,7 @@ macro_rules! ForwardDekuWrite {
         }
 
         impl DekuWriter<ByteSize> for $typ {
-            #[inline]
+            #[inline(always)]
             fn to_writer<W: Write>(
                 &self,
                 writer: &mut Writer<W>,
@@ -539,7 +539,7 @@ macro_rules! ForwardDekuWrite {
         }
 
         impl DekuWriter for $typ {
-            #[inline]
+            #[inline(always)]
             fn to_writer<W: Write>(&self, writer: &mut Writer<W>, _: ()) -> Result<(), DekuError> {
                 <$typ>::to_writer(self, writer, Endian::default())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,6 +531,7 @@ where
     T: DekuWriter<Ctx>,
     Ctx: Copy,
 {
+    #[inline(always)]
     fn to_writer<W: no_std_io::Write>(
         &self,
         writer: &mut Writer<W>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,6 +472,7 @@ pub trait DekuContainerWrite: DekuWriter<()> {
     /// let bytes = s.to_bytes().unwrap();
     /// assert_eq!(bytes, [0x01, 0x02, 0x00, 0x03, 0x00, 0x00, 0x00]);
     /// ````
+    #[inline(always)]
     fn to_bytes(&self) -> Result<Vec<u8>, DekuError> {
         let mut out_buf = Vec::new();
         let mut __deku_writer = Writer::new(&mut out_buf);
@@ -501,6 +502,7 @@ pub trait DekuContainerWrite: DekuWriter<()> {
     /// let bits = test.to_bits().unwrap();
     /// assert_eq!(deku::bitvec::bitvec![1, 1, 1, 1, 0, 0, 0, 1, 1], bits);
     /// ```
+    #[inline(always)]
     fn to_bits(&self) -> Result<bitvec::BitVec<u8, bitvec::Msb0>, DekuError> {
         let mut out_buf = Vec::new();
         let mut __deku_writer = Writer::new(&mut out_buf);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -134,7 +134,7 @@ impl<'a, R: Read> Reader<'a, R> {
     ///
     /// # Params
     /// `amt`    - Amount of bits that will be read. Must be <= [`MAX_BITS_AMT`].
-    #[cold]
+    #[inline(never)]
     pub fn read_bits(&mut self, amt: usize) -> Result<Option<BitVec<u8, Msb0>>, DekuError> {
         #[cfg(feature = "logging")]
         log::trace!("read_bits: requesting {amt} bits");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -134,7 +134,7 @@ impl<'a, R: Read> Reader<'a, R> {
     ///
     /// # Params
     /// `amt`    - Amount of bits that will be read. Must be <= [`MAX_BITS_AMT`].
-    #[inline]
+    #[cold]
     pub fn read_bits(&mut self, amt: usize) -> Result<Option<BitVec<u8, Msb0>>, DekuError> {
         #[cfg(feature = "logging")]
         log::trace!("read_bits: requesting {amt} bits");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -206,7 +206,7 @@ impl<'a, R: Read> Reader<'a, R> {
     ///
     /// # Params
     /// `amt`    - Amount of bytes that will be read
-    #[inline]
+    #[inline(always)]
     pub fn read_bytes(&mut self, amt: usize, buf: &mut [u8]) -> Result<ReaderRet, DekuError> {
         #[cfg(feature = "logging")]
         log::trace!("read_bytes: requesting {amt} bytes");

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -43,7 +43,7 @@ impl<W: Write> Writer<W> {
     ///
     /// Any leftover bits will be written before `bits`, and non-written bits will
     /// be stored in `self.leftover`.
-    #[inline]
+    #[inline(never)]
     pub fn write_bits(&mut self, bits: &BitSlice<u8, Msb0>) -> Result<(), DekuError> {
         #[cfg(feature = "logging")]
         log::trace!("attempting {} bits", bits.len());


### PR DESCRIPTION
This fixes *most* performance issues where the rustc compiler in different version with different parameters didn't inline several functions, both generated and `impl`'ed in deku.

See https://github.com/wcampbell0x2a/deku-bench/pull/6 for benchmarks. Speaking of which I will probably add these benchmarks directly into this project at some point.

I actually opened a ticked for `rust-lang`, since the nightly changes regressed the performance of this crate, until this commit was added: https://github.com/rust-lang/rust/issues/118674

This might removed the need for testing: https://github.com/sharksforarms/deku/issues/358, and discussed with https://github.com/sharksforarms/deku/issues/308#issuecomment-1532593054.

See https://github.com/sharksforarms/deku/issues/25