### PR TITLE
Remove re-reading for ip_pat

### DIFF
--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -530,6 +530,61 @@ struct FieldData {
 }
 
 impl FieldData {
+    pub fn any_field_set(&self) -> bool {
+        // NOTE: Ignore ident
+        let mut any_option_set = self.endian.is_some();
+
+        #[cfg(feature = "bits")]
+        {
+            any_option_set = any_option_set || self.bits.is_some();
+        }
+
+        any_option_set = any_option_set || self.bytes.is_some() || self.count.is_some();
+
+        #[cfg(feature = "bits")]
+        {
+            any_option_set = any_option_set || self.bits_read.is_some();
+        }
+
+        any_option_set = any_option_set
+            || self.bytes_read.is_some()
+            || self.until.is_some()
+            || self.map.is_some()
+            || self.ctx.is_some()
+            || self.update.is_some()
+            || self.reader.is_some()
+            || self.writer.is_some();
+
+        #[cfg(feature = "bits")]
+        {
+            any_option_set = any_option_set || self.pad_bits_before.is_some();
+        }
+
+        any_option_set = any_option_set || self.pad_bytes_before.is_some();
+
+        #[cfg(feature = "bits")]
+        {
+            any_option_set = any_option_set || self.pad_bits_after.is_some();
+        }
+
+        // NOTE: Ignore default
+        any_option_set = any_option_set
+            || self.pad_bytes_after.is_some()
+            || self.temp_value.is_some()
+            || self.cond.is_some()
+            || self.assert.is_some()
+            || self.assert_eq.is_some()
+            || self.seek_from_current.is_some()
+            || self.seek_from_end.is_some()
+            || self.seek_from_start.is_some()
+            || self.bit_order.is_some()
+            || self.magic.is_some();
+
+        let any_bool_set = self.read_all || self.skip || self.temp || self.seek_rewind;
+
+        any_option_set || any_bool_set
+    }
+
     fn from_receiver(receiver: DekuFieldReceiver) -> Result<Self, TokenStream> {
         let ctx = receiver
             .ctx?

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -100,12 +100,26 @@ impl ToTokens for Num {
 impl FromMeta for Num {
     fn from_value(value: &syn::Lit) -> darling::Result<Self> {
         (match *value {
-            syn::Lit::Str(ref s) => Ok(Num::TokenStream(
-                apply_replacements(s)
-                    .map_err(darling::Error::custom)?
-                    .parse::<TokenStream>()
-                    .expect("could not parse token stream"),
-            )),
+            syn::Lit::Str(ref s) => {
+                let str_value = s.value();
+
+                // Attempt to read ("2") as a Num LitInt (2)
+                match str_value.parse::<u64>() {
+                    Ok(int_value) => {
+                        let int_string = int_value.to_string();
+                        let span = s.span();
+                        let lit_int = syn::LitInt::new(&int_string, span);
+                        Ok(Num::new(lit_int))
+                    }
+                    // else, just a tokenstream
+                    Err(_) => Ok(Num::TokenStream(
+                        apply_replacements(s)
+                            .map_err(darling::Error::custom)?
+                            .parse::<TokenStream>()
+                            .expect("could not parse token stream"),
+                    )),
+                }
+            }
             syn::Lit::Int(ref s) => Ok(Num::new(s.clone())),
             _ => Err(darling::Error::unexpected_lit_type(value)),
         })

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -278,6 +278,15 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
         let variant_read_func = if variant_reader.is_some() {
             quote! { #variant_reader; }
         } else {
+            // VarDefault { id: u8, value: u8 }, is allowed
+            // VarDefault, is not, if we need to store the id
+            if pad_id && variant.id.is_none() && variant.fields.is_empty() {
+                // TODO: This would be nice to point to the field
+                return Err(syn::Error::new(
+                    input.ident.span(),
+                    "DekuRead: id_pat requires storage field",
+                ));
+            }
             let (field_idents, field_reads) =
                 emit_field_reads(input, &variant.fields.as_ref(), &ident, pad_id)?;
 

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -11,7 +11,7 @@ use crate::macros::{
     assertion_failed, gen_bit_order_from_str, gen_ctx_types_and_arg, gen_field_args,
     gen_internal_field_idents, token_contains_string, wrap_default_ctx,
 };
-use crate::{DekuData, DekuDataEnum, DekuDataStruct, FieldData, Id, Num};
+use crate::{DekuData, DekuDataEnum, DekuDataStruct, FieldData, Id};
 
 use super::{gen_internal_field_ident, gen_type_from_ctx_id};
 
@@ -820,37 +820,12 @@ fn emit_field_read(
         };
 
         if pad_id {
-            #[cfg(not(feature = "bits"))]
-            if let (Some(Num::LitInt(a)), Some(Num::LitInt(b))) = (&f.bits, &input.bits) {
-                if a != b {
-                    // TODO: This would be nice to point to the field
-                    return Err(syn::Error::new(
-                        input.ident.span(),
-                        format!("DekuRead: id_pat bits `{}` must match bits `{}`", a, b),
-                    ));
-                }
-            }
-            if let (Some(Num::LitInt(a)), Some(Num::LitInt(b))) = (&f.bytes, &input.bytes) {
-                if a != b {
-                    // TODO: This would be nice to point to the field
-                    return Err(syn::Error::new(
-                        input.ident.span(),
-                        format!("DekuRead: id_pat bytes `{}` must match bytes `{}`", a, b),
-                    ));
-                }
-            }
-            if let (Some(a), Some(b)) = (&f.endian, &input.id_endian) {
-                if a != b {
-                    // TODO: This would be nice to point to the field
-                    return Err(syn::Error::new(
-                        input.ident.span(),
-                        format!(
-                            "DekuRead: id_pat endian `{}` must match id_endian `{}`",
-                            a.value(),
-                            b.value(),
-                        ),
-                    ));
-                }
+            if f.any_field_set() {
+                // TODO: This would be nice to point to the field
+                return Err(syn::Error::new(
+                    input.ident.span(),
+                    "DekuRead: id_pat id storage cannot have attributes",
+                ));
             }
             quote! {
                 __deku_variant_id;

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1596,7 +1596,8 @@ assert_eq!(
 
 Specify the identifier in the form of a match pattern for the enum variant.
 
-The enum variant must have space to store the identifier for proper writing.
+The first field of the variant is used for storage, and must be the same type as `id_type` and no attributes.
+The writing of the field will use the same options as the reading.
 
 Example:
 ```rust

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -36,8 +36,6 @@ pub struct Reader<R: Read + Seek> {
     inner: R,
     /// bits stored from previous reads that didn't read to the end of a byte size
     pub leftover: Option<Leftover>,
-    /// Amount of bits read after last read, reseted before reading enum ids
-    pub last_bits_read_amt: usize,
     /// Amount of bits read during the use of [read_bits](Reader::read_bits) and [read_bytes](Reader::read_bytes)
     pub bits_read: usize,
 }
@@ -85,28 +83,8 @@ impl<R: Read + Seek> Reader<R> {
         Self {
             inner,
             leftover: None,
-            last_bits_read_amt: 0,
             bits_read: 0,
         }
-    }
-
-    /// Seek to previous previous before the last read, used for `id_pat`
-    #[inline]
-    pub fn seek_last_read(&mut self) -> no_std_io::io::Result<()> {
-        // save the previous bits read
-        let bits_read = self.bits_read;
-
-        let number = self.last_bits_read_amt as i64;
-        let seek_amt = (number / 8).saturating_add((number % 8).signum());
-        #[cfg(feature = "logging")]
-        log::trace!("seek_last_read: {seek_amt:?}");
-        self.seek(SeekFrom::Current(seek_amt.saturating_neg()))?;
-
-        // restore bits read, minus bits we read last time
-        self.bits_read = bits_read - self.last_bits_read_amt;
-        self.leftover = None;
-
-        Ok(())
     }
 
     /// Consume self, returning inner Reader
@@ -394,7 +372,6 @@ impl<R: Read + Seek> Reader<R> {
         }
 
         let bits_read = ret.len();
-        self.last_bits_read_amt += bits_read;
         self.bits_read += bits_read;
 
         #[cfg(feature = "logging")]
@@ -431,7 +408,6 @@ impl<R: Read + Seek> Reader<R> {
             }
 
             let bits_read = amt * 8;
-            self.last_bits_read_amt += bits_read;
             self.bits_read += bits_read;
 
             #[cfg(feature = "logging")]
@@ -522,7 +498,6 @@ impl<R: Read + Seek> Reader<R> {
                 return Err(DekuError::Io(e.kind()));
             }
 
-            self.last_bits_read_amt += N * 8;
             self.bits_read += N * 8;
 
             #[cfg(feature = "logging")]
@@ -650,64 +625,6 @@ mod tests {
         let _ = reader.read_bytes(1, &mut buf, Order::Lsb0).unwrap();
         assert_eq!([0xaa], buf);
         assert_eq!(reader.bits_read, 8);
-    }
-
-    #[test]
-    fn test_seek_last_read_bytes() {
-        // bytes
-        let input = hex!("aa");
-        let mut cursor = Cursor::new(input);
-        let mut reader = Reader::new(&mut cursor);
-        let mut buf = [0; 1];
-        let _ = reader.read_bytes(1, &mut buf, Order::Msb0).unwrap();
-        assert_eq!([0xaa], buf);
-        assert_eq!(reader.bits_read, 8);
-
-        reader.seek_last_read().unwrap();
-        let _ = reader.read_bytes(1, &mut buf, Order::Msb0).unwrap();
-        assert_eq!([0xaa], buf);
-        assert_eq!(reader.bits_read, 8);
-
-        // 2 bytes (and const)
-        let input = hex!("aabb");
-        let mut cursor = Cursor::new(input);
-        let mut reader = Reader::new(&mut cursor);
-        let mut buf = [0; 2];
-        let _ = reader.read_bytes_const::<2>(&mut buf, Order::Msb0).unwrap();
-        assert_eq!([0xaa, 0xbb], buf);
-        assert_eq!(reader.bits_read, 16);
-
-        reader.seek_last_read().unwrap();
-        let _ = reader.read_bytes_const::<2>(&mut buf, Order::Msb0).unwrap();
-        assert_eq!([0xaa, 0xbb], buf);
-        assert_eq!(reader.bits_read, 16);
-    }
-
-    #[cfg(feature = "bits")]
-    #[test]
-    fn test_seek_last_read_bits() {
-        let input = hex!("ab");
-        let mut cursor = Cursor::new(input);
-        let mut reader = Reader::new(&mut cursor);
-        let bits = reader.read_bits(4, Order::Msb0).unwrap();
-        assert_eq!(bits, Some(bitvec![u8, Msb0; 1, 0, 1, 0]));
-        assert_eq!(reader.bits_read, 4);
-        reader.seek_last_read().unwrap();
-        let bits = reader.read_bits(4, Order::Msb0).unwrap();
-        assert_eq!(bits, Some(bitvec![u8, Msb0; 1, 0, 1, 0]));
-        assert_eq!(reader.bits_read, 4);
-
-        // more than byte
-        let input = hex!("abd0");
-        let mut cursor = Cursor::new(input);
-        let mut reader = Reader::new(&mut cursor);
-        let bits = reader.read_bits(9, Order::Msb0).unwrap();
-        assert_eq!(bits, Some(bitvec![u8, Msb0; 1, 0, 1, 0, 1, 0, 1, 1, 1]));
-        assert_eq!(reader.bits_read, 9);
-        reader.seek_last_read().unwrap();
-        let bits = reader.read_bits(9, Order::Msb0).unwrap();
-        assert_eq!(bits, Some(bitvec![u8, Msb0; 1, 0, 1, 0, 1, 0, 1, 1, 1]));
-        assert_eq!(reader.bits_read, 9);
     }
 
     #[cfg(feature = "bits")]

--- a/tests/test_compile/cases/enum_validation.rs
+++ b/tests/test_compile/cases/enum_validation.rs
@@ -76,7 +76,7 @@ enum Test11 {
     B(u8),
 }
 
-// test non matching bits (2) == bits (7)
+// Test id_pat id storage must not have attributes
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u8", bits = "2")]
 pub enum Test12 {
@@ -84,7 +84,7 @@ pub enum Test12 {
     B(#[deku(bits = 7)] u8, #[deku(bits = 6)] u8),
 }
 
-// test non matching bytes(2) == bytes (3)
+// Test id_pat id storage must not have attributes
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u32", bytes = "2")]
 pub enum Test13 {
@@ -92,7 +92,7 @@ pub enum Test13 {
     B(#[deku(bytes = 3)] u32, #[deku(bits = 6)] u8),
 }
 
-// test non matching bytes(2) == bytes (3)
+// Test id_pat id storage must not have attributes
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u32", bytes = "2", id_endian = "little")]
 pub enum Test14 {
@@ -100,12 +100,20 @@ pub enum Test14 {
     B(#[deku(bytes = 2, endian = "big")] u32, #[deku(bits = 6)] u8),
 }
 
-// test non matching type
+// Test id_pat id storage must have matching types
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u32", bytes = "2")]
 pub enum Test15 {
     #[deku(id_pat = "_")]
-    B(#[deku(bits = 2)] u8, #[deku(bits = 6)] u8),
+    B(u8, #[deku(bits = 6)] u8),
+}
+
+// Test id_pat id storage must have matching types
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+#[deku(id_type = "[u8; 32]")]
+pub enum Test16 {
+    #[deku(id_pat = "_")]
+    B(u16, #[deku(bits = 6)] u8),
 }
 
 fn main() {}

--- a/tests/test_compile/cases/enum_validation.rs
+++ b/tests/test_compile/cases/enum_validation.rs
@@ -116,4 +116,20 @@ pub enum Test16 {
     B(u16, #[deku(bits = 6)] u8),
 }
 
+// Test id_pat id storage must exist (read)
+#[derive(PartialEq, Debug, DekuRead)]
+#[deku(id_type = "u8")]
+pub enum Test17 {
+    #[deku(id_pat = "_")]
+    B,
+}
+
+// Test id_pat id storage must exist (write)
+#[derive(PartialEq, Debug, DekuWrite)]
+#[deku(id_type = "u8")]
+pub enum Test18 {
+    #[deku(id_pat = "_")]
+    B,
+}
+
 fn main() {}

--- a/tests/test_compile/cases/enum_validation.rs
+++ b/tests/test_compile/cases/enum_validation.rs
@@ -76,4 +76,36 @@ enum Test11 {
     B(u8),
 }
 
+// test non matching bits (2) == bits (7)
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+#[deku(id_type = "u8", bits = "2")]
+pub enum Test12 {
+    #[deku(id_pat = "_")]
+    B(#[deku(bits = 7)] u8, #[deku(bits = 6)] u8),
+}
+
+// test non matching bytes(2) == bytes (3)
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+#[deku(id_type = "u32", bytes = "2")]
+pub enum Test13 {
+    #[deku(id_pat = "_")]
+    B(#[deku(bytes = 3)] u32, #[deku(bits = 6)] u8),
+}
+
+// test non matching bytes(2) == bytes (3)
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+#[deku(id_type = "u32", bytes = "2", id_endian = "little")]
+pub enum Test14 {
+    #[deku(id_pat = "_")]
+    B(#[deku(bytes = 2, endian = "big")] u32, #[deku(bits = 6)] u8),
+}
+
+// test non matching type
+#[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+#[deku(id_type = "u32", bytes = "2")]
+pub enum Test15 {
+    #[deku(id_pat = "_")]
+    B(#[deku(bits = 2)] u8, #[deku(bits = 6)] u8),
+}
+
 fn main() {}

--- a/tests/test_compile/cases/enum_validation.stderr
+++ b/tests/test_compile/cases/enum_validation.stderr
@@ -64,13 +64,19 @@ error: DekuRead: `id` must be specified on non-unit variants
 76 |     B(u8),
    |     ^
 
-error: DekuRead: id_pat bytes `3` must match bytes `2`
+error: DekuRead: id_pat id storage cannot have attributes
+  --> tests/test_compile/cases/enum_validation.rs:82:10
+   |
+82 | pub enum Test12 {
+   |          ^^^^^^
+
+error: DekuRead: id_pat id storage cannot have attributes
   --> tests/test_compile/cases/enum_validation.rs:90:10
    |
 90 | pub enum Test13 {
    |          ^^^^^^
 
-error: DekuRead: id_pat endian `big` must match id_endian `little`
+error: DekuRead: id_pat id storage cannot have attributes
   --> tests/test_compile/cases/enum_validation.rs:98:10
    |
 98 | pub enum Test14 {
@@ -83,4 +89,13 @@ error[E0308]: `?` operator has incompatible types
     |                            ^^^^^^^^ expected `u8`, found `u32`
     |
     = note: `?` operator cannot convert from `u32` to `u8`
+    = note: this error originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: `?` operator has incompatible types
+   --> tests/test_compile/cases/enum_validation.rs:112:28
+    |
+112 | #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    |                            ^^^^^^^^ expected `u16`, found `[u8; 32]`
+    |
+    = note: `?` operator cannot convert from `[u8; 32]` to `u16`
     = note: this error originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/test_compile/cases/enum_validation.stderr
+++ b/tests/test_compile/cases/enum_validation.stderr
@@ -63,3 +63,24 @@ error: DekuRead: `id` must be specified on non-unit variants
    |
 76 |     B(u8),
    |     ^
+
+error: DekuRead: id_pat bytes `3` must match bytes `2`
+  --> tests/test_compile/cases/enum_validation.rs:90:10
+   |
+90 | pub enum Test13 {
+   |          ^^^^^^
+
+error: DekuRead: id_pat endian `big` must match id_endian `little`
+  --> tests/test_compile/cases/enum_validation.rs:98:10
+   |
+98 | pub enum Test14 {
+   |          ^^^^^^
+
+error[E0308]: `?` operator has incompatible types
+   --> tests/test_compile/cases/enum_validation.rs:104:28
+    |
+104 | #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+    |                            ^^^^^^^^ expected `u8`, found `u32`
+    |
+    = note: `?` operator cannot convert from `u32` to `u8`
+    = note: this error originates in the derive macro `DekuRead` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/test_compile/cases/enum_validation.stderr
+++ b/tests/test_compile/cases/enum_validation.stderr
@@ -82,6 +82,18 @@ error: DekuRead: id_pat id storage cannot have attributes
 98 | pub enum Test14 {
    |          ^^^^^^
 
+error: DekuRead: id_pat requires storage field
+   --> tests/test_compile/cases/enum_validation.rs:122:10
+    |
+122 | pub enum Test17 {
+    |          ^^^^^^
+
+error: DekuRead: id_pat requires storage field
+   --> tests/test_compile/cases/enum_validation.rs:130:10
+    |
+130 | pub enum Test18 {
+    |          ^^^^^^
+
 error[E0308]: `?` operator has incompatible types
    --> tests/test_compile/cases/enum_validation.rs:104:28
     |

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -102,7 +102,7 @@ fn test_enum_array_type() {
         #[deku(id = "[1,1,1]")]
         VarB,
         #[deku(id_pat = "_")]
-        VarC((u8, u8, u8)),
+        VarC([u8; 3]),
     }
 
     let input = b"123".to_vec();
@@ -116,7 +116,7 @@ fn test_enum_array_type() {
     let input = b"321".to_vec();
 
     let ret_read = TestEnumArray::try_from(input.as_slice()).unwrap();
-    assert_eq!(TestEnumArray::VarC((b"3"[0], b"2"[0], b"1"[0])), ret_read);
+    assert_eq!(TestEnumArray::VarC([b"3"[0], b"2"[0], b"1"[0]]), ret_read);
 
     let ret_write: Vec<u8> = ret_read.try_into().unwrap();
     assert_eq!(input.to_vec(), ret_write);
@@ -176,7 +176,7 @@ fn test_id_pat_with_id() {
         v,
         DekuTest {
             my_id: 0x06,
-            enum_from_id: MyEnum::VariantB
+            enum_from_id: MyEnum::VariantB,
         }
     );
     assert_eq!(input, &*v.to_bytes().unwrap());
@@ -192,45 +192,13 @@ fn id_pat_with_id_bits() {
         A(#[deku(bits = 6)] u8),
 
         #[deku(id_pat = "_")]
-        B(#[deku(bits = 8)] u8),
+        B(#[deku(bits = 2)] u8, #[deku(bits = 6)] u8),
     }
 
     let input = [0b1100_1111];
     let mut cursor = Cursor::new(input);
     let (_, v) = IdPatBits::from_reader((&mut cursor, 0)).unwrap();
-    assert_eq!(v, IdPatBits::B(0b1100_1111));
-    assert_eq!(input, &*v.to_bytes().unwrap());
-
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8", bits = "7")]
-    pub enum IdPatBitsBigger {
-        #[deku(id = 1)]
-        A(#[deku(bits = 9)] u16),
-
-        #[deku(id_pat = "_")]
-        B(u16),
-    }
-
-    let input = [0b0000_0000, 0b0000_0001];
-    let mut cursor = Cursor::new(input);
-    let (_, v) = IdPatBitsBigger::from_reader((&mut cursor, 0)).unwrap();
-    assert_eq!(v, IdPatBitsBigger::B(0b1_0000_0000));
-    assert_eq!(input, &*v.to_bytes().unwrap());
-
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    #[deku(id_type = "u8", bits = "7")]
-    pub enum IdPatBitsTuple {
-        #[deku(id = 1)]
-        A(#[deku(bits = 9)] u16),
-
-        #[deku(id_pat = "_")]
-        B((u8, u8)),
-    }
-
-    let input = [0b0000_0000, 0b0000_0001];
-    let mut cursor = Cursor::new(input);
-    let (_, v) = IdPatBitsTuple::from_reader((&mut cursor, 0)).unwrap();
-    assert_eq!(v, IdPatBitsTuple::B((0, 1)));
+    assert_eq!(v, IdPatBits::B(0b11, 0b00_1111));
     assert_eq!(input, &*v.to_bytes().unwrap());
 }
 

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -192,7 +192,7 @@ fn id_pat_with_id_bits() {
         A(#[deku(bits = 6)] u8),
 
         #[deku(id_pat = "_")]
-        B(#[deku(bits = 2)] u8, #[deku(bits = 6)] u8),
+        B(u8, #[deku(bits = 6)] u8),
     }
 
     let input = [0b1100_1111];

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -395,7 +395,7 @@ fn issue_533() {
         #[deku(id = 0)]
         Zero,
         #[deku(id_pat = "_")]
-        Other(#[deku(bits = 1)] u8),
+        Other(u8),
     }
     let input = [0b0100_0000];
     let mut cursor = Cursor::new(input);


### PR DESCRIPTION
* Use the last read value for the id instead of jumping back and re-reading that value.
* Compare the endian, bits,and bytes amt when reading from an id. This is important when writing
  as without this check you end up with different bytes being written. More fields could
  be checked against this?
* Reader: Remove last_bits_read_amt and seek_last_read

Should close #533 