### PR TITLE
Fix DekuRead for #[repr(...)] enums constructed using `id` via `ctx` and whose variants assign discriminant values 

### DIFF
--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -184,7 +184,7 @@ struct DekuData {
     bit_order: Option<syn::LitStr>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ReprType {
     U8,
     U16,

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -198,6 +198,23 @@ enum ReprType {
     I128,
 }
 
+impl From<ReprType> for TokenStream {
+    fn from(value: ReprType) -> Self {
+        match value {
+            ReprType::U8 => quote! { u8 },
+            ReprType::U16 => quote! { u16 },
+            ReprType::U32 => quote! { u32 },
+            ReprType::U64 => quote! { u64 },
+            ReprType::U128 => quote! { u128 },
+            ReprType::I8 => quote! { i8 },
+            ReprType::I16 => quote! { i16 },
+            ReprType::I32 => quote! { i32 },
+            ReprType::I64 => quote! { i64 },
+            ReprType::I128 => quote! { i128 },
+        }
+    }
+}
+
 fn from_token(ts: TokenStream) -> Option<ReprType> {
     let mut repr_value = None;
 

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -254,29 +254,24 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 variant_id_pat.clone()
             }
         } else if has_discriminant {
-            match input.repr {
-                None => {
+            let Some(repr) = input.repr else {
+                return Err(syn::Error::new(
+                    variant.ident.span(),
+                    "DekuRead: `id_type` must be specified on non-unit variants",
+                ));
+            };
+            if let Some(id_type) = id_type {
+                let Some(id_type_repr) = from_token(id_type.clone()) else {
                     return Err(syn::Error::new(
                         variant.ident.span(),
-                        "DekuRead: `id_type` must be specified on non-unit variants",
+                        "DekuRead: `repr` must be specified on non-unit variants",
                     ));
-                }
-                Some(repr) => {
-                    if let Some(id_type) = id_type {
-                        if let Some(id_type_repr) = from_token(id_type.clone()) {
-                            if id_type_repr != repr {
-                                return Err(syn::Error::new(
-                                    variant.ident.span(),
-                                    "DekuRead: `repr` must match `id_type`",
-                                ));
-                            }
-                        } else {
-                            return Err(syn::Error::new(
-                                variant.ident.span(),
-                                "DekuRead: `repr` must be specified on non-unit variants",
-                            ));
-                        }
-                    }
+                };
+                if id_type_repr != repr {
+                    return Err(syn::Error::new(
+                        variant.ident.span(),
+                        "DekuRead: `repr` must match `id_type`",
+                    ));
                 }
             }
             let ident = &variant.ident;

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -254,7 +254,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 variant_id_pat.clone()
             }
         } else if has_discriminant {
-            match &input.repr {
+            match input.repr {
                 None => {
                     return Err(syn::Error::new(
                         variant.ident.span(),
@@ -264,7 +264,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 Some(repr) => {
                     if let Some(id_type) = id_type {
                         if let Some(id_type_repr) = from_token(id_type.clone()) {
-                            if id_type_repr != *repr {
+                            if id_type_repr != repr {
                                 return Err(syn::Error::new(
                                     variant.ident.span(),
                                     "DekuRead: `repr` must match `id_type`",

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -274,11 +274,12 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                     ));
                 }
             }
+            let repr_type: TokenStream = repr.into();
             let ident = &variant.ident;
             let internal_ident = gen_internal_field_ident(&quote!(#ident));
             pre_match_tokens.push(quote! {
                 // https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.access-memory
-                let #internal_ident = unsafe { *(&Self::#ident as *const Self as *const #id_type) };
+                let #internal_ident = unsafe { *(&Self::#ident as *const Self as *const #repr_type) };
             });
             quote! { _ if __deku_variant_id == #internal_ident }
         } else {

--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -278,7 +278,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             let internal_ident = gen_internal_field_ident(&quote!(#ident));
             pre_match_tokens.push(quote! {
                 // https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.access-memory
-                let #internal_ident = <#id_type>::try_from(unsafe { *(&Self::#ident as *const Self as *const #id_type) })?;
+                let #internal_ident = unsafe { *(&Self::#ident as *const Self as *const #id_type) };
             });
             quote! { _ if __deku_variant_id == #internal_ident }
         } else {

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -267,7 +267,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                 // if the variant has fields, the first must be storing the id
                 quote! {}
             } else if has_discriminant {
-                match &input.repr {
+                match input.repr {
                     None => {
                         return Err(syn::Error::new(
                             variant.ident.span(),
@@ -277,7 +277,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                     Some(repr) => {
                         if let Some(id_type) = id_type {
                             if let Some(id_type_repr) = from_token(id_type.clone()) {
-                                if id_type_repr != *repr {
+                                if id_type_repr != repr {
                                     return Err(syn::Error::new(
                                         variant.ident.span(),
                                         "DekuWrite: `repr` must match `id_type`",


### PR DESCRIPTION
I hit this case in the process of converting an NVMe-MI implementation over to using deku. The TokenStream emitted by the derive macro was broken at the point of the type conversion for the discriminant value. I got to the bottom of it with a bit of poking around via `cargo expand`.