### PR TITLE
Change Strings in DekuError to Cow<'static, str>

### DIFF
--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -1,10 +1,11 @@
 /*!
 Procedural macros that implement `DekuRead` and `DekuWrite` traits
  */
-
 #![warn(missing_docs)]
 
-use std::borrow::Cow;
+extern crate alloc;
+
+use alloc::borrow::Cow;
 use std::convert::TryFrom;
 
 use darling::{ast, FromDeriveInput, FromField, FromMeta, FromVariant, ToTokens};

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -414,11 +414,13 @@ fn emit_padding(bit_size: &TokenStream) -> TokenStream {
     quote! {
         {
             use core::convert::TryFrom;
+            extern crate alloc;
+            use alloc::borrow::Cow;
             let __deku_pad = usize::try_from(#bit_size).map_err(|e|
-                ::#crate_::DekuError::InvalidParam(format!(
+                ::#crate_::DekuError::InvalidParam(Cow::from(format!(
                     "Invalid padding param \"({})\": cannot convert to usize",
                     stringify!(#bit_size)
-                ))
+                )))
             )?;
             __deku_writer.write_bits(::#crate_::bitvec::bitvec![u8, ::#crate_::bitvec::Msb0; 0; __deku_pad].as_bitslice())?;
         }

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -372,12 +372,14 @@ fn assertion_failed(
     #[cfg(not(feature = "no-assert-string"))]
     {
         quote! {
-            return Err(::#crate_::DekuError::Assertion(format!(
+            extern crate alloc;
+            use alloc::borrow::Cow;
+            return Err(::#crate_::DekuError::Assertion(Cow::from(format!(
                 "{}.{} field failed assertion: {}",
                 #ident,
                 #field_ident_str,
                 #stringify,
-            )));
+            ))));
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
 //! Error module
 
 #![cfg(feature = "alloc")]
+use alloc::borrow::Cow;
 
 use alloc::format;
-use alloc::string::String;
 
 /// Number of bits needed to retry parsing
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,13 +38,13 @@ pub enum DekuError {
     /// Parsing error when reading
     Incomplete(NeedSize),
     /// Parsing error when reading
-    Parse(String),
+    Parse(Cow<'static, str>),
     /// Invalid parameter
-    InvalidParam(String),
     /// Unexpected error
     Unexpected(String),
+    InvalidParam(Cow<'static, str>),
     /// Assertion error from `assert` or `assert_eq` attributes
-    Assertion(String),
+    Assertion(Cow<'static, str>),
     /// Assertion error from `assert` or `assert_eq` attributes, without string
     AssertionNoStr,
     /// Could not resolve `id` for variant
@@ -55,13 +55,13 @@ pub enum DekuError {
 
 impl From<core::num::TryFromIntError> for DekuError {
     fn from(e: core::num::TryFromIntError) -> DekuError {
-        DekuError::Parse(format!("error parsing int: {e}"))
+        DekuError::Parse(Cow::from(format!("error parsing int: {e}")))
     }
 }
 
 impl From<core::array::TryFromSliceError> for DekuError {
     fn from(e: core::array::TryFromSliceError) -> DekuError {
-        DekuError::Parse(format!("error parsing from slice: {e}"))
+        DekuError::Parse(Cow::from(format!("error parsing from slice: {e}")))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,8 +40,6 @@ pub enum DekuError {
     /// Parsing error when reading
     Parse(Cow<'static, str>),
     /// Invalid parameter
-    /// Unexpected error
-    Unexpected(String),
     InvalidParam(Cow<'static, str>),
     /// Assertion error from `assert` or `assert_eq` attributes
     Assertion(Cow<'static, str>),
@@ -82,7 +80,6 @@ impl core::fmt::Display for DekuError {
             ),
             DekuError::Parse(ref err) => write!(f, "Parse error: {err}"),
             DekuError::InvalidParam(ref err) => write!(f, "Invalid param error: {err}"),
-            DekuError::Unexpected(ref err) => write!(f, "Unexpected error: {err}"),
             DekuError::Assertion(ref err) => write!(f, "Assertion error: {err}"),
             DekuError::AssertionNoStr => write!(f, "Assertion error"),
             DekuError::IdVariantNotFound => write!(f, "Could not resolve `id` for variant"),
@@ -106,7 +103,6 @@ impl From<DekuError> for std::io::Error {
             DekuError::Incomplete(_) => io::Error::new(io::ErrorKind::UnexpectedEof, error),
             DekuError::Parse(_) => io::Error::new(io::ErrorKind::InvalidData, error),
             DekuError::InvalidParam(_) => io::Error::new(io::ErrorKind::InvalidInput, error),
-            DekuError::Unexpected(_) => io::Error::new(io::ErrorKind::Other, error),
             DekuError::Assertion(_) => io::Error::new(io::ErrorKind::InvalidData, error),
             DekuError::AssertionNoStr => io::Error::from(io::ErrorKind::InvalidData),
             DekuError::IdVariantNotFound => io::Error::new(io::ErrorKind::NotFound, error),

--- a/src/impls/bool.rs
+++ b/src/impls/bool.rs
@@ -1,6 +1,8 @@
 use no_std_io::io::{Read, Write};
 
 #[cfg(feature = "alloc")]
+use alloc::borrow::Cow;
+#[cfg(feature = "alloc")]
 use alloc::format;
 
 use crate::reader::Reader;
@@ -21,7 +23,9 @@ where
         let ret = match val {
             0x01 => Ok(true),
             0x00 => Ok(false),
-            _ => Err(DekuError::Parse(format!("cannot parse bool value: {val}",))),
+            _ => Err(DekuError::Parse(Cow::from(format!(
+                "cannot parse bool value: {val}",
+            )))),
         }?;
 
         Ok(ret)

--- a/src/impls/cstring.rs
+++ b/src/impls/cstring.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use no_std_io::io::{Read, Write};
 use std::ffi::CString;
 
@@ -27,8 +28,9 @@ where
         let bytes =
             Vec::from_reader_with_ctx(reader, (Limit::from(|b: &u8| *b == 0x00), inner_ctx))?;
 
-        let value = CString::from_vec_with_nul(bytes)
-            .map_err(|e| DekuError::Parse(format!("Failed to convert Vec to CString: {e}")))?;
+        let value = CString::from_vec_with_nul(bytes).map_err(|e| {
+            DekuError::Parse(Cow::from(format!("Failed to convert Vec to CString: {e}")))
+        })?;
 
         Ok(value)
     }

--- a/src/impls/nonzero.rs
+++ b/src/impls/nonzero.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "alloc")]
+use alloc::borrow::Cow;
+#[cfg(feature = "alloc")]
 use alloc::format;
 use core::num::*;
 use no_std_io::io::{Read, Write};
@@ -19,7 +21,7 @@ macro_rules! ImplDekuTraitsCtx {
                 let value = <$typ>::new(value);
 
                 match value {
-                    None => Err(DekuError::Parse(format!("NonZero assertion"))),
+                    None => Err(DekuError::Parse(Cow::from(format!("NonZero assertion")))),
                     Some(v) => Ok(v),
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,12 @@ Then you'd call `env_logger::init()` or `env_logger::try_init()` prior to doing 
 Deku uses the `trace` logging level, so if you run your application with `RUST_LOG=trace` in your
 environment, you will see logging messages as Deku does its deserialising.
 
+# Reducing parser code size
+
+- With the use of the `no-assert-string` feature, you can remove the strings Deku adds to assertion errors.
+- `DekuError` whenever possible will use a `'static str`, to make the errors compile away when following a
+   guide such as [min-sized-rust](https://github.com/johnthagen/min-sized-rust).
+
 */
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
* Change all strings in DekuError to Cow<'static, str> so that more can be defined as "not alloc'ed strings" and be removed with panic=abort, build-std and friends.