### PR TITLE
Add bits as an optional feature for bitvec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
       - run: cargo test --all
       # run examples
       - run: cargo run --example 2>&1 | grep -P '   ' | awk '{print $1}' | xargs -i cargo run --example {}
+      # test with no bits feature (don't test docs)
+      - run: cargo test --lib --examples --tests --features std --no-default-features
 
   # Only build on MSRV, since trybuild will fail on older version
   build-msrv:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,31 @@ workspace = true
 # Triggers in macro generated code of darling
 # https://github.com/rust-lang/rust-clippy/issues/12643
 manual-unwrap-or-default = "allow"
+
+[[example]]
+name = "custom_reader_and_writer"
+required-features = ["bits"]
+
+[[example]]
+name = "deku_input"
+
+[[example]]
+name = "enums_catch_all"
+required-features = ["bits"]
+
+[[example]]
+name = "enums"
+
+[[example]]
+name = "example"
+required-features = ["bits"]
+
+[[example]]
+name = "ipv4"
+required-features = ["bits"]
+
+[[example]]
+name = "many"
+
+[[example]]
+name = "read_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,17 @@ members = [
 ]
 
 [features]
-default = ["std"]
-std = ["deku_derive/std", "bitvec/std", "alloc", "no_std_io/std"]
-alloc = ["bitvec/alloc"]
+default = ["std", "bits"]
+std = ["deku_derive/std", "bitvec?/std", "alloc", "no_std_io/std"]
+alloc = ["bitvec?/alloc"]
 logging = ["deku_derive/logging", "log"]
 no-assert-string = ["deku_derive/no-assert-string"]
 error_in_core = []
+bits = ["dep:bitvec", "deku_derive/bits"]
 
 [dependencies]
 deku_derive = { version = "^0.17.0", path = "deku-derive", default-features = false}
-bitvec = { version = "1.0.1", default-features = false }
+bitvec = { version = "1.0.1", default-features = false, optional = true }
 log = { version = "0.4.21", optional = true }
 no_std_io = { version = "0.8.0", default-features = false, features = ["alloc"], package = "no_std_io2" }
 rustversion = "1.0.16"

--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -3,6 +3,7 @@ use std::io::{Cursor, Read, Seek};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use deku::prelude::*;
 
+#[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuBits {
     #[deku(bits = 1)]
@@ -61,6 +62,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             }))
         })
     });
+    #[cfg(feature = "bits")]
     c.bench_function("deku_read_bits", |b| {
         let reader = Cursor::new(&[0x01; 1]);
         b.iter_batched(
@@ -69,6 +71,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             BatchSize::SmallInput,
         )
     });
+    #[cfg(feature = "bits")]
     c.bench_function("deku_write_bits", |b| {
         b.iter(|| {
             deku_write(black_box(&DekuBits {

--- a/deku-derive/Cargo.toml
+++ b/deku-derive/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 std = ["proc-macro-crate"]
 logging = []
 no-assert-string = []
+bits = []
 
 [dependencies]
 quote = "1.0"

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -91,6 +91,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     // Implement `DekuContainerWrite` for types that don't need a context
     if input.ctx.is_none() || (input.ctx.is_some() && input.ctx_default.is_some()) {
+        #[cfg(feature = "bits")]
         tokens.extend(quote! {
              impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> #wher {
                 type Error = ::#crate_::DekuError;
@@ -100,7 +101,9 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
                     input.to_bits()
                 }
             }
+        });
 
+        tokens.extend(quote! {
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
                 type Error = ::#crate_::DekuError;
 
@@ -288,6 +291,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     // Implement `DekuContainerWrite` for types that don't need a context
     if input.ctx.is_none() || (input.ctx.is_some() && input.ctx_default.is_some()) {
+        #[cfg(feature = "bits")]
         tokens.extend(quote! {
              impl #imp core::convert::TryFrom<#ident> for ::#crate_::bitvec::BitVec<u8, ::#crate_::bitvec::Msb0> #wher {
                 type Error = ::#crate_::DekuError;
@@ -297,7 +301,9 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                     input.to_bits()
                 }
             }
+        });
 
+        tokens.extend(quote! {
             impl #imp core::convert::TryFrom<#ident> for Vec<u8> #wher {
                 type Error = ::#crate_::DekuError;
 
@@ -308,7 +314,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             }
 
             impl #imp DekuContainerWrite for #ident #wher {}
-        })
+        });
     }
 
     let (ctx_types, ctx_arg) = gen_ctx_types_and_arg(input.ctx.as_ref())?;

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -340,6 +340,7 @@ fn token_contains_string(tok: &Option<TokenStream>, s: &str) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(feature = "bits")]
 fn pad_bits(
     bits: Option<&TokenStream>,
     bytes: Option<&TokenStream>,
@@ -352,6 +353,17 @@ fn pad_bits(
         (Some(pad_bits), None) => emit_padding(pad_bits),
         (None, Some(pad_bytes)) => emit_padding(&quote! {((#pad_bytes) * 8)}),
         (None, None) => quote!(),
+    }
+}
+
+#[cfg(not(feature = "bits"))]
+fn pad_bytes(
+    bytes: Option<&TokenStream>,
+    emit_padding: fn(&TokenStream) -> TokenStream,
+) -> TokenStream {
+    match bytes {
+        Some(pad_bytes) => emit_padding(&quote! {((#pad_bytes))}),
+        None => quote!(),
     }
 }
 

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -20,6 +20,6 @@ alloc = []
 
 [dependencies]
 cortex-m-rt = "0.7.3"
-deku = { path = "../", default-features = false, features = ["alloc"] }
+deku = { path = "../", default-features = false, features = ["alloc", "bits"] }
 embedded-alloc = "0.5.1"
 

--- a/src/impls/bool.rs
+++ b/src/impls/bool.rs
@@ -73,6 +73,7 @@ mod tests {
         assert_eq!(expected, res_read);
     }
 
+    #[cfg(feature = "bits")]
     #[test]
     fn test_bool_with_context() {
         let input = &[0b01_000000];
@@ -83,12 +84,16 @@ mod tests {
         assert!(res_read);
     }
 
+    #[cfg(feature = "bits")]
     #[test]
-    fn test_writer() {
+    fn test_writer_bits() {
         let mut writer = Writer::new(Cursor::new(vec![]));
         true.to_writer(&mut writer, BitSize(1)).unwrap();
         assert_eq!(vec![true], writer.rest());
+    }
 
+    #[test]
+    fn test_writer() {
         let mut writer = Writer::new(Cursor::new(vec![]));
         true.to_writer(&mut writer, ()).unwrap();
         assert_eq!(vec![1], writer.inner.into_inner());

--- a/src/impls/boxed.rs
+++ b/src/impls/boxed.rs
@@ -81,6 +81,7 @@ mod tests {
     use crate::ctx::*;
     use crate::native_endian;
     use crate::reader::Reader;
+    #[cfg(feature = "bits")]
     use bitvec::prelude::*;
 
     #[rstest(input, expected,
@@ -101,6 +102,7 @@ mod tests {
     }
 
     // Note: Copied tests from vec.rs impl
+    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes, expected_write,
         case::normal_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), 2.into(), vec![0xBBAA, 0xDDCC].into_boxed_slice(), bits![u8, Msb0;], &[], vec![0xAA, 0xBB, 0xCC, 0xDD]),
         case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD].into_boxed_slice(), bits![u8, Msb0;], &[], vec![0xAA, 0xBB, 0xCC, 0xDD]),

--- a/src/impls/hashmap.rs
+++ b/src/impls/hashmap.rs
@@ -231,6 +231,7 @@ mod tests {
     use crate::reader::Reader;
 
     use super::*;
+    #[cfg(feature = "bits")]
     use bitvec::prelude::*;
 
     // Macro to create a deterministic HashMap for tests
@@ -250,6 +251,7 @@ mod tests {
          };
     );
 
+    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes,
         case::count_0([0xAA].as_ref(), Endian::Little, Some(8), 0.into(), FxHashMap::default(), bits![u8, Msb0;], &[0xaa]),
         case::count_1([0x01, 0xAA, 0x02, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), fxhashmap!{0x01 => 0xAA}, bits![u8, Msb0;], &[0x02, 0xbb]),

--- a/src/impls/hashset.rs
+++ b/src/impls/hashset.rs
@@ -212,6 +212,7 @@ impl<T: DekuWriter<Ctx>, S, Ctx: Copy> DekuWriter<Ctx> for HashSet<T, S> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "bits")]
     use crate::bitvec::{bits, BitSlice, Msb0};
     use no_std_io::io::Cursor;
     use rstest::rstest;
@@ -221,6 +222,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes,
         case::count_0([0xAA].as_ref(), Endian::Little, Some(8), 0.into(), FxHashSet::default(), bits![u8, Msb0;], &[0xaa]),
         case::count_1([0xAA, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), vec![0xAA].into_iter().collect(), bits![u8, Msb0;], &[0xbb]),
@@ -285,6 +287,7 @@ mod tests {
     }
 
     // Note: These tests also exist in boxed.rs
+    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes, expected_write,
         case::normal_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), 2.into(), vec![0xBBAA, 0xDDCC].into_iter().collect(), bits![u8, Msb0;], &[], vec![0xCC, 0xDD, 0xAA, 0xBB]),
         case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD].into_iter().collect(), bits![u8, Msb0;], &[], vec![0xCC, 0xDD, 0xAA, 0xBB]),

--- a/src/impls/nonzero.rs
+++ b/src/impls/nonzero.rs
@@ -43,6 +43,7 @@ macro_rules! ImplDekuTraitsCtx {
 macro_rules! ImplDekuTraits {
     ($typ:ty, $readtype:ty) => {
         ImplDekuTraitsCtx!($typ, $readtype, (), ());
+        #[cfg(feature = "bits")]
         ImplDekuTraitsCtx!($typ, $readtype, (endian, bitsize), (Endian, BitSize));
         ImplDekuTraitsCtx!($typ, $readtype, (endian, bytesize), (Endian, ByteSize));
         ImplDekuTraitsCtx!($typ, $readtype, endian, Endian);
@@ -66,7 +67,6 @@ ImplDekuTraits!(NonZeroIsize, isize);
 mod tests {
     use hexlit::hex;
     use rstest::rstest;
-    use std::io::Cursor;
 
     use crate::reader::Reader;
 

--- a/src/impls/nonzero.rs
+++ b/src/impls/nonzero.rs
@@ -65,13 +65,14 @@ ImplDekuTraits!(NonZeroIsize, isize);
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use hexlit::hex;
     use rstest::rstest;
 
     use crate::reader::Reader;
 
     use super::*;
-    use bitvec::prelude::*;
 
     #[rstest(input, expected,
         case(&hex!("FF"), NonZeroU8::new(0xFF).unwrap()),
@@ -80,7 +81,7 @@ mod tests {
         case(&hex!("00"), NonZeroU8::new(0xFF).unwrap()),
     )]
     fn test_non_zero(input: &[u8], expected: NonZeroU8) {
-        let mut cursor = std::io::Cursor::new(input);
+        let mut cursor = Cursor::new(input);
         let mut reader = Reader::new(&mut cursor);
         let res_read = NonZeroU8::from_reader_with_ctx(&mut reader, ()).unwrap();
         assert_eq!(expected, res_read);

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -803,6 +803,7 @@ mod tests {
         native_endian!(-0.006_f64)
     );
 
+    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, expected, expected_rest_bits, expected_rest_bytes,
         case::normal([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, Some(32), 0xAABB_CCDD, bits![u8, Msb0;], &[]),
         case::normal([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Big, Some(32), 0xDDCC_BBAA, bits![u8, Msb0;], &[]),
@@ -880,6 +881,7 @@ mod tests {
         assert_eq!(expected_rest_bytes, buf);
     }
 
+    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, expected, expected_leftover,
         case::normal_le(0xDDCC_BBAA, Endian::Little, None, vec![0xAA, 0xBB, 0xCC, 0xDD], vec![]),
         case::normal_be(0xDDCC_BBAA, Endian::Big, None, vec![0xDD, 0xCC, 0xBB, 0xAA], vec![]),
@@ -925,6 +927,7 @@ mod tests {
         assert_hex::assert_eq_hex!(expected, writer.inner.into_inner());
     }
 
+    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, expected, expected_write,
         case::normal([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, Some(32), 0xAABB_CCDD, vec![0xDD, 0xCC, 0xBB, 0xAA]),
     )]
@@ -970,11 +973,17 @@ mod tests {
         };
     }
 
+    #[cfg(feature = "bits")]
     TestSignExtending!(test_sign_extend_i8, i8);
+    #[cfg(feature = "bits")]
     TestSignExtending!(test_sign_extend_i16, i16);
+    #[cfg(feature = "bits")]
     TestSignExtending!(test_sign_extend_i32, i32);
+    #[cfg(feature = "bits")]
     TestSignExtending!(test_sign_extend_i64, i64);
+    #[cfg(feature = "bits")]
     TestSignExtending!(test_sign_extend_i128, i128);
+    #[cfg(feature = "bits")]
     TestSignExtending!(test_sign_extend_isize, isize);
 
     macro_rules! TestSignExtendingPanic {
@@ -998,9 +1007,14 @@ mod tests {
         };
     }
 
+    #[cfg(feature = "bits")]
     TestSignExtendingPanic!(test_sign_extend_i8_panic, i8, 8);
+    #[cfg(feature = "bits")]
     TestSignExtendingPanic!(test_sign_extend_i16_panic, i16, 16);
+    #[cfg(feature = "bits")]
     TestSignExtendingPanic!(test_sign_extend_i32_panic, i32, 32);
+    #[cfg(feature = "bits")]
     TestSignExtendingPanic!(test_sign_extend_i64_panic, i64, 64);
+    #[cfg(feature = "bits")]
     TestSignExtendingPanic!(test_sign_extend_i128_panic, i128, 128);
 }

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -3,6 +3,7 @@ use alloc::borrow::Cow;
 use alloc::format;
 use core::convert::TryInto;
 
+#[cfg(feature = "bits")]
 use bitvec::prelude::*;
 use no_std_io::io::{Read, Seek, Write};
 
@@ -12,6 +13,7 @@ use crate::writer::Writer;
 use crate::{DekuError, DekuReader, DekuWriter};
 
 /// "Read" trait: read bits and construct type
+#[cfg(feature = "bits")]
 trait DekuRead<'a, Ctx = ()> {
     /// Read bits and construct type
     /// * **input** - Input as bits
@@ -32,8 +34,8 @@ trait DekuRead<'a, Ctx = ()> {
 }
 
 // specialize u8 for ByteSize
+#[cfg(feature = "bits")]
 impl DekuRead<'_, (Endian, ByteSize)> for u8 {
-    /// Ignore endian and byte_size, as this is a `u8`
     #[inline]
     fn read(
         input: &BitSlice<u8, Msb0>,
@@ -59,6 +61,7 @@ impl DekuReader<'_, (Endian, ByteSize)> for u8 {
         let ret = reader.read_bytes_const::<MAX_TYPE_BYTES>(&mut buf)?;
         let a = match ret {
             ReaderRet::Bytes => <u8>::from_be_bytes(buf),
+            #[cfg(feature = "bits")]
             ReaderRet::Bits(bits) => {
                 let Some(bits) = bits else {
                     return Err(DekuError::Parse(Cow::from("no bits read from reader")));
@@ -71,6 +74,7 @@ impl DekuReader<'_, (Endian, ByteSize)> for u8 {
     }
 }
 
+#[cfg(feature = "bits")]
 impl DekuWriter<(Endian, BitSize)> for u8 {
     /// Ignore endian, as this is a `u8`
     #[inline(always)]
@@ -126,6 +130,7 @@ impl DekuWriter<(Endian, ByteSize)> for u8 {
 
 macro_rules! ImplDekuReadBits {
     ($typ:ty, $inner:ty) => {
+        #[cfg(feature = "bits")]
         impl DekuRead<'_, (Endian, BitSize)> for $typ {
             #[inline(never)]
             fn read(
@@ -202,6 +207,7 @@ macro_rules! ImplDekuReadBits {
             }
         }
 
+        #[cfg(feature = "bits")]
         impl DekuReader<'_, (Endian, BitSize)> for $typ {
             #[inline(always)]
             fn from_reader_with_ctx<R: Read + Seek>(
@@ -228,6 +234,7 @@ macro_rules! ImplDekuReadBits {
 
 macro_rules! ImplDekuReadBytes {
     ($typ:ty, $inner:ty) => {
+        #[cfg(feature = "bits")]
         impl DekuRead<'_, (Endian, ByteSize)> for $typ {
             #[inline(never)]
             fn read(
@@ -268,10 +275,12 @@ macro_rules! ImplDekuReadBytes {
                             <$typ>::from_be_bytes(buf.try_into().unwrap())
                         }
                     }
+                    #[cfg(feature = "bits")]
                     ReaderRet::Bits(Some(bits)) => {
                         let a = <$typ>::read(&bits, (endian, size))?;
                         a.1
                     }
+                    #[cfg(feature = "bits")]
                     ReaderRet::Bits(None) => {
                         return Err(DekuError::Parse(Cow::from("no bits read from reader")));
                     }
@@ -284,6 +293,7 @@ macro_rules! ImplDekuReadBytes {
 
 macro_rules! ImplDekuReadSignExtend {
     ($typ:ty, $inner:ty) => {
+        #[cfg(feature = "bits")]
         impl DekuRead<'_, (Endian, ByteSize)> for $typ {
             #[inline(never)]
             fn read(
@@ -317,6 +327,7 @@ macro_rules! ImplDekuReadSignExtend {
                             <$typ>::from_be_bytes(buf.try_into()?)
                         }
                     }
+                    #[cfg(feature = "bits")]
                     ReaderRet::Bits(bits) => {
                         let Some(bits) = bits else {
                             return Err(DekuError::Parse(Cow::from("no bits read from reader")));
@@ -334,6 +345,7 @@ macro_rules! ImplDekuReadSignExtend {
             }
         }
 
+        #[cfg(feature = "bits")]
         impl DekuRead<'_, (Endian, BitSize)> for $typ {
             #[inline(never)]
             fn read(
@@ -351,6 +363,7 @@ macro_rules! ImplDekuReadSignExtend {
             }
         }
 
+        #[cfg(feature = "bits")]
         impl DekuReader<'_, (Endian, BitSize)> for $typ {
             #[inline(always)]
             fn from_reader_with_ctx<R: Read + Seek>(
@@ -395,10 +408,12 @@ macro_rules! ForwardDekuRead {
                             <$typ>::from_be_bytes(buf)
                         }
                     }
+                    #[cfg(feature = "bits")]
                     ReaderRet::Bits(Some(bits)) => {
                         let a = <$typ>::read(&bits, (endian, ByteSize(MAX_TYPE_BYTES)))?;
                         a.1
                     }
+                    #[cfg(feature = "bits")]
                     ReaderRet::Bits(None) => {
                         return Err(DekuError::Parse(Cow::from("no bits read from reader")));
                     }
@@ -422,6 +437,7 @@ macro_rules! ForwardDekuRead {
         }
 
         //// Only have `bit_size`, set `endian` to `Endian::default`.
+        #[cfg(feature = "bits")]
         impl DekuReader<'_, BitSize> for $typ {
             #[inline(always)]
             fn from_reader_with_ctx<R: Read + Seek>(
@@ -452,6 +468,7 @@ macro_rules! ForwardDekuRead {
 
 macro_rules! ImplDekuWrite {
     ($typ:ty) => {
+        #[cfg(feature = "bits")]
         impl DekuWriter<(Endian, BitSize)> for $typ {
             #[inline(always)]
             fn to_writer<W: Write + Seek>(
@@ -578,6 +595,7 @@ macro_rules! ImplDekuWriteOnlyEndian {
 
 macro_rules! ForwardDekuWrite {
     ($typ:ty) => {
+        #[cfg(feature = "bits")]
         impl DekuWriter<BitSize> for $typ {
             #[inline(always)]
             fn to_writer<W: Write + Seek>(

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -96,12 +96,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "bits")]
     use bitvec::prelude::*;
     use rstest::rstest;
     use std::io::Cursor;
 
     use crate::{ctx::Endian, reader::Reader, writer::Writer, DekuReader};
 
+    #[cfg(feature = "bits")]
     #[rstest(input,endian,expected,
         case::normal_le([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Little, [0xCCDD, 0xAABB]),
         case::normal_be([0xDD, 0xCC, 0xBB, 0xAA].as_ref(), Endian::Big, [0xDDCC, 0xBBAA]),

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -176,6 +176,7 @@ impl<T: DekuWriter<Ctx>, Ctx: Copy> DekuWriter<Ctx> for Vec<T> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "bits")]
     use crate::bitvec::{bits, BitSlice, Msb0};
     use rstest::rstest;
     use std::io::Cursor;
@@ -184,6 +185,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "bits")]
     #[rstest(input, limit, expected, expected_rest_bits, expected_rest_bytes,
         case::count_0([0xAA].as_ref(), 0.into(), vec![], bits![u8, Msb0;], &[0xaa]),
         case::count_1([0xAA, 0xBB].as_ref(), 1.into(), vec![0xAA], bits![u8, Msb0;], &[0xbb]),
@@ -211,6 +213,7 @@ mod tests {
         assert_eq!(expected_rest_bytes, buf);
     }
 
+    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes,
         case::count_0([0xAA].as_ref(), Endian::Little, Some(8), 0.into(), vec![], bits![u8, Msb0;], &[0xaa]),
         case::count_1([0xAA, 0xBB].as_ref(), Endian::Little, Some(8), 1.into(), vec![0xAA], bits![u8, Msb0;], &[0xbb]),
@@ -271,6 +274,7 @@ mod tests {
     }
 
     // Note: These tests also exist in boxed.rs
+    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes, expected_write,
         case::normal_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), 2.into(), vec![0xBBAA, 0xDDCC], bits![u8, Msb0;], &[], vec![0xAA, 0xBB, 0xCC, 0xDD]),
         case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD], bits![u8, Msb0;], &[], vec![0xAA, 0xBB, 0xCC, 0xDD]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,7 @@ pub mod no_std_io {
 }
 
 /// re-export of bitvec
+#[cfg(feature = "bits")]
 pub mod bitvec {
     pub use bitvec::prelude::*;
     pub use bitvec::view::BitView;
@@ -568,6 +569,7 @@ pub trait DekuContainerWrite: DekuWriter<()> {
     /// assert_eq!(deku::bitvec::bitvec![1, 1, 1, 1, 0, 0, 0, 1, 1], bits);
     /// ```
     #[inline(always)]
+    #[cfg(feature = "bits")]
     fn to_bits(&self) -> Result<bitvec::BitVec<u8, bitvec::Msb0>, DekuError> {
         let mut out_buf = Vec::new();
         let mut cursor = no_std_io::Cursor::new(&mut out_buf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,6 +338,11 @@ environment, you will see logging messages as Deku does its deserialising.
 - `DekuError` whenever possible will use a `'static str`, to make the errors compile away when following a
    guide such as [min-sized-rust](https://github.com/johnthagen/min-sized-rust).
 
+# Performance: Compile without `bitvec`
+The feature `bits` enables the `bitvec` crate to use when reading and writing, which is enabled by default.
+This however slows down the reading and writing process if your code doesn't use `bits` and the `bit_offset`
+in `from_bytes`.
+
 */
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -478,6 +478,7 @@ mod tests {
     use no_std_io::io::Cursor;
 
     #[test]
+    #[cfg(feature = "bits")]
     fn test_end() {
         let input = hex!("aabb");
         let mut cursor = Cursor::new(input);
@@ -498,6 +499,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "bits")]
     fn test_bits_less() {
         let input = hex!("aa");
         let mut cursor = Cursor::new(input);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -206,7 +206,8 @@ mod tests {
     use hexlit::hex;
 
     #[test]
-    fn test_writer() {
+    #[cfg(feature = "bits")]
+    fn test_writer_bits() {
         let mut out_buf = Cursor::new(vec![]);
         let mut writer = Writer::new(&mut out_buf);
 
@@ -242,5 +243,17 @@ mod tests {
             &mut out_buf.into_inner(),
             &mut vec![0xaa, 0xbb, 0xf1, 0xaa, 0x1f, 0x1a, 0xaf]
         );
+    }
+
+    #[test]
+    #[cfg(feature = "bits")]
+    fn test_writer_bytes() {
+        let mut out_buf = Cursor::new(vec![]);
+        let mut writer = Writer::new(&mut out_buf);
+
+        let mut input = hex!("aa");
+        writer.write_bytes(&mut input).unwrap();
+
+        assert_eq!(&mut out_buf.into_inner(), &mut vec![0xaa]);
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,6 +1,8 @@
 //! Writer for writer functions
 
+#[cfg(feature = "bits")]
 use bitvec::bitvec;
+#[cfg(feature = "bits")]
 use bitvec::{field::BitField, prelude::*};
 use no_std_io::io::{Seek, SeekFrom, Write};
 
@@ -20,6 +22,7 @@ pub const MAX_BITS_AMT: usize = 128;
 pub struct Writer<W: Write + Seek> {
     pub(crate) inner: W,
     /// Leftover bits
+    #[cfg(feature = "bits")]
     pub leftover: BitVec<u8, Msb0>,
     /// Total bits written
     pub bits_written: usize,
@@ -29,8 +32,13 @@ impl<W: Write + Seek> Seek for Writer<W> {
     fn seek(&mut self, pos: SeekFrom) -> no_std_io::io::Result<u64> {
         #[cfg(feature = "logging")]
         log::trace!("seek: {pos:?}");
+
         // clear leftover
-        self.leftover = BitVec::new();
+        #[cfg(feature = "bits")]
+        {
+            self.leftover = BitVec::new();
+        }
+
         self.inner.seek(pos)
     }
 }
@@ -41,6 +49,7 @@ impl<W: Write + Seek> Writer<W> {
     pub fn new(inner: W) -> Self {
         Self {
             inner,
+            #[cfg(feature = "bits")]
             leftover: BitVec::new(),
             bits_written: 0,
         }
@@ -49,7 +58,15 @@ impl<W: Write + Seek> Writer<W> {
     /// Return the unused bits
     #[inline]
     pub fn rest(&mut self) -> alloc::vec::Vec<bool> {
-        self.leftover.iter().by_vals().collect()
+        #[cfg(feature = "bits")]
+        {
+            self.leftover.iter().by_vals().collect()
+        }
+
+        #[cfg(not(feature = "bits"))]
+        {
+            alloc::vec![]
+        }
     }
 
     /// Write all `bits` to `Writer` buffer if bits can fit into a byte buffer.
@@ -60,6 +77,7 @@ impl<W: Write + Seek> Writer<W> {
     /// # Params
     /// `bits`    - Amount of bits that will be written. length must be <= [`MAX_BITS_AMT`].
     #[inline(never)]
+    #[cfg(feature = "bits")]
     pub fn write_bits(&mut self, bits: &BitSlice<u8, Msb0>) -> Result<(), DekuError> {
         #[cfg(feature = "logging")]
         log::trace!("attempting {} bits", bits.len());
@@ -119,6 +137,7 @@ impl<W: Write + Seek> Writer<W> {
         #[cfg(feature = "logging")]
         log::trace!("writing {} bytes: {buf:02x?}", buf.len());
 
+        #[cfg(feature = "bits")]
         if !self.leftover.is_empty() {
             #[cfg(feature = "logging")]
             log::trace!("leftover exists");
@@ -133,6 +152,14 @@ impl<W: Write + Seek> Writer<W> {
             self.bits_written += buf.len() * 8;
         }
 
+        #[cfg(not(feature = "bits"))]
+        {
+            if let Err(e) = self.inner.write_all(buf) {
+                return Err(DekuError::Io(e.kind()));
+            }
+            self.bits_written += buf.len() * 8;
+        }
+
         Ok(())
     }
 
@@ -140,6 +167,7 @@ impl<W: Write + Seek> Writer<W> {
     /// into a byte buffer
     #[inline]
     pub fn finalize(&mut self) -> Result<(), DekuError> {
+        #[cfg(feature = "bits")]
         if !self.leftover.is_empty() {
             #[cfg(feature = "logging")]
             log::trace!("finalized: {} bits leftover", self.leftover.len());

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -2,3 +2,5 @@
 
 mod test_attributes;
 mod test_compile;
+#[cfg(feature = "bits")]
+mod test_to_bits;

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -7,12 +7,14 @@ use deku::prelude::*;
 #[global_allocator]
 static A: AllocCounterSystem = AllocCounterSystem;
 
+#[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(ctx = "_endian: Endian")]
 struct NestedStruct {
     field_a: u8,
 }
 
+#[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(id_type = "u8", ctx = "_endian: Endian")]
 enum NestedEnum {
@@ -20,6 +22,7 @@ enum NestedEnum {
     VarA(u8),
 }
 
+#[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(id_type = "u32", bytes = 2, ctx = "_endian: Endian")]
 enum NestedEnum2 {
@@ -27,6 +30,7 @@ enum NestedEnum2 {
     VarA(u8),
 }
 
+#[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(endian = "big")]
 struct TestDeku {
@@ -44,6 +48,7 @@ struct TestDeku {
                  //field_i: NestedEnum2,
 }
 
+#[cfg(feature = "bits")]
 mod tests {
     use alloc_counter::count_alloc;
     use hexlit::hex;

--- a/tests/test_attributes/test_limits/mod.rs
+++ b/tests/test_attributes/test_limits/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "bits")]
 mod test_bits_read;
 mod test_bytes_read;
 mod test_count;

--- a/tests/test_attributes/test_padding/mod.rs
+++ b/tests/test_attributes/test_padding/mod.rs
@@ -2,11 +2,14 @@ use std::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 
+#[cfg(feature = "bits")]
 mod test_pad_bits_after;
+#[cfg(feature = "bits")]
 mod test_pad_bits_before;
 mod test_pad_bytes_after;
 mod test_pad_bytes_before;
 
+#[cfg(feature = "bits")]
 #[test]
 #[allow(clippy::identity_op)]
 fn test_pad_bits_before_and_pad_bytes_before() {
@@ -34,6 +37,7 @@ fn test_pad_bits_before_and_pad_bytes_before() {
     assert_eq!(vec![0b10_000000, 0x00, 0xbb], ret_write);
 }
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_pad_bits_after_and_pad_bytes_after() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]

--- a/tests/test_attributes/test_padding/test_pad_bytes_after.rs
+++ b/tests/test_attributes/test_padding/test_pad_bytes_after.rs
@@ -42,6 +42,8 @@ fn test_pad_bytes_after_not_enough() {
     let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
+// TODO: add cfg test with updated msg for not(bits)
+#[cfg(feature = "bits")]
 #[test]
 #[should_panic(
     expected = r#"InvalidParam("Invalid padding param \"(((- 2) * 8))\": cannot convert to usize")"#
@@ -59,6 +61,8 @@ fn test_pad_bytes_after_read_err() {
     let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
+// TODO: add cfg test with updated msg for not(bits)
+#[cfg(feature = "bits")]
 #[test]
 #[should_panic(
     expected = r#"InvalidParam("Invalid padding param \"(((- 2) * 8))\": cannot convert to usize")"#

--- a/tests/test_attributes/test_padding/test_pad_bytes_before.rs
+++ b/tests/test_attributes/test_padding/test_pad_bytes_before.rs
@@ -42,6 +42,8 @@ fn test_pad_bytes_before_not_enough() {
     let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
+// TODO: add cfg test with updated msg for not(bits)
+#[cfg(feature = "bits")]
 #[test]
 #[should_panic(
     expected = r#"InvalidParam("Invalid padding param \"(((- 2) * 8))\": cannot convert to usize")"#
@@ -59,6 +61,8 @@ fn test_pad_bytes_before_read_err() {
     let _ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 }
 
+// TODO: add cfg test with updated msg for not(bits)
+#[cfg(feature = "bits")]
 #[test]
 #[should_panic(
     expected = r#"InvalidParam("Invalid padding param \"(((- 2) * 8))\": cannot convert to usize")"#

--- a/tests/test_bit_container_size.rs
+++ b/tests/test_bit_container_size.rs
@@ -1,6 +1,7 @@
 use deku::prelude::*;
 use rstest::*;
 
+#[cfg(feature = "bits")]
 #[derive(Debug, Default, PartialEq, DekuWrite, DekuRead)]
 #[deku(endian = "big")]
 struct Test {
@@ -14,6 +15,7 @@ struct Test {
     field_u32_be: u32,
 }
 
+#[cfg(feature = "bits")]
 #[rstest(input,
     #[should_panic(
         expected = "InvalidParam(\"bit size 5 of input is larger than bit requested size 4\")"

--- a/tests/test_compile/mod.rs
+++ b/tests/test_compile/mod.rs
@@ -1,4 +1,5 @@
 #[test]
+#[cfg(feature = "bits")]
 #[cfg(not(tarpaulin))]
 #[cfg_attr(miri, ignore)]
 fn test_compile() {

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -8,6 +8,7 @@ use rstest::*;
 /// General smoke tests for enums
 /// TODO: These should be divided into smaller tests
 
+#[cfg(feature = "bits")]
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u8")]
 enum TestEnum {
@@ -32,6 +33,7 @@ enum TestEnum {
     VarDefault { id: u8, value: u8 },
 }
 
+#[cfg(feature = "bits")]
 #[rstest(input,expected,
     case(&hex!("01AB"), TestEnum::VarA(0xAB)),
     case(&hex!("0269"), TestEnum::VarB(0b0110, 0b1001)),

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -178,7 +178,11 @@ fn test_id_pat_with_id() {
         }
     );
     assert_eq!(input, &*v.to_bytes().unwrap());
+}
 
+#[test]
+#[cfg(feature = "bits")]
+fn id_pat_with_id_bits() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     #[deku(id_type = "u8", bits = "2")]
     pub enum IdPatBits {

--- a/tests/test_from_bytes.rs
+++ b/tests/test_from_bytes.rs
@@ -1,5 +1,6 @@
 use deku::prelude::*;
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_from_bytes_struct() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
@@ -28,6 +29,7 @@ fn test_from_bytes_struct() {
     assert_eq!(0, i);
 }
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_from_bytes_enum() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]

--- a/tests/test_from_reader.rs
+++ b/tests/test_from_reader.rs
@@ -1,6 +1,7 @@
 use deku::prelude::*;
 use no_std_io::io::Seek;
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_from_reader_struct() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
@@ -21,7 +22,6 @@ fn test_from_reader_struct() {
     total_read = amt_read;
     assert_eq!(TestDeku(0b0110), ret_read);
 
-    env_logger::init();
     c.rewind().unwrap();
     let (amt_read, ret_read) = TestDeku::from_reader((&mut c, total_read)).unwrap();
     assert_eq!(amt_read, 12);
@@ -34,6 +34,7 @@ fn test_from_reader_struct() {
     assert_eq!(TestDeku(0b1010), ret_read);
 }
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_from_reader_enum() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -5,6 +5,7 @@ use std::io::Cursor;
 // BitSlice to type
 //
 // https://github.com/sharksforarms/deku/issues/224
+#[cfg(feature = "bits")]
 #[test]
 fn issue_224() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
@@ -66,6 +67,7 @@ fn issue_224() {
     let _packet = Packet::from_reader((&mut c, 0)).unwrap();
 }
 
+#[cfg(feature = "bits")]
 // Extra zeroes added when reading fewer bytes than needed to fill a number
 //
 // https://github.com/sharksforarms/deku/issues/282
@@ -128,6 +130,7 @@ mod issue_282 {
 // Invalid alignment assumptions when converting doing Bits and Bytes optimizations
 //
 // https://github.com/sharksforarms/deku/issues/292
+#[cfg(feature = "bits")]
 #[test]
 fn test_regression_292() {
     let test_data = [0x0f, 0xf0];

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -10,11 +10,13 @@ mod test_common;
 /// TODO: These should be divided into smaller tests
 
 // Common struct to test nesting
+#[cfg(feature = "bits")]
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 pub struct DoubleNestedDeku {
     pub data: u16,
 }
 
+#[cfg(feature = "bits")]
 // Common struct to test nesting
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 pub struct NestedDeku {
@@ -26,6 +28,7 @@ pub struct NestedDeku {
     pub inner: DoubleNestedDeku,
 }
 
+#[cfg(feature = "bits")]
 #[test]
 #[should_panic(expected = r#"Parse("Too much data")"#)]
 fn test_read_too_much_data() {
@@ -39,6 +42,7 @@ fn test_read_too_much_data() {
     TestStruct::try_from(test_data).unwrap();
 }
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_unnamed_struct() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
@@ -96,6 +100,7 @@ fn test_unnamed_struct() {
     assert_eq!(test_data, ret_write);
 }
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_named_struct() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]

--- a/tests/test_to_bits.rs
+++ b/tests/test_to_bits.rs
@@ -1,8 +1,10 @@
 use std::convert::TryFrom;
 
+#[cfg(feature = "bits")]
 use deku::bitvec::Lsb0;
 use deku::prelude::*;
 
+#[cfg(feature = "bits")]
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 pub struct Test {
     #[deku(bits = "4")]
@@ -11,6 +13,7 @@ pub struct Test {
     pub b: u8,
 }
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_to_bits_correct() {
     let test_data: &[u8] = &[0xf1];
@@ -19,6 +22,7 @@ fn test_to_bits_correct() {
     assert_eq!(deku::bitvec::bitvec![1, 1, 1, 1, 0, 0, 0, 1], bits);
 }
 
+#[cfg(feature = "bits")]
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 pub struct TestOver {
     #[deku(bits = "4")]
@@ -29,6 +33,7 @@ pub struct TestOver {
     pub c: u8,
 }
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_to_bits_correct_over() {
     let test_data: &[u8] = &[0xf1, 0x80];
@@ -37,6 +42,7 @@ fn test_to_bits_correct_over() {
     assert_eq!(deku::bitvec::bitvec![1, 1, 1, 1, 0, 0, 0, 1, 1], bits);
 }
 
+#[cfg(feature = "bits")]
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u8", bits = "4")]
 enum TestEnum {
@@ -44,6 +50,7 @@ enum TestEnum {
     VarA,
 }
 
+#[cfg(feature = "bits")]
 #[test]
 fn test_to_bits_enum() {
     let test_data: &[u8] = &[0b1010_0000];

--- a/tests/test_to_slice.rs
+++ b/tests/test_to_slice.rs
@@ -20,6 +20,7 @@ fn test_to_slice_bytes() {
     assert_eq!(amt_written, 3);
 }
 
+#[cfg(feature = "bits")]
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 pub struct B {
     #[deku(bits = "3", endian = "little")]
@@ -27,6 +28,7 @@ pub struct B {
 }
 
 #[test]
+#[cfg(feature = "bits")]
 fn test_to_slice_bits() {
     let b = B { inner: 0b111 };
 


### PR DESCRIPTION
This is like the final boss of all my performance work. I try to explain the "no warranty and testing are given for the disable of this feature", while still implementing enough to make this useful in the case of "I want perf to matter".

![image](https://github.com/sharksforarms/deku/assets/15236002/5a33fb7a-1087-4b04-a7f8-1b540207ccc6)

bench: https://github.com/wcampbell0x2a/deku-bench/pull/24