### PR TITLE
`Reader` shouldn't require its inner type to be a mutable reference

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -61,7 +61,7 @@ impl<R: Read + Seek> AsMut<R> for Reader<R> {
     }
 }
 
-impl<'a, R: Read + Seek> Reader<R> {
+impl<R: Read + Seek> Reader<R> {
     /// Create a new `Reader`
     #[inline]
     pub fn new(inner: R) -> Self {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -32,8 +32,8 @@ enum Leftover {
 }
 
 /// Reader to use with `from_reader_with_ctx`
-pub struct Reader<'a, R: Read + Seek> {
-    inner: &'a mut R,
+pub struct Reader<R: Read + Seek> {
+    inner: R,
     /// bits stored from previous reads that didn't read to the end of a byte size
     leftover: Option<Leftover>,
     /// Amount of bits read after last read, reseted before reading enum ids
@@ -42,7 +42,7 @@ pub struct Reader<'a, R: Read + Seek> {
     pub bits_read: usize,
 }
 
-impl<R: Read + Seek> Seek for Reader<'_, R> {
+impl<R: Read + Seek> Seek for Reader<R> {
     #[inline]
     fn seek(&mut self, pos: SeekFrom) -> no_std_io::io::Result<u64> {
         #[cfg(feature = "logging")]
@@ -54,17 +54,17 @@ impl<R: Read + Seek> Seek for Reader<'_, R> {
     }
 }
 
-impl<R: Read + Seek> AsMut<R> for Reader<'_, R> {
+impl<R: Read + Seek> AsMut<R> for Reader<R> {
     #[inline]
     fn as_mut(&mut self) -> &mut R {
-        self.inner
+        &mut self.inner
     }
 }
 
-impl<'a, R: Read + Seek> Reader<'a, R> {
+impl<'a, R: Read + Seek> Reader<R> {
     /// Create a new `Reader`
     #[inline]
-    pub fn new(inner: &'a mut R) -> Self {
+    pub fn new(inner: R) -> Self {
         Self {
             inner,
             leftover: None,
@@ -87,7 +87,7 @@ impl<'a, R: Read + Seek> Reader<'a, R> {
 
     /// Consume self, returning inner Reader
     #[inline]
-    pub fn into_inner(self) -> &'a mut R {
+    pub fn into_inner(self) -> R {
         self.inner
     }
 


### PR DESCRIPTION
This makes `Reader` more general, so it can e.g. take ownership of a `Read + Seek` type.