### PR TITLE
Remove one writer alloc

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -19,6 +19,9 @@ pub enum ReaderRet {
     Bits(Option<BitVec<u8, Msb0>>),
 }
 
+/// Max bits requested from [`Reader::read_bits`] during one call
+pub const MAX_BITS_AMT: usize = 128;
+
 /// Reader to use with `from_reader_with_ctx`
 pub struct Reader<'a, R: Read> {
     inner: &'a mut R,
@@ -27,9 +30,6 @@ pub struct Reader<'a, R: Read> {
     /// Amount of bits read during the use of [read_bits](Reader::read_bits) and [read_bytes](Reader::read_bytes).
     pub bits_read: usize,
 }
-
-/// Max bits requested from [`Reader::read_bits`] during one call
-pub const MAX_BITS_AMT: usize = 128;
 
 impl<'a, R: Read> Reader<'a, R> {
     /// Create a new `Reader`

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -63,4 +63,19 @@ mod tests {
             (5, 0, 5)
         );
     }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_simple_write() {
+        let input = hex!("aa_bbbb_cc_0102_dd_ffffff_aa_0100ff");
+        let t = TestDeku::from_reader((&mut input.as_slice(), 0)).unwrap().1;
+
+        assert_eq!(
+            count_alloc(|| {
+                t.to_bytes().unwrap();
+            })
+            .0,
+            (2, 1, 2)
+        );
+    }
 }


### PR DESCRIPTION
* Remove allocation and force bit.len() < MAX_BITS_AMT like reader does
* Speed up deku_write_bits by 20% on my machine