### PR TITLE
Qualify types in derive macros

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -43,7 +43,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_reader.seek(SeekFrom::Current(i64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -53,7 +53,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_reader.seek(SeekFrom::End(i64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -63,7 +63,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_reader.seek(SeekFrom::Start(u64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -72,7 +72,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             {
                 use ::#crate_::no_std_io::Seek;
                 if let Err(e) = __deku_reader.rewind() {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -105,6 +105,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
     if input.ctx.is_none() || (input.ctx.is_some() && input.ctx_default.is_some()) {
         let from_reader_body = quote! {
             use core::convert::TryFrom;
+            use ::#crate_::DekuReader as _;
             let __deku_reader = &mut deku::reader::Reader::new(__deku_input.0);
             if __deku_input.1 != 0 {
                 __deku_reader.skip_bits(__deku_input.1)?;
@@ -117,6 +118,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         let from_bytes_body = quote! {
             use core::convert::TryFrom;
+            use ::#crate_::DekuReader as _;
             let mut __deku_cursor = #crate_::no_std_io::Cursor::new(__deku_input.0);
             let mut __deku_reader = &mut deku::reader::Reader::new(&mut __deku_cursor);
             if __deku_input.1 != 0 {
@@ -374,6 +376,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     if input.ctx.is_none() || (input.ctx.is_some() && input.ctx_default.is_some()) {
         let from_reader_body = quote! {
             use core::convert::TryFrom;
+            use ::#crate_::DekuReader as _;
             let __deku_reader = &mut deku::reader::Reader::new(__deku_input.0);
             if __deku_input.1 != 0 {
                 __deku_reader.skip_bits(__deku_input.1)?;
@@ -386,6 +389,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
         let from_bytes_body = quote! {
             use core::convert::TryFrom;
+            use ::#crate_::DekuReader as _;
             let mut __deku_cursor = #crate_::no_std_io::Cursor::new(__deku_input.0);
             let mut __deku_reader = &mut deku::reader::Reader::new(&mut __deku_cursor);
             if __deku_input.1 != 0 {
@@ -417,6 +421,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
     let read_body = quote! {
         use core::convert::TryFrom;
+        use ::#crate_::DekuReader as _;
 
         #magic_read
 
@@ -466,10 +471,10 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             tokens.extend(quote! {
             impl<'__deku> #imp ::#crate_::DekuEnumExt<#lifetime, (#deku_id_type)> for #ident #wher {
                 #[inline]
-                fn deku_id(&self) -> core::result::Result<(#deku_id_type), DekuError> {
+                fn deku_id(&self) -> core::result::Result<(#deku_id_type), ::#crate_::DekuError> {
                     match self {
                         #(#deku_ids ,)*
-                        _ => Err(DekuError::IdVariantNotFound),
+                        _ => Err(::#crate_::DekuError::IdVariantNotFound),
                     }
                 }
             }
@@ -647,7 +652,7 @@ fn emit_field_read(
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_reader.seek(SeekFrom::Current(i64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -657,7 +662,7 @@ fn emit_field_read(
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_reader.seek(SeekFrom::End(i64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -667,7 +672,7 @@ fn emit_field_read(
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_reader.seek(SeekFrom::Start(u64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -676,7 +681,7 @@ fn emit_field_read(
             {
                 use ::#crate_::no_std_io::Seek;
                 if let Err(e) = __deku_reader.rewind() {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -761,7 +766,7 @@ fn emit_field_read(
             quote! {
                 {
                     if let Err(e) = __deku_reader.seek_last_read() {
-                        return Err(DekuError::Io(e.kind()));
+                        return Err(::#crate_::DekuError::Io(e.kind()));
                     }
                     #type_as_deku_read::from_reader_with_ctx
                     (

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -34,7 +34,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_writer.seek(SeekFrom::Current(i64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -44,7 +44,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_writer.seek(SeekFrom::End(i64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -54,7 +54,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_writer.seek(SeekFrom::Start(u64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -63,7 +63,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             {
                 use ::#crate_::no_std_io::Seek;
                 if let Err(e) = __deku_writer.rewind() {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -98,6 +98,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
                 #[inline]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
+                    use ::#crate_::DekuContainerWrite as _;
                     input.to_bits()
                 }
             }
@@ -113,7 +114,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 }
             }
 
-            impl #imp DekuContainerWrite for #ident #wher {}
+            impl #imp ::#crate_::DekuContainerWrite for #ident #wher {}
         });
     }
 
@@ -135,7 +136,7 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let update_use = check_update_use(&field_updates);
 
     tokens.extend(quote! {
-        impl #imp DekuUpdate for #ident #wher {
+        impl #imp ::#crate_::DekuUpdate for #ident #wher {
             #[inline]
             fn update(&mut self) -> core::result::Result<(), ::#crate_::DekuError> {
                 #update_use
@@ -304,6 +305,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
 
                 #[inline]
                 fn try_from(input: #ident) -> core::result::Result<Self, Self::Error> {
+                    use ::#crate_::DekuContainerWrite as _;
                     input.to_bits()
                 }
             }
@@ -319,7 +321,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 }
             }
 
-            impl #imp DekuContainerWrite for #ident #wher {}
+            impl #imp ::#crate_::DekuContainerWrite for #ident #wher {}
         });
     }
 
@@ -339,7 +341,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
     let update_use = check_update_use(&variant_updates);
 
     tokens.extend(quote! {
-        impl #imp DekuUpdate for #ident #wher {
+        impl #imp ::#crate_::DekuUpdate for #ident #wher {
             #[inline]
             fn update(&mut self) -> core::result::Result<(), ::#crate_::DekuError> {
                 #update_use
@@ -521,7 +523,7 @@ fn emit_field_write(
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_writer.seek(SeekFrom::Current(i64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -531,7 +533,7 @@ fn emit_field_write(
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_writer.seek(SeekFrom::End(i64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -541,7 +543,7 @@ fn emit_field_write(
                 use ::#crate_::no_std_io::Seek;
                 use ::#crate_::no_std_io::SeekFrom;
                 if let Err(e) = __deku_writer.seek(SeekFrom::Start(u64::try_from(#num).unwrap())) {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }
@@ -550,7 +552,7 @@ fn emit_field_write(
             {
                 use ::#crate_::no_std_io::Seek;
                 if let Err(e) = __deku_writer.rewind() {
-                    return Err(DekuError::Io(e.kind()));
+                    return Err(::#crate_::DekuError::Io(e.kind()));
                 }
             }
         }

--- a/tests/test_compile/mod.rs
+++ b/tests/test_compile/mod.rs
@@ -4,5 +4,6 @@
 #[cfg_attr(miri, ignore)]
 fn test_compile() {
     let t = trybuild::TestCases::new();
+    t.pass("tests/test_compile/pass_cases/*.rs");
     t.compile_fail("tests/test_compile/cases/*.rs");
 }

--- a/tests/test_compile/pass_cases/no_prelude.rs
+++ b/tests/test_compile/pass_cases/no_prelude.rs
@@ -1,0 +1,27 @@
+#[derive(PartialEq, Debug, deku::DekuRead, deku::DekuWrite)]
+#[deku(id_type = "u8")]
+enum TestEnum {
+    #[deku(id = "1")]
+    VarA(u8),
+    #[deku(id = "2")]
+    VarB(#[deku(bits = 4)] u8, #[deku(bits = 4)] u8),
+    #[deku(id = "3")]
+    VarC {
+        #[deku(update = "field_b.len()")]
+        field_a: u8,
+        #[deku(count = "field_a")]
+        field_b: Vec<u8>,
+    },
+    #[deku(id = "4")]
+    VarD(
+        #[deku(update = "field_1.len()")] u8,
+        #[deku(count = "field_0")] Vec<u8>,
+    ),
+
+    #[deku(id_pat = "_")]
+    VarDefault { id: u8, value: u8 },
+}
+
+fn main() {
+    
+}

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -235,6 +235,7 @@ fn id_pat_with_id_bits() {
 }
 
 #[test]
+#[cfg(feature = "bits")]
 fn test_litbool_as_id() {
     use deku::prelude::*;
 


### PR DESCRIPTION
`derive(DekuRead)` and `derive(DekuWrite)` currently don't work without importing `deku::prelude` because of some unqualified types and trait methods.  
I updated everything unqualified I found in the macros and added a (non-exhaustive) test to ensure they compile without the prelude.