### PR TITLE
Fix problem with clippy:manual_unwrap_or_default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,11 @@ assert_hex = "0.4.1"
 [[bench]]
 name = "deku"
 harness = false
+
+[lints]
+workspace = true
+
+[workspace.lints.clippy]
+# Triggers in macro generated code of darling
+# https://github.com/rust-lang/rust-clippy/issues/12643
+manual-unwrap-or-default = "allow"

--- a/deku-derive/Cargo.toml
+++ b/deku-derive/Cargo.toml
@@ -28,3 +28,6 @@ proc-macro-crate = { version = "3.1.0", optional = true }
 
 [dev-dependencies]
 rstest = "0.19"
+
+[lints]
+workspace = true


### PR DESCRIPTION
* Fix bugged trigger in darling over new stable clippy lint. This is the same fix that `serde_with` used.

See https://github.com/rust-lang/rust-clippy/issues/12643