### PR TITLE
Pin rustc-hash to 2.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ hexlit = "0.5.5"
 criterion = "0.5.1"
 alloc_counter = "0.0.4"
 trybuild = "1.0.99"
-rustc-hash = "2.0.0"
+rustc-hash = "=2.1.0"
 env_logger = "0.11.5"
 assert_hex = "0.4.1"
 


### PR DESCRIPTION
Pin rustc-hash that is used internally for testing. This library updated it's internal algorithm in newer versions, but we only use it to compare the bytes written. See https://github.com/rust-lang/rustc-hash/blob/master/CHANGELOG.md#211

This was found in https://github.com/sharksforarms/deku/pull/529 and https://github.com/sharksforarms/deku/pull/528 since we don't have a lockfile.