### PR TITLE
Missing magic changed to be a unique error vs a parsing error

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -444,7 +444,8 @@ fn emit_magic_read(input: &DekuData) -> TokenStream {
                 if *__deku_byte != __deku_read_byte {
                     extern crate alloc;
                     use alloc::borrow::Cow;
-                    return Err(::#crate_::DekuError::Parse(Cow::from(format!("Missing magic value {:?}", #magic))));
+                    return Err(::#crate_::DekuError::Framing(::#crate_::error::NeedMagic::new(&__deku_magic[0..])));
+                    // return Err(::#crate_::DekuError::Parse(Cow::from(format!("Missing magic value {:?}", #magic))));
                 }
             }
         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,7 @@
 
 [What is a prelude?](std::prelude)
 */
-pub use crate::error::{DekuError, NeedSize};
+pub use crate::error::{DekuError, NeedSize, NeedMagic};
 pub use crate::{
     deku_derive, reader::Reader, writer::Writer, DekuContainerRead, DekuContainerWrite,
     DekuEnumExt, DekuRead, DekuReader, DekuUpdate, DekuWrite, DekuWriter,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,7 +5,7 @@ use core::cmp::Ordering;
 use bitvec::prelude::*;
 use no_std_io::io::{ErrorKind, Read};
 
-use crate::{prelude::NeedSize, DekuError};
+use crate::{prelude::NeedSize, prelude::NeedMagic, DekuError};
 use alloc::vec::Vec;
 
 #[cfg(feature = "logging")]

--- a/tests/test_compile/cases/attribute_token_stream.stderr
+++ b/tests/test_compile/cases/attribute_token_stream.stderr
@@ -12,12 +12,12 @@ error[E0277]: can't compare `{integer}` with `bool`
   |
   = help: the trait `PartialEq<bool>` is not implemented for `{integer}`
   = help: the following other types implement trait `PartialEq<Rhs>`:
-            isize
-            i8
+            f128
+            f16
+            f32
+            f64
+            i128
             i16
             i32
             i64
-            i128
-            usize
-            u8
           and $N others

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -7,16 +7,16 @@ use rstest::rstest;
 #[rstest(input,
     case(&hex!("64656b75")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Framing(NeedMagic { magic: [100, 101, 107, 117] })")]
     case(&hex!("64656bde")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Framing(NeedMagic { magic: [100, 101, 107, 117] })")]
     case(&hex!("6465ad75")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Framing(NeedMagic { magic: [100, 101, 107, 117] })")]
     case(&hex!("64be6b75")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Framing(NeedMagic { magic: [100, 101, 107, 117] })")]
     case(&hex!("ef656b75")),
 
     #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
@@ -38,19 +38,19 @@ fn test_magic_struct(input: &[u8]) {
 #[rstest(input,
     case(&hex!("64656b7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Framing(NeedMagic { magic: [100, 101, 107, 117] })")]
     case(&hex!("64656bde00")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Framing(NeedMagic { magic: [100, 101, 107, 117] })")]
     case(&hex!("6465ad7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Framing(NeedMagic { magic: [100, 101, 107, 117] })")]
     case(&hex!("64be6b7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Framing(NeedMagic { magic: [100, 101, 107, 117] })")]
     case(&hex!("ef656b7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Framing(NeedMagic { magic: [100, 101, 107, 117] })")]
     case(&hex!("64656b00")),
 
     #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]


### PR DESCRIPTION
This change is needed so parsers that work on stream data can know wether to advance into the buffer to find a valid message without having to manually search for magic bytes before feeding the DekuRead object.