### PR TITLE
Support ipaddr in no-std

### DIFF
--- a/src/impls/ipaddr.rs
+++ b/src/impls/ipaddr.rs
@@ -1,4 +1,4 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use no_std_io::io::{Read, Seek, Write};
 

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -1,4 +1,5 @@
 mod bool;
+mod ipaddr;
 mod nonzero;
 mod option;
 mod primitive;
@@ -21,9 +22,6 @@ mod hashmap;
 
 #[cfg(feature = "std")]
 mod hashset;
-
-#[cfg(feature = "std")]
-mod ipaddr;
 
 #[cfg(feature = "alloc")]
 mod boxed;


### PR DESCRIPTION
* ipaddr has moved into core::net in the std library. These changes reflect this and allow ipaddr in no-std envs.

Closes #376