### PR TITLE
reader: Remove constraint of MAX_BITS_AMT

### DIFF
--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -66,7 +66,7 @@ mod tests {
                 let _ = TestDeku::from_reader((&mut cursor, 0)).unwrap();
             })
             .0,
-            (5, 0, 5)
+            (6, 0, 6)
         );
     }
 


### PR DESCRIPTION
* In order to allow one to read a large amount of bytes after an unaligned bit reading, remove MAX_BITS_AMT and allocate a length of bytes_len to store the byte read result.

  See #527