### PR TITLE
Add map attribute to "list of attributes" in documentation

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -58,6 +58,7 @@ enum DekuEnum {
 | [pad_bits_after](#pad_bits_after) | field | Skip bits after reading, pad after writing
 | [cond](#cond) | field | Conditional expression for the field
 | [default](#default) | field | Provide default value. Used with [skip](#skip) or [cond](#cond)
+| [map](#map) | field | Specify a function or lambda to apply to the result of the read
 | [bits](#bits) | field | Set the bit-size of the field
 | [reader](#readerwriter) | variant, field | Custom reader code
 | [writer](#readerwriter) | variant, field | Custom writer code


### PR DESCRIPTION
The `map` attribute was missing from the "List of attributes". This commit adds it.