### PR TITLE
deku-derive: deku_read: Use checked slice for remaining data

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -137,7 +137,10 @@ fn emit_struct(input: &DekuData) -> Result<TokenStream, syn::Error> {
             } else {
                 (__deku_reader.bits_read - (__deku_reader.bits_read % 8)) / 8
             };
-            Ok(((&__deku_input.0[idx..], __deku_reader.bits_read % 8), __deku_value))
+            let Some(rest) = __deku_input.0.get(idx..) else {
+                return Err(deku::DekuError::Incomplete(deku::prelude::NeedSize::new(8 * (idx - __deku_input.0.len()))));
+            };
+            Ok(((rest, __deku_reader.bits_read % 8), __deku_value))
         };
 
         tokens.extend(emit_try_from(&imp, &lifetime, &ident, wher));
@@ -436,7 +439,10 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             } else {
                 (__deku_reader.bits_read - (__deku_reader.bits_read % 8)) / 8
             };
-            Ok(((&__deku_input.0[idx..], __deku_reader.bits_read % 8), __deku_value))
+            let Some(rest) = __deku_input.0.get(idx..) else {
+                return Err(deku::DekuError::Incomplete(deku::prelude::NeedSize::new(8 * (idx - __deku_input.0.len()))));
+            };
+            Ok(((rest, __deku_reader.bits_read % 8), __deku_value))
         };
 
         tokens.extend(emit_try_from(&imp, &lifetime, &ident, wher));

--- a/tests/test_from_bytes.rs
+++ b/tests/test_from_bytes.rs
@@ -81,3 +81,30 @@ fn test_from_bytes_long() {
     assert_eq!(6, i);
     assert_eq!(0b0101_1010u8, rest[0]);
 }
+
+#[test]
+fn test_from_bytes_short_with_seek() {
+    #[derive(Debug, DekuRead, Eq, PartialEq)]
+    #[deku(ctx = "mid: u8", id = "mid")]
+    enum Sneaky {
+        #[deku(id = 0)]
+        Zero,
+        #[deku(id = 1)]
+        One,
+    }
+
+    #[derive(Debug, DekuRead, Eq, PartialEq)]
+    struct Seeky {
+        id: u8,
+        // Use seek to force an out-of-bounds slice for remaining data
+        #[deku(seek_from_current = "1")]
+        #[deku(ctx = "*id")]
+        body: Sneaky,
+    }
+
+    let bytes: [u8; 1] = [0x01];
+    assert_eq!(
+        Err(DekuError::Incomplete(NeedSize::new(8))),
+        Seeky::from_bytes((&bytes, 0))
+    );
+}


### PR DESCRIPTION
Protocols whose wire format splits an enum variant's discriminant from associated data may generate an out-of-bounds slice index when combined with the seek attributes and a malformed message encoding.

Use a checked operation to extract the slice of remaining data.

Without the fix, the test produces the following output:

    test test_from_bytes_short_with_seek ... FAILED

    failures:

    ---- test_from_bytes_short_with_seek stdout ----

    thread 'test_from_bytes_short_with_seek' panicked at tests/test_from_bytes.rs:95:21:
    range start index 2 out of range for slice of length 1
    stack backtrace:
       0: __rustc::rust_begin_unwind
                 at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:697:5
       1: core::panicking::panic_fmt
                 at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:75:14
       2: core::slice::index::slice_start_index_len_fail::do_panic::runtime
                 at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panic.rs:218:21
       3: core::slice::index::slice_start_index_len_fail::do_panic
                 at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/intrinsics/mod.rs:3196:9
       4: core::slice::index::slice_start_index_len_fail
                 at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panic.rs:223:9
       5: <core::ops::range::RangeFrom<usize> as core::slice::index::SliceIndex<[T]>>::index
                 at /home/andrew/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:561:13
       6: core::slice::index::<impl core::ops::index::Index<I> for [T]>::index
                 at /home/andrew/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:16:9
       7: <test_from_bytes::test_from_bytes_short_with_seek::Seeky as deku::DekuContainerRead>::from_bytes
                 at ./tests/test_from_bytes.rs:95:21
       8: test_from_bytes::test_from_bytes_short_with_seek
                 at ./tests/test_from_bytes.rs:107:9
       9: test_from_bytes::test_from_bytes_short_with_seek::{{closure}}
                 at ./tests/test_from_bytes.rs:85:37
      10: core::ops::function::FnOnce::call_once
                 at /home/andrew/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
      11: core::ops::function::FnOnce::call_once
                 at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/ops/function.rs:250:5
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.