### PR TITLE
Fix invalid input bits into benchmarks

### DIFF
--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -72,9 +72,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("deku_write_bits", |b| {
         b.iter(|| {
             deku_write(black_box(&DekuBits {
-                data_01: 0x0f,
-                data_02: 0x00,
-                data_03: 0x01,
+                data_01: 0x01,
+                data_02: 0x03,
+                data_03: 0x06,
             }))
         })
     });


### PR DESCRIPTION
* Broken by https://github.com/sharksforarms/deku/pull/458, fixed by this commit