### PR TITLE
Add returning io:ErrorKind from reader and writer

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -88,7 +88,7 @@ impl core::fmt::Display for DekuError {
             DekuError::Assertion(ref err) => write!(f, "Assertion error: {err}"),
             DekuError::AssertionNoStr => write!(f, "Assertion error"),
             DekuError::IdVariantNotFound => write!(f, "Could not resolve `id` for variant"),
-            DekuError::Io(ref e) => write!(f, "io errorr: {e}"),
+            DekuError::Io(ref e) => write!(f, "io errorr: {e:?}"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@
 
 #![cfg(feature = "alloc")]
 
+use no_std_io::io::ErrorKind;
+
 use alloc::format;
 use alloc::string::String;
 
@@ -49,8 +51,8 @@ pub enum DekuError {
     AssertionNoStr,
     /// Could not resolve `id` for variant
     IdVariantNotFound,
-    /// IO error while writing
-    Write,
+    /// IO error while reading or writing
+    Io(ErrorKind),
 }
 
 impl From<core::num::TryFromIntError> for DekuError {
@@ -86,7 +88,7 @@ impl core::fmt::Display for DekuError {
             DekuError::Assertion(ref err) => write!(f, "Assertion error: {err}"),
             DekuError::AssertionNoStr => write!(f, "Assertion error"),
             DekuError::IdVariantNotFound => write!(f, "Could not resolve `id` for variant"),
-            DekuError::Write => write!(f, "write error"),
+            DekuError::Io(ref e) => write!(f, "io errorr: {e}"),
         }
     }
 }
@@ -110,7 +112,7 @@ impl From<DekuError> for std::io::Error {
             DekuError::Assertion(_) => io::Error::new(io::ErrorKind::InvalidData, error),
             DekuError::AssertionNoStr => io::Error::from(io::ErrorKind::InvalidData),
             DekuError::IdVariantNotFound => io::Error::new(io::ErrorKind::NotFound, error),
-            DekuError::Write => io::Error::new(io::ErrorKind::BrokenPipe, error),
+            DekuError::Io(e) => io::Error::new(e, error),
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -169,8 +169,7 @@ impl<'a, R: Read> Reader<'a, R> {
                     if e.kind() == ErrorKind::UnexpectedEof {
                         return Err(DekuError::Incomplete(NeedSize::new(amt)));
                     }
-
-                    // TODO: other errors?
+                    return Err(DekuError::Io(e.kind()));
                 }
                 let read_buf = &buf[..bytes_len];
 
@@ -219,8 +218,7 @@ impl<'a, R: Read> Reader<'a, R> {
                 if e.kind() == ErrorKind::UnexpectedEof {
                     return Err(DekuError::Incomplete(NeedSize::new(amt * 8)));
                 }
-
-                // TODO: other errors?
+                return Err(DekuError::Io(e.kind()));
             }
 
             self.bits_read += amt * 8;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -81,8 +81,8 @@ impl<W: Write> Writer<W> {
         bits = unsafe { bits.get_unchecked(count * bits_of::<u8>()..) };
 
         self.leftover = bits.to_bitvec();
-        if self.inner.write_all(&buf).is_err() {
-            return Err(DekuError::Write);
+        if let Err(e) = self.inner.write_all(&buf) {
+            return Err(DekuError::Io(e.kind()));
         }
 
         self.bits_written += buf.len() * 8;
@@ -110,8 +110,8 @@ impl<W: Write> Writer<W> {
             // instead of sending the entire thing. The rest would be through self.inner.write.
             self.write_bits(&BitVec::from_slice(buf))?;
         } else {
-            if self.inner.write_all(buf).is_err() {
-                return Err(DekuError::Write);
+            if let Err(e) = self.inner.write_all(buf) {
+                return Err(DekuError::Io(e.kind()));
             }
             self.bits_written += buf.len() * 8;
         }
@@ -141,8 +141,8 @@ impl<W: Write> Writer<W> {
                     *slot = byte.load_be();
                 });
 
-            if self.inner.write_all(&buf).is_err() {
-                return Err(DekuError::Write);
+            if let Err(e) = self.inner.write_all(&buf) {
+                return Err(DekuError::Io(e.kind()));
             }
             self.bits_written += buf.len() * 8;
 


### PR DESCRIPTION
* Remove DekuError::Write and replace with DekuError::Io. Instead of ignoring error other then UnexpectedEof, return them to bubble up.