### PR TITLE
Draft: Support arbitrary enum discriminant

### DIFF
--- a/examples/enums_catch_all.rs
+++ b/examples/enums_catch_all.rs
@@ -10,13 +10,13 @@ use hexlit::hex;
 pub enum DekuTest {
     /// A
     #[deku(id = "1")]
-    A = 0,
+    A,
     /// B
     #[deku(id = "2")]
-    B = 1,
+    B,
     /// C
     #[deku(id = "3", default)]
-    C = 2,
+    C,
 }
 
 fn main() {

--- a/tests/test_catch_all.rs
+++ b/tests/test_catch_all.rs
@@ -27,13 +27,13 @@ mod test {
     pub enum AdvancedRemapping {
         /// A
         #[deku(id = "1")]
-        A = 0,
+        A,
         /// B
         #[deku(id = "2")]
-        B = 1,
+        B,
         /// C
         #[deku(id = "3", default)]
-        C = 2,
+        C,
     }
 
     #[test]

--- a/tests/test_compile/cases/attribute_token_stream.stderr
+++ b/tests/test_compile/cases/attribute_token_stream.stderr
@@ -12,12 +12,12 @@ error[E0277]: can't compare `{integer}` with `bool`
   |
   = help: the trait `PartialEq<bool>` is not implemented for `{integer}`
   = help: the following other types implement trait `PartialEq<Rhs>`:
-            isize
-            i8
+            f128
+            f16
+            f32
+            f64
+            i128
             i16
             i32
             i64
-            i128
-            usize
-            u8
           and $N others

--- a/tests/test_compile/cases/id_arbitrary_enum_discriminant.stderr
+++ b/tests/test_compile/cases/id_arbitrary_enum_discriminant.stderr
@@ -1,0 +1,5 @@
+error: DekuRead: `id` cannot be used with arbitrary_enum_discriminant
+ --> tests/test_compile/cases/id_arbitrary_enum_discriminant.rs:8:5
+  |
+8 |     A(u8) = 0,
+  |     ^

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -152,3 +152,43 @@ fn test_id_pat_with_id() {
     );
     assert_eq!(input, &*v.to_bytes().unwrap());
 }
+
+#[test]
+fn test_arbitrary() {
+    #[repr(u8)]
+    #[derive(DekuRead, DekuWrite, Debug, PartialEq)]
+    #[deku(id_type = "u8")]
+    enum Foo {
+        A(u8) = 0,
+        B(bool) = 42,
+        I(Inner) = 12,
+        N = 10,
+    }
+
+    #[repr(u8)]
+    #[derive(DekuRead, DekuWrite, Debug, PartialEq)]
+    #[deku(id_type = "u8")]
+    enum Inner {
+        One(u8) = 0,
+    }
+
+    let bytes = [0, 1];
+    let (_, foo) = Foo::from_bytes((&bytes, 0)).unwrap();
+    assert_eq!(foo, Foo::A(1));
+    assert_eq!(bytes, &*foo.to_bytes().unwrap());
+
+    let bytes = [42, 1];
+    let (_, foo) = Foo::from_bytes((&bytes, 0)).unwrap();
+    assert_eq!(foo, Foo::B(true));
+    assert_eq!(bytes, &*foo.to_bytes().unwrap());
+
+    let bytes = [12, 0, 1];
+    let (_, foo) = Foo::from_bytes((&bytes, 0)).unwrap();
+    assert_eq!(foo, Foo::I(Inner::One(1)));
+    assert_eq!(bytes, &*foo.to_bytes().unwrap());
+
+    let bytes = [10];
+    let (_, foo) = Foo::from_bytes((&bytes, 0)).unwrap();
+    assert_eq!(foo, Foo::N);
+    assert_eq!(bytes, &*foo.to_bytes().unwrap());
+}


### PR DESCRIPTION
* Add support for arbitrary enum discriminant
* Remove support for defining both `id = 1` and having a discriminant
* Made DekuRead/DekuWrite Id const if possible

Closes #306