### PR TITLE
Fix unknown id Type for EnumExt::deku_id()

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -4,7 +4,6 @@ use darling::ast::{Data, Fields};
 use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::spanned::Spanned;
 
 use crate::macros::{
     gen_ctx_types_and_arg, gen_field_args, gen_internal_field_ident, gen_internal_field_idents,
@@ -397,11 +396,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let deku_id_type = if let Some(id_type) = id_type {
         Some(quote! {#id_type})
     } else if let (Some(ctx), Some(id)) = (input.ctx.as_ref(), input.id.as_ref()) {
-        if let Some(r) = gen_type_from_ctx_id(ctx, id) {
-            Some(r)
-        } else {
-            None
-        }
+        gen_type_from_ctx_id(ctx, id)
     } else {
         None
     };

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -397,12 +397,11 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let deku_id_type = if let Some(id_type) = id_type {
         Some(quote! {#id_type})
     } else if let (Some(ctx), Some(id)) = (input.ctx.as_ref(), input.id.as_ref()) {
-        Some(gen_type_from_ctx_id(ctx, id).ok_or_else(|| {
-            syn::Error::new(
-                id.span(),
-                "DekuReader: cannot determine `id` type from `ctx`",
-            )
-        })?)
+        if let Some(r) = gen_type_from_ctx_id(ctx, id) {
+            Some(r)
+        } else {
+            None
+        }
     } else {
         None
     };

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -199,7 +199,9 @@ fn gen_type_from_ctx_id(
     id: &crate::Id,
 ) -> Option<TokenStream> {
     let parser = Punctuated::<Ident, Comma>::parse_terminated;
-    let s = parser.parse(id.to_token_stream().into()).unwrap();
+    let Ok(s) = parser.parse(id.to_token_stream().into()) else {
+        return None;
+    };
     let mut matching_types = quote! {};
     for s in s {
         let id = syn::Ident::new(&s.to_string(), id.span());

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -359,3 +359,35 @@ fn issue_310() {
     #[derive(DekuRead, DekuWrite)]
     struct Test {}
 }
+
+#[test]
+fn issue_397() {
+    use deku::prelude::*;
+
+    #[derive(Debug, Copy, Clone, PartialEq, DekuRead, DekuWrite)]
+    struct Header {
+        kind: PacketType,
+    }
+
+    #[derive(Debug, Copy, Clone, PartialEq, DekuRead, DekuWrite)]
+    #[deku(type = "u8", endian = "big")]
+    enum PacketType {
+        #[deku(id = 0)]
+        Zero,
+    }
+
+    #[derive(Debug, Copy, Clone, PartialEq, DekuRead, DekuWrite)]
+    struct Packet {
+        header: Header,
+        #[deku(ctx = "header")]
+        payload: Payload,
+    }
+
+    #[derive(Debug, Copy, Clone, PartialEq, DekuRead, DekuWrite)]
+    #[deku(ctx = "header: &Header", id = "header.kind")]
+    enum Payload {
+        #[deku(id = "PacketType::Zero")]
+        Zero(u8),
+    }
+    let _ = Packet::from_bytes((&[0x00, 0x01], 0));
+}


### PR DESCRIPTION
Remove unwrap causing the following error when the EnumExt tried to infer what type is was to return. An attribute could be added in the future to aid this, but for now we will just not emit the deku_id() for this type of enum. I decided in other causes (which aren't tested), to also remove the error and just not emit the function also.

 help: message: called `Result::unwrap()` on an `Err` value: Error("expected `,`")

Closes #397