### PR TITLE
Change arc/cow/cstring requirements from std to alloc

### DIFF
--- a/src/impls/arc.rs
+++ b/src/impls/arc.rs
@@ -1,7 +1,6 @@
-use no_std_io::io::{Read, Seek, Write};
-use std::sync::Arc;
-
+use alloc::sync::Arc;
 use alloc::vec::Vec;
+use no_std_io::io::{Read, Seek, Write};
 
 use crate::ctx::Limit;
 use crate::reader::Reader;

--- a/src/impls/cow.rs
+++ b/src/impls/cow.rs
@@ -1,4 +1,4 @@
-use std::borrow::{Borrow, Cow};
+use alloc::borrow::{Borrow, Cow};
 
 use no_std_io::io::{Read, Seek, Write};
 

--- a/src/impls/cstring.rs
+++ b/src/impls/cstring.rs
@@ -1,6 +1,8 @@
 use alloc::borrow::Cow;
+use alloc::ffi::CString;
+use alloc::format;
+use alloc::vec::Vec;
 use no_std_io::io::{Read, Seek, Write};
-use std::ffi::CString;
 
 use crate::reader::Reader;
 use crate::writer::Writer;

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -8,13 +8,13 @@ mod tuple;
 mod unit;
 mod vec;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod arc;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod cow;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod cstring;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
 `DekuReader` and `DekuWriter` can be implemented for `Arc`, `Cow` and `CString` with only `alloc` and not `std`, which would be a good thing for `no_std` environments.