### PR TITLE
Add diagnostic::on_unimplemented attribute on rust >=1.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ deku_derive = { version = "^0.16.0", path = "deku-derive", default-features = fa
 bitvec = { version = "1.0.1", default-features = false }
 log = { version = "0.4.17", optional = true }
 no_std_io = { version = "0.5.0", default-features = false, features = ["alloc"] }
+rustversion = "1.0.15"
 
 [dev-dependencies]
 rstest = "0.18.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,13 @@ use crate::reader::Reader;
 use crate::writer::Writer;
 
 /// "Reader" trait: read bytes and bits from [`no_std_io::Read`]er
+#[rustversion::attr(
+    since(1.78),
+    diagnostic::on_unimplemented(
+        note = "implement by adding #[derive(DekuRead)] to `{Self}`",
+        note = "make sure the `ctx` sent into the function matches `{Self}`'s `ctx`",
+    )
+)]
 pub trait DekuReader<'a, Ctx = ()> {
     /// Construct type from `reader` implementing [`no_std_io::Read`], with ctx.
     ///
@@ -403,6 +410,13 @@ pub trait DekuReader<'a, Ctx = ()> {
 
 /// "Reader" trait: implemented on DekuRead struct and enum containers. A `container` is a type which
 /// doesn't need any context information.
+#[rustversion::attr(
+    since(1.78),
+    diagnostic::on_unimplemented(
+        note = "implement by adding #[derive(DekuRead)] to `{Self}`",
+        note = "make sure the `ctx` sent into the function matches `{Self}`'s `ctx`",
+    )
+)]
 pub trait DekuContainerRead<'a>: DekuReader<'a, ()> {
     /// Construct type from Reader implementing [`no_std_io::Read`].
     /// * **input** - Input given as "Reader" and bit offset
@@ -444,6 +458,13 @@ pub trait DekuContainerRead<'a>: DekuReader<'a, ()> {
 }
 
 /// "Writer" trait: write from type to bytes
+#[rustversion::attr(
+    since(1.78),
+    diagnostic::on_unimplemented(
+        note = "implement by adding #[derive(DekuRead)] to `{Self}`",
+        note = "make sure the `ctx` sent into the function matches `{Self}`'s `ctx`",
+    )
+)]
 pub trait DekuWriter<Ctx = ()> {
     /// Write type to bytes
     fn to_writer<W: no_std_io::Write>(
@@ -455,6 +476,13 @@ pub trait DekuWriter<Ctx = ()> {
 
 /// "Writer" trait: implemented on DekuWrite struct and enum containers. A `container` is a type which
 /// doesn't need any context information.
+#[rustversion::attr(
+    since(1.78),
+    diagnostic::on_unimplemented(
+        note = "implement by adding #[derive(DekuWrite)] to `{Self}`",
+        note = "make sure the `ctx` sent into the function matches `{Self}`'s `ctx`",
+    )
+)]
 pub trait DekuContainerWrite: DekuWriter<()> {
     /// Write struct/enum to Vec<u8>
     ///


### PR DESCRIPTION
* Add the following diagnostics to hopefully lead people in the right direction when seeing trait problems related to ctxs and derives

```
error[E0277]: the trait bound `FieldF: deku::DekuReader<'_, _>` is not satisfied
  --> examples/example.rs:37:14
   |
37 |     field_f: FieldF,
   |              ^^^^^^ the trait `deku::DekuReader<'_, _>` is not implemented for `FieldF`
   |
   = note: implement by adding #[derive(DekuRead)] to `FieldF`
   = note: make sure the `ctx` sent into the function matches `FieldF`'s `ctx`
   = help: the following other types implement trait `deku::DekuReader<'a, Ctx>`:
             <() as deku::DekuReader<'_, Ctx>>
             <(A, B) as deku::DekuReader<'a, Ctx>>
             <(A, B, C) as deku::DekuReader<'a, Ctx>>
             <(A, B, C, D) as deku::DekuReader<'a, Ctx>>
             <(A, B, C, D, E) as deku::DekuReader<'a, Ctx>>
             <(A, B, C, D, E, F) as deku::DekuReader<'a, Ctx>>
             <(A, B, C, D, E, F, G) as deku::DekuReader<'a, Ctx>>
             <(A, B, C, D, E, F, G, H) as deku::DekuReader<'a, Ctx>>
           and 152 others
```

* Rust Release: https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html
* Rust MR: https://github.com/rust-lang/rust/pull/119888/