### PR TITLE
Support Unit like structs for DekuWrite

### DIFF
--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -34,6 +34,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let field_updates = emit_field_updates(&fields, Some(quote! { self. }));
 
     let named = fields.style.is_struct();
+    let unit = fields.style.is_unit();
 
     let field_idents = fields.iter().enumerate().filter_map(|(i, f)| {
         if !f.temp {
@@ -43,7 +44,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
         }
     });
 
-    let destructured = gen_struct_destruction(named, &input.ident, field_idents);
+    let destructured = gen_struct_destruction(named, unit, &input.ident, field_idents);
 
     // Implement `DekuContainerWrite` for types that don't need a context
     if input.ctx.is_none() || (input.ctx.is_some() && input.ctx_default.is_some()) {

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -95,10 +95,15 @@ fn gen_struct_init<I: ToTokens>(
 /// - Unnamed: `#ident ( ref fields )`
 fn gen_struct_destruction<I: ToTokens, F: ToTokens>(
     named: bool,
+    unit: bool,
     ident: I,
     field_idents: impl Iterator<Item = F>,
 ) -> TokenStream {
-    if named {
+    if unit {
+        quote! {
+            #ident
+        }
+    } else if named {
         quote! {
             #ident {
                 #(ref #field_idents),*

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -204,3 +204,19 @@ fn test_big_endian() {
     let new_bytes = a.to_bytes().unwrap();
     assert_eq!(&bytes[..2], &*new_bytes);
 }
+
+#[test]
+fn test_units() {
+    #[derive(DekuRead, DekuWrite)]
+    #[deku(magic = b"\xf0")]
+    struct Unit;
+
+    let bytes = [0xf0];
+    let a = Unit::from_bytes((&bytes, 0)).unwrap().1;
+    let new_bytes = a.to_bytes().unwrap();
+    assert_eq!(bytes, &*new_bytes);
+
+    let a = Unit;
+    let new_bytes = a.to_bytes().unwrap();
+    assert_eq!(bytes, &*new_bytes);
+}


### PR DESCRIPTION
* Fix support for DekuWrite by not adding fields to the struct destruction in deku-write proc-macro
* Add test

Closes #449