### PR TITLE
Add Error and ErrorKind in no_std_io re-exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,8 @@ use alloc::vec::Vec;
 /// re-export of [no_std_io2](https://crates.io/crates/no-std-io2)
 pub mod no_std_io {
     pub use no_std_io::io::Cursor;
+    pub use no_std_io::io::Error;
+    pub use no_std_io::io::ErrorKind;
     pub use no_std_io::io::Read;
     pub use no_std_io::io::Result;
     pub use no_std_io::io::Seek;


### PR DESCRIPTION
Hello! I'm making a library that needs both `deku` and `no_std_io`, and I need to convert `no_std_io2::io::Error` into `mycrate::Error`. Thus, as some structs and traits are already re-exported by `deku`, I think re-exporting also `Error` and `ErrorKind` is also a good idea to avoid asking `no_std_io_2` as an other dependency