### PR TITLE
Add core_in_error support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["sharks <sharks@sharks>"]
 edition = "2021"
 name = "deku"
-version = "0.17.0"
+version = "0.17.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sharksforarms/deku"
 keywords = ["deku", "bits", "serialization", "deserialization", "struct"]
@@ -25,6 +25,7 @@ std = ["deku_derive/std", "bitvec/std", "alloc", "no_std_io/std"]
 alloc = ["bitvec/alloc"]
 logging = ["deku_derive/logging", "log"]
 no-assert-string = ["deku_derive/no-assert-string"]
+error_in_core = []
 
 [dependencies]
 deku_derive = { version = "^0.17.0", path = "deku-derive", default-features = false}

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,3 +112,6 @@ impl From<DekuError> for std::io::Error {
         }
     }
 }
+
+#[cfg(feature = "error_in_core")]
+impl core::error::Error for DekuError {}


### PR DESCRIPTION
Add the `core_in_error` feature and implement `core::error::Error` for `DekuError` if the `core_in_error` feature is enabled.

This feature is automatically enabled in Rust nightly so when using Rust nightly you get this feature by default. When using stable Rust, this feature can be optionally added.