### PR TITLE
chore: added test from issue 564 (failing)

### DIFF
--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -1,3 +1,5 @@
+use core::mem;
+
 use no_std_io::io::{Read, Seek, Write};
 
 #[cfg(feature = "alloc")]
@@ -40,6 +42,11 @@ where
     Ctx: Copy,
     Predicate: FnMut(usize, &T) -> bool,
 {
+    // ZST detected, return empty vec
+    if mem::size_of::<T>() == 0 {
+        return Ok(Vec::new());
+    }
+
     let mut res = capacity.map_or_else(Vec::new, Vec::with_capacity);
 
     let start_read = reader.bits_read;
@@ -67,6 +74,11 @@ where
     T: DekuReader<'a, Ctx>,
     Ctx: Copy,
 {
+    // ZST detected, return empty vec
+    if mem::size_of::<T>() == 0 {
+        return Ok(Vec::new());
+    }
+
     let mut res = capacity.map_or_else(Vec::new, Vec::with_capacity);
     loop {
         if reader.end() {

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -230,3 +230,36 @@ fn test_units() {
     let new_bytes = a.to_bytes().unwrap();
     assert_eq!(bytes, &*new_bytes);
 }
+
+/// Issue 513
+#[test]
+fn test_zst_vec_1() {
+    #[derive(Debug, PartialEq, DekuRead)]
+    struct EmptyThing {}
+
+    #[derive(Debug, PartialEq, DekuRead)]
+    struct ListOfThings {
+        #[deku(read_all)]
+        things: Vec<EmptyThing>,
+    }
+
+    let bytes = vec![];
+    let (y, x) = ListOfThings::from_bytes((&bytes, 0)).unwrap();
+    assert_eq!(x.things.len(), 0);
+}
+/// Issue 513
+#[test]
+fn test_zst_vec_2() {
+    #[derive(Debug, PartialEq, DekuRead)]
+    struct EmptyThing {}
+
+    #[derive(Debug, PartialEq, DekuRead)]
+    struct ListOfThings {
+        #[deku(bytes_read = "1")]
+        things: Vec<EmptyThing>,
+    }
+
+    let bytes = vec![];
+    let (y, x) = ListOfThings::from_bytes((&bytes, 0)).unwrap();
+    assert_eq!(x.things.len(), 0);
+}


### PR DESCRIPTION
* Return an empty vec when instructed to read to end or certain bytes
  but the struct is a ZST
  
  NOTE: I tried to solve this using const assertions, but quickly ran into the following. I think you could fix it with unsafe? But not very sure about that solution.
```
error[E0401]: can't use generic parameters from outer item
  --> src/impls/vec.rs:73:34
   |
72 | const fn assert_not_zst<T>() {
   |                         - type parameter from outer item
73 |     const_assert!(mem::size_of::<T>() > 0);
   |                                  ^ use of generic parameter from outer item
   |
   = note: a `const` is a separate item from the item that contains it
```