### PR TITLE
Expose `alloc` as a selectable feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
           toolchain: nightly
           targets: thumbv7em-none-eabihf
       - run: cd ensure_no_std && cargo build --release --target thumbv7em-none-eabihf
+      - run: cd ensure_no_std && cargo build --release --target thumbv7em-none-eabihf --no-default-features
 
   ensure_wasm:
     name: Ensure wasm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,14 @@ jobs:
       - run: cargo build --all
       # test
       - run: cargo test --all
+      - run: cargo test --all-features
+      - run: cargo test --no-default-features
+      - run: cargo test --no-default-features --features=alloc
+      - run: cargo test --no-default-features --features=descriptive-errors
+      - run: cargo test --no-default-features --features=bits
+      - run: cargo test --no-default-features --features=logging
       # run examples
       - run: cargo run --example 2>&1 | grep -P '   ' | awk '{print $1}' | xargs -i cargo run --example {}
-      # test with no bits feature (don't test docs)
-      - run: cargo test --lib --examples --tests --features std --no-default-features
 
   # Only build on MSRV, since trybuild will fail on older version
   build-msrv:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Added
 
 - The `alloc` feature, allowing use in environments lacking a heap [#582](https://github.com/sharksforarms/deku/pull/582)
+- The `descriptive-errors` feature, replacing `no-assertion-string` [#582](https://github.com/sharksforarms/deku/pull/582)
 
 ## [0.19.1] - 2025-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## Added
+
+- The `alloc` feature, allowing use in environments lacking a heap [#582](https://github.com/sharksforarms/deku/pull/582)
+
 ## [0.19.1] - 2025-05-22
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 [features]
 default = ["std", "bits"]
 std = ["deku_derive/std", "bitvec?/std", "alloc", "no_std_io/std"]
-alloc = ["bitvec?/alloc"]
+alloc = ["bitvec?/alloc", "deku_derive/alloc", "no_std_io/alloc" ]
 logging = ["deku_derive/logging", "log"]
 no-assert-string = ["deku_derive/no-assert-string"]
 bits = ["dep:bitvec", "deku_derive/bits", "alloc" ]
@@ -31,7 +31,7 @@ bits = ["dep:bitvec", "deku_derive/bits", "alloc" ]
 deku_derive = { version = "^0.19.1", path = "deku-derive", default-features = false}
 bitvec = { version = "1.0.1", default-features = false, optional = true }
 log = { version = "0.4.22", optional = true }
-no_std_io = { version = "0.9.0", default-features = false, features = ["alloc"], package = "no_std_io2" }
+no_std_io = { version = "0.9.0", default-features = false, package = "no_std_io2" }
 rustversion = "1.0.17"
 
 [dev-dependencies]
@@ -48,6 +48,7 @@ log = { version = "0.4.22" }
 [[bench]]
 name = "deku"
 harness = false
+required-features = ["alloc"]
 
 [lints]
 workspace = true
@@ -63,6 +64,7 @@ required-features = ["bits"]
 
 [[example]]
 name = "deku_input"
+required-features = ["std"]
 
 [[example]]
 name = "enums_catch_all"
@@ -70,6 +72,7 @@ required-features = ["bits"]
 
 [[example]]
 name = "enums"
+required-features = ["std"]
 
 [[example]]
 name = "example"
@@ -85,6 +88,8 @@ required-features = ["bits"]
 
 [[example]]
 name = "many"
+required-features = ["std"]
 
 [[example]]
 name = "read_all"
+required-features = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ std = ["deku_derive/std", "bitvec?/std", "alloc", "no_std_io/std"]
 alloc = ["bitvec?/alloc"]
 logging = ["deku_derive/logging", "log"]
 no-assert-string = ["deku_derive/no-assert-string"]
-bits = ["dep:bitvec", "deku_derive/bits"]
+bits = ["dep:bitvec", "deku_derive/bits", "alloc" ]
 
 [dependencies]
 deku_derive = { version = "^0.19.1", path = "deku-derive", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ members = [
 ]
 
 [features]
-default = ["std", "bits"]
+default = ["std", "bits", "descriptive-errors"]
 std = ["deku_derive/std", "bitvec?/std", "alloc", "no_std_io/std"]
 alloc = ["bitvec?/alloc", "deku_derive/alloc", "no_std_io/alloc" ]
 logging = ["deku_derive/logging", "log"]
-no-assert-string = ["deku_derive/no-assert-string"]
 bits = ["dep:bitvec", "deku_derive/bits", "alloc" ]
+descriptive-errors = ["alloc"]
 
 [dependencies]
 deku_derive = { version = "^0.19.1", path = "deku-derive", default-features = false}

--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -132,6 +132,7 @@ pub fn read_all_vs_count_vs_read_exact(c: &mut Criterion) {
 
     #[derive(DekuRead, DekuWrite)]
     #[deku(ctx = "len: usize")]
+    #[expect(dead_code)]
     pub struct CountFromCtxWrapper {
         #[deku(count = "len")]
         pub data: Vec<u8>,

--- a/benches/deku.rs
+++ b/benches/deku.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Seek};
+use no_std_io::io::{Cursor, Read, Seek};
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use deku::prelude::*;

--- a/deku-derive/Cargo.toml
+++ b/deku-derive/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro = true
 std = ["proc-macro-crate", "alloc"]
 alloc = []
 logging = []
-no-assert-string = []
 bits = []
 
 [dependencies]

--- a/deku-derive/Cargo.toml
+++ b/deku-derive/Cargo.toml
@@ -13,7 +13,8 @@ rust-version = "1.81"
 proc-macro = true
 
 [features]
-std = ["proc-macro-crate"]
+std = ["proc-macro-crate", "alloc"]
+alloc = []
 logging = []
 no-assert-string = []
 bits = []

--- a/deku-derive/src/lib.rs
+++ b/deku-derive/src/lib.rs
@@ -21,6 +21,36 @@ use crate::macros::deku_write::emit_deku_write;
 
 mod macros;
 
+// Pad attribute values are not bounded by the implementation, however, for
+// implementation purposes we need a concrete object to contain padding data.
+// To allow use of padding in constrained environments we define the object as
+// an array (by contrast to a vec). PAD_ARRAY_SIZE controls the length of
+// these arrays.
+//
+// The length of the padding array is chosen with the following considerations:
+//
+// - A loop is necessary to avoid arbitrarily picking an upper-bound for
+//   requested padding values
+//
+// - Given the loop there aren't any strong constraints on the size of the
+//   padding array
+//
+// - My estimate is padding requests tend to be in the range of 1-16 bytes.
+//   From a [brief inspection][github-search-pad-bytes] it seems that estimate
+//   is reasonable
+//
+// - We desire a value large enough to cover common cases and avoid unnecessary
+//   loop trips, but small enough not to cause trouble on the stack (for
+//   instance, requesting a page of zeros feels unreasonable)
+//
+// - Try to pick something that only requires 1 execution of the loop body for
+//   common cases.
+//
+// [github-search-pad-bytes]:
+//   https://github.com/search?q=pad_bytes_before+OR+pad_bytes_after&type=code
+#[cfg(not(feature = "bits"))]
+const PAD_ARRAY_SIZE: usize = 64;
+
 #[derive(Debug)]
 enum Id {
     TokenStream(TokenStream),

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -417,13 +417,6 @@ fn assertion_failed(
     } else {
         quote! { stringify!(#v) }
     };
-    #[cfg(feature = "no-assert-string")]
-    {
-        quote! {
-            return Err(::#crate_::DekuError::AssertionNoStr);
-        }
-    }
-    #[cfg(not(feature = "no-assert-string"))]
     {
         quote! {
             return Err(::#crate_::deku_error!(::#crate_::DekuError::Assertion, "Field failed assertion", "{}.{}: {}", #ident, #field_ident_str, #stringify));

--- a/deku-derive/src/macros/mod.rs
+++ b/deku-derive/src/macros/mod.rs
@@ -4,7 +4,9 @@ use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::Comma;
-use syn::{Lifetime, LitStr};
+use syn::Lifetime;
+#[cfg(feature = "bits")]
+use syn::LitStr;
 
 use crate::Num;
 
@@ -424,15 +426,7 @@ fn assertion_failed(
     #[cfg(not(feature = "no-assert-string"))]
     {
         quote! {
-            extern crate alloc;
-            use alloc::borrow::Cow;
-            use alloc::format;
-            return Err(::#crate_::DekuError::Assertion(Cow::from(format!(
-                "{}.{} field failed assertion: {}",
-                #ident,
-                #field_ident_str,
-                #stringify,
-            ))));
+            return Err(::#crate_::deku_error!(::#crate_::DekuError::Assertion, "Field failed assertion", "{}.{}: {}", #ident, #field_ident_str, #stringify));
         }
     }
 }

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -22,11 +22,11 @@ name = "ensure_no_std"
 path = "src/main.rs"
 
 [features]
-default = ["alloc"]
+default = ["alloc", "deku/alloc", "deku/bits" ]
 alloc = []
 
 [dependencies]
 cortex-m-rt = "0.7.3"
-deku = { path = "../", default-features = false, features = ["alloc", "bits"] }
+deku = { path = "../", default-features = false }
 embedded-alloc = "0.6.0"
 

--- a/ensure_no_std/src/lib.rs
+++ b/ensure_no_std/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 pub mod no_alloc_imports;
+#[cfg(feature = "alloc")]
 pub mod with_alloc_imports;

--- a/ensure_no_std/src/main.rs
+++ b/ensure_no_std/src/main.rs
@@ -2,23 +2,22 @@
 #![no_std]
 #![no_main]
 
-extern crate alloc;
-
 use no_std_lib::*;
 
 use core::panic::PanicInfo;
 
 use cortex_m_rt::entry;
-use embedded_alloc::LlffHeap as Heap;
-
-#[global_allocator]
-static HEAP: Heap = Heap::empty();
 
 #[entry]
 fn main() -> ! {
     // Initialize the allocator BEFORE you use it
+    #[cfg(feature = "alloc")]
     {
+        use embedded_alloc::LlffHeap as Heap;
         use core::mem::MaybeUninit;
+
+        #[global_allocator]
+        static HEAP: Heap = Heap::empty();
         const HEAP_SIZE: usize = 1024;
         static HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
         unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
@@ -27,6 +26,7 @@ fn main() -> ! {
     // now the allocator is ready types like Box, Vec can be used.
 
     no_alloc_imports::rw();
+    #[cfg(feature = "alloc")]
     with_alloc_imports::rw();
 
     loop { /* .. */ }

--- a/ensure_no_std/src/no_alloc_imports.rs
+++ b/ensure_no_std/src/no_alloc_imports.rs
@@ -2,29 +2,27 @@ use deku::prelude::*;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
-    #[deku(bits = 5)]
     field_a: u8,
-    #[deku(bits = 3)]
     field_b: u8,
     count: u8,
 }
 
 pub fn rw() {
     #[allow(clippy::unusual_byte_groupings)]
-    let test_data: &[u8] = &[0b10101_101, 0x02];
-    let mut cursor = deku::no_std_io::Cursor::new(test_data);
+    let test_data: &[u8] = &[0xaa, 0xb0, 0x02];
 
     // Test reading
-    let (_rest, val) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
+    let (_rest, val) = DekuTest::from_bytes((test_data, 0)).unwrap();
     assert_eq!(
         DekuTest {
-            field_a: 0b10101,
-            field_b: 0b101,
+            field_a: 0xaa,
+            field_b: 0xb0,
             count: 0x02,
         },
         val
     );
 
     // Test writing
-    let _val = val.to_bytes().unwrap();
+    let mut buf = [0; 20];
+    let _val = val.to_slice(&mut buf).unwrap();
 }

--- a/examples/80211.rs
+++ b/examples/80211.rs
@@ -1,7 +1,7 @@
 use deku::ctx::Order;
 use deku::prelude::*;
 
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 #[derive(Debug, DekuRead, DekuWrite, PartialEq)]
 #[deku(id_type = "u8", bits = "2")]

--- a/examples/custom_reader_and_writer.rs
+++ b/examples/custom_reader_and_writer.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 use deku::ctx::BitSize;
 use deku::writer::Writer;

--- a/examples/custom_reader_and_writer.rs
+++ b/examples/custom_reader_and_writer.rs
@@ -3,9 +3,9 @@ use core::convert::TryInto;
 use deku::ctx::BitSize;
 use deku::writer::Writer;
 use deku::{prelude::*, DekuWriter};
-use no_std_io::io::{Seek, Write};
+use no_std_io::io::{Cursor, Read, Seek, Write};
 
-fn bit_flipper_read<R: std::io::Read + std::io::Seek>(
+fn bit_flipper_read<R: Read + Seek>(
     field_a: u8,
     reader: &mut Reader<R>,
     bit_size: BitSize,
@@ -59,7 +59,7 @@ struct DekuTest {
 
 fn main() {
     let test_data = [0x01, 0b1001_0110];
-    let mut cursor = std::io::Cursor::new(test_data);
+    let mut cursor = Cursor::new(test_data);
 
     let (_read_amt, ret_read) = DekuTest::from_reader((&mut cursor, 0)).unwrap();
 

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use no_std_io::io::Cursor;
 
 use deku::{prelude::*, reader::Reader};
 use hexlit::hex;

--- a/examples/enums_catch_all.rs
+++ b/examples/enums_catch_all.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 use hexlit::hex;

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -5,7 +5,7 @@
 
 #![allow(clippy::unusual_byte_groupings)]
 
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/examples/ipv4.rs
+++ b/examples/ipv4.rs
@@ -50,7 +50,7 @@ pub struct Ipv4Header {
 fn main() {
     let test_data = hex!("4500004b0f490000801163a591fea0ed91fd02cb").to_vec();
 
-    let mut cursor = std::io::Cursor::new(test_data.clone());
+    let mut cursor = no_std_io::io::Cursor::new(test_data.clone());
     let mut reader = deku::reader::Reader::new(&mut cursor);
     let ip_header = Ipv4Header::from_reader_with_ctx(&mut reader, ()).unwrap();
 

--- a/examples/ipv4.rs
+++ b/examples/ipv4.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use core::net::Ipv4Addr;
 
 use deku::prelude::*;
 use hexlit::hex;

--- a/examples/read_all.rs
+++ b/examples/read_all.rs
@@ -1,5 +1,5 @@
+use core::convert::{TryFrom, TryInto};
 use deku::prelude::*;
-use std::convert::{TryFrom, TryInto};
 
 fn main() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -672,12 +672,12 @@ let data: &[u8] = &[0x00, 0x01, 0x02];
 
 let value = DekuTest::try_from(data);
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "descriptive-errors")]
 assert_eq!(
     Err(DekuError::Assertion("Field failed assertion: DekuTest.data: * data >= 8".into())),
     value
 );
-#[cfg(not(feature = "alloc"))]
+#[cfg(not(feature = "descriptive-errors"))]
 assert_eq!(
     Err(DekuError::Assertion("Field failed assertion".into())),
     value
@@ -717,10 +717,16 @@ value.data = 0x02;
 
 let value: Result<Vec<u8>, DekuError> = value.try_into();
 
+# #[cfg(feature = "descriptive-errors")]
 assert_eq!(
     Err(DekuError::Assertion("Field failed assertion: DekuTest.data: data == 0x01".into())),
     value
 );
+# #[cfg(not(feature = "descriptive-errors"))]
+# assert_eq!(
+#    Err(DekuError::Assertion("Field failed assertion".into())),
+#    value
+# );
 # }
 #
 # #[cfg(not(feature = "alloc"))]

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -80,8 +80,8 @@ Precedence: field > top-level > system endianness (default)
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # use std::io::Cursor;
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 // #[deku(endian = "little")] // top-level, defaults to system endianness
@@ -112,8 +112,8 @@ assert_eq!(data, &*value);
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")] // context passed from `DekuTest` top-level endian
 struct Child {
@@ -153,8 +153,8 @@ assert_eq!(&*data, value);
 Specify the field or containers bit order. By default all bits are read in `Msb0` (Most significant bit) order.
 ### Top-Level Example
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, DekuRead, DekuWrite, PartialEq)]
 #[deku(bit_order = "lsb")]
 pub struct SquashfsV3 {
@@ -192,8 +192,8 @@ assert_eq!(
 ```
 With endian-ness:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, DekuRead, DekuWrite, PartialEq)]
 #[deku(endian = "big", bit_order = "lsb")]
 pub struct BigEndian {
@@ -216,8 +216,8 @@ assert_eq!(bytes, data);
 ````
 ### Field Example
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, DekuRead, DekuWrite, PartialEq)]
 pub struct LsbField {
     #[deku(bit_order = "lsb", bits = "13")]
@@ -240,8 +240,8 @@ that type's data when writing.
 
 Example (top-level):
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(magic = b"deku")]
 struct DekuTest {
@@ -263,8 +263,8 @@ assert_eq!(data, value);
 
 Example (field):
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(magic = b"deku")]
@@ -291,9 +291,9 @@ Using the internal reader, seek to current position plus offset before reading f
 Field Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     // how many following bytes to skip
@@ -319,9 +319,9 @@ assert_eq!(bytes, data);
 Top-Level Example (with ctx usage):
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(seek_from_current = "skip", ctx = "skip: usize")]
 struct DekuTest {
@@ -353,9 +353,9 @@ Using the internal reader, seek to size of reader plus offset before reading fie
 Field Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(seek_from_end = "-2")]
@@ -384,9 +384,9 @@ assert_eq!(buf, data);
 Top-Level Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(seek_from_end = "-2")]
 struct DekuTest {
@@ -419,9 +419,9 @@ Using the internal reader, seek from reader start plus offset before reading fie
 Field Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(seek_from_start = "2")]
@@ -450,9 +450,9 @@ assert_eq!(buf, data);
 Top-Level Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(seek_from_start = "2")]
 struct DekuTest {
@@ -485,9 +485,9 @@ Rewind the internal reader to starting position.
 Field Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     byte_01: u8,
@@ -511,9 +511,9 @@ assert_eq!(bytes, data);
 Top-Level Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(seek_rewind)]
 struct DekuTest {
@@ -540,8 +540,8 @@ Assert a condition after reading and before writing a field
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(assert = "*data >= 8")]
@@ -564,8 +564,8 @@ Assert equals after reading and before writing a field
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(assert_eq = "0x01")]
@@ -599,8 +599,8 @@ Set the bit-size of the field
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(bits = 2)]
@@ -631,8 +631,8 @@ This attribute can also be set from a previous read:
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
     field_a_len: u8,
@@ -668,8 +668,8 @@ Set the byte-size of the field
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(bytes = 2)]
@@ -697,8 +697,8 @@ This attribute can also be set from a previous read:
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
     field_a_size: u8,
@@ -728,8 +728,8 @@ Specify the field representing the length of the container, i.e. a Vec
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(update = "self.items.len()")]
@@ -766,8 +766,8 @@ Specify the field representing the total number of bytes to read into a containe
 See the following example, where `InnerDekuTest` is 2 bytes, so setting `bytes_read` to
 4 will read 2 items into the container:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct InnerDekuTest {
     field_a: u8,
@@ -821,8 +821,8 @@ as to whether this should be the last item or not. If it returns true, then read
 
 A good example of this is to read a null-terminated string:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # use std::ffi::CString;
 # #[derive(Debug, PartialEq, DekuRead)]
 struct DekuTest {
@@ -847,8 +847,8 @@ Read values into the container until [reader.end()] returns `true`.
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct InnerDekuTest {
     field_a: u8,
@@ -884,8 +884,8 @@ Specify custom code to run on the field when `.update()` is called on the struct
 
 Example:
 ```rust
+use core::convert::{TryInto, TryFrom};
 use deku::prelude::*;
-use std::convert::{TryInto, TryFrom};
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(update = "self.items.len()")]
@@ -931,8 +931,8 @@ struct/enum needs to be modified at compile time.
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[deku_derive(DekuRead, DekuWrite)]
 #[derive(Debug, PartialEq)]
 struct DekuTest {
@@ -971,8 +971,8 @@ struct/enum needs to be modified at compile time.
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[deku_derive(DekuRead, DekuWrite)]
 #[derive(Debug, PartialEq)]
 struct DekuTest {
@@ -1001,8 +1001,8 @@ Defaults value to [default](#default)
 Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     field_a: u8,
@@ -1028,8 +1028,8 @@ Skip a number of bytes before reading, pad with 0x00s before writing
 Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 pub struct DekuTest {
     pub field_a: u8,
@@ -1060,8 +1060,8 @@ Skip a number of bytes before reading, pad with 0s before writing
 Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(bits = 2)]
@@ -1093,8 +1093,8 @@ Skip a number of bytes after reading, pad with 0x00s after writing
 Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 pub struct DekuTest {
     #[deku(pad_bytes_after = "2")]
@@ -1125,8 +1125,8 @@ Skip a number of bytes after reading, pad with 0s after writing
 Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     #[deku(bits = 2, pad_bits_after = "2")]
@@ -1160,8 +1160,8 @@ Specify a condition to parse or skip a field
 Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     field_a: u8,
@@ -1197,8 +1197,8 @@ Defaults to `Default::default()`
 Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     field_a: u8,
@@ -1226,8 +1226,8 @@ Example:
 Read a `u8` and apply a function to convert it to a `String`.
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead)]
 struct DekuTest {
     #[deku(map = "|field: u8| -> Result<_, DekuError> { Ok(field.to_string()) }")]
@@ -1258,7 +1258,7 @@ Specify custom reader or writer tokens for reading a field or variant
 
 Example:
 ```rust
-use std::convert::{TryInto, TryFrom};
+use core::convert::{TryInto, TryFrom};
 use deku::bitvec::{BitSlice, BitVec, Msb0};
 use deku::prelude::*;
 
@@ -1432,8 +1432,8 @@ This is useful in cases when the enum `id` is already consumed or is given exter
 Example:
 
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 struct DekuTest {
     my_id: u8,
@@ -1478,9 +1478,9 @@ or [id (top-level)](#id-top-level)
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u8")]
 enum DekuTest {
@@ -1516,9 +1516,9 @@ assert_eq!(vec![0x02, 0xAB, 0xEF, 0xBE], variant_bytes);
 
 Example discriminant
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[repr(u8)]
 #[deku(id_type = "u8")]
@@ -1557,8 +1557,8 @@ Specify the endianness of the variant `id`, without mandating the same endiannes
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u16", id_endian = "big", endian = "little")]
 enum DekuTest {
@@ -1605,9 +1605,9 @@ The writing of the field will use the same options as the reading.
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u8")]
 enum DekuTest {
@@ -1657,9 +1657,9 @@ Set the bit size of the enum variant `id`
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
 # use std::io::Cursor;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u8", bits = 4)]
 enum DekuTest {
@@ -1689,8 +1689,8 @@ Set the byte size of the enum variant `id`
 
 Example:
 ```rust
+# use core::convert::{TryInto, TryFrom};
 # use deku::prelude::*;
-# use std::convert::{TryInto, TryFrom};
 # #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u32", bytes = 2)]
 enum DekuTest {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Error module
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "descriptive-errors")]
 use alloc::borrow::Cow;
 
 use no_std_io::io::ErrorKind;
@@ -31,10 +31,10 @@ impl NeedSize {
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "descriptive-errors")]
 type DekuErrorString = Cow<'static, str>;
 
-#[cfg(not(feature = "alloc"))]
+#[cfg(not(feature = "descriptive-errors"))]
 type DekuErrorString = &'static str;
 
 /// Deku errors
@@ -49,8 +49,6 @@ pub enum DekuError {
     InvalidParam(DekuErrorString),
     /// Assertion error from `assert` or `assert_eq` attributes
     Assertion(DekuErrorString),
-    /// Assertion error from `assert` or `assert_eq` attributes, without string
-    AssertionNoStr,
     /// Could not resolve `id` for variant
     IdVariantNotFound,
     /// IO error while reading or writing
@@ -76,7 +74,7 @@ pub enum DekuError {
 ///                     bit_size,
 ///                     input_size);
 /// ```
-#[cfg(feature = "alloc")]
+#[cfg(feature = "descriptive-errors")]
 #[macro_export]
 macro_rules! deku_error {
     ($p:path, $desc:expr, $fmt:expr, $($arg:expr),*) => {{
@@ -112,7 +110,7 @@ macro_rules! deku_error {
 ///                     bit_size,
 ///                     input_size);
 /// ```
-#[cfg(not(feature = "alloc"))]
+#[cfg(not(feature = "descriptive-errors"))]
 #[macro_export]
 macro_rules! deku_error {
     ($p:path, $desc:expr, $fmt:expr, $($arg:expr),*) => {{
@@ -158,8 +156,7 @@ impl core::fmt::Display for DekuError {
             ),
             DekuError::Parse(ref err) => write!(f, "Parse error: {err}"),
             DekuError::InvalidParam(ref err) => write!(f, "Invalid param error: {err}"),
-            DekuError::Assertion(ref err) => write!(f, "Assertion error: {err}"),
-            DekuError::AssertionNoStr => write!(f, "Assertion error"),
+            DekuError::Assertion(ref err) => write!(f, "{err}"),
             DekuError::IdVariantNotFound => write!(f, "Could not resolve `id` for variant"),
             DekuError::Io(ref e) => write!(f, "io errorr: {e:?}"),
         }
@@ -211,7 +208,6 @@ impl From<DekuError> for std::io::Error {
             DekuError::Parse(_) => io::Error::new(io::ErrorKind::InvalidData, error),
             DekuError::InvalidParam(_) => io::Error::new(io::ErrorKind::InvalidInput, error),
             DekuError::Assertion(_) => io::Error::new(io::ErrorKind::InvalidData, error),
-            DekuError::AssertionNoStr => io::Error::from(io::ErrorKind::InvalidData),
             DekuError::IdVariantNotFound => io::Error::new(io::ErrorKind::NotFound, error),
             DekuError::Io(e) => io::Error::new(e, error),
         }

--- a/src/impls/arc.rs
+++ b/src/impls/arc.rs
@@ -74,11 +74,14 @@ where
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::vec;
     use no_std_io::io::Cursor;
     use rstest::rstest;
 
     use super::*;
-    use crate::ctx::*;
+    #[cfg(feature = "bits")]
+    use crate::ctx::{BitSize, Endian};
     use crate::native_endian;
     use crate::reader::Reader;
     #[cfg(feature = "bits")]

--- a/src/impls/boxed.rs
+++ b/src/impls/boxed.rs
@@ -72,9 +72,11 @@ where
     }
 }
 
+#[cfg(all(feature = "alloc", feature = "bits"))]
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use no_std_io::io::Cursor;
     use rstest::rstest;
 
@@ -82,7 +84,6 @@ mod tests {
     use crate::ctx::*;
     use crate::native_endian;
     use crate::reader::Reader;
-    #[cfg(feature = "bits")]
     use bitvec::prelude::*;
 
     #[rstest(input, expected,
@@ -103,7 +104,6 @@ mod tests {
     }
 
     // Note: Copied tests from vec.rs impl
-    #[cfg(feature = "bits")]
     #[rstest(input, endian, bit_size, limit, expected, expected_rest_bits, expected_rest_bytes, expected_write,
         case::normal_le([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Little, Some(16), 2.into(), vec![0xBBAA, 0xDDCC].into_boxed_slice(), bits![u8, Msb0;], &[], vec![0xAA, 0xBB, 0xCC, 0xDD]),
         case::normal_be([0xAA, 0xBB, 0xCC, 0xDD].as_ref(), Endian::Big, Some(16), 2.into(), vec![0xAABB, 0xCCDD].into_boxed_slice(), bits![u8, Msb0;], &[], vec![0xAA, 0xBB, 0xCC, 0xDD]),

--- a/src/impls/cow.rs
+++ b/src/impls/cow.rs
@@ -37,12 +37,15 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::vec;
     use no_std_io::io::Cursor;
     use rstest::rstest;
 
     use super::*;
     use crate::{native_endian, reader::Reader};
 
+    #[cfg(feature = "alloc")]
     #[rstest(input, expected,
         case(
             &[0xEF, 0xBE],

--- a/src/impls/cstring.rs
+++ b/src/impls/cstring.rs
@@ -1,6 +1,5 @@
-use alloc::borrow::Cow;
 use alloc::ffi::CString;
-use alloc::format;
+
 use alloc::vec::Vec;
 use no_std_io::io::{Read, Seek, Write};
 
@@ -32,7 +31,12 @@ impl DekuReader<'_> for CString {
             Vec::<u8>::from_reader_with_ctx(reader, (Limit::from(|b: &u8| *b == 0x00), ()))?;
 
         let value = CString::from_vec_with_nul(bytes).map_err(|e| {
-            DekuError::Parse(Cow::from(format!("Failed to convert Vec to CString: {e}")))
+            crate::deku_error!(
+                DekuError::Parse,
+                "Failed to convert Vec to CString",
+                "{}",
+                e
+            )
         })?;
 
         Ok(value)
@@ -50,7 +54,12 @@ where
         let bytes = Vec::from_reader_with_ctx(reader, (Limit::from(byte_size.0), ()))?;
 
         let value = CString::from_vec_with_nul(bytes).map_err(|e| {
-            DekuError::Parse(Cow::from(format!("Failed to convert Vec to CString: {e}")))
+            crate::deku_error!(
+                DekuError::Parse,
+                "Failed to convert Vec to CString",
+                "{}",
+                e
+            )
         })?;
 
         Ok(value)
@@ -95,7 +104,7 @@ mod tests {
             b"a",
         ),
 
-        #[should_panic(expected = "Parse(\"Failed to convert Vec to CString: data provided is not nul terminated\")")]
+        #[should_panic(expected = "Failed to convert Vec to CString")]
         case(
             b"test",
             Some(4),

--- a/src/impls/cstring.rs
+++ b/src/impls/cstring.rs
@@ -59,6 +59,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::vec;
     use no_std_io::io::Cursor;
     use rstest::rstest;
 
@@ -66,6 +68,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "alloc")]
     #[rstest(input, len, expected, expected_rest,
         case(
             b"test\0",

--- a/src/impls/hashmap.rs
+++ b/src/impls/hashmap.rs
@@ -82,8 +82,13 @@ where
     /// ```rust
     /// # use deku::ctx::*;
     /// # use deku::DekuReader;
+    /// # #[cfg(feature = "std")]
     /// # use std::collections::HashMap;
+    /// # #[cfg(feature = "std")]
     /// # use std::io::Cursor;
+    ///
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
     /// let mut input = Cursor::new(vec![100, 1, 2, 3, 4]);
     /// let mut reader = deku::reader::Reader::new(&mut input);
     /// let map =
@@ -91,6 +96,10 @@ where
     /// let mut expected = HashMap::<u8, u32>::default();
     /// expected.insert(100, 0x04030201);
     /// assert_eq!(expected, map)
+    /// # }
+    ///
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
     /// ```
     fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut crate::reader::Reader<R>,
@@ -198,9 +207,15 @@ impl<K: DekuWriter<Ctx>, V: DekuWriter<Ctx>, S, Ctx: Copy> DekuWriter<Ctx> for H
     /// ```rust
     /// # use deku::{ctx::Endian, DekuWriter};
     /// # use deku::writer::Writer;
+    /// # #[cfg(feature = "bits")]
     /// # use deku::bitvec::{Msb0, bitvec};
+    /// # #[cfg(feature = "std")]
     /// # use std::collections::HashMap;
+    /// # #[cfg(feature = "std")]
     /// # use std::io::Cursor;
+    ///
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
     /// let mut out_buf = vec![];
     /// let mut cursor = Cursor::new(&mut out_buf);
     /// let mut writer = Writer::new(&mut cursor);
@@ -209,6 +224,10 @@ impl<K: DekuWriter<Ctx>, V: DekuWriter<Ctx>, S, Ctx: Copy> DekuWriter<Ctx> for H
     /// map.to_writer(&mut writer, Endian::Big).unwrap();
     /// let expected: Vec<u8> = vec![100, 4, 3, 2, 1];
     /// assert_eq!(expected, out_buf);
+    /// # }
+    ///
+    /// # #[cfg(not(feature = "std"))]
+    /// fn main() {}
     /// ```
     fn to_writer<W: Write + Seek>(
         &self,
@@ -228,6 +247,7 @@ mod tests {
     use rstest::rstest;
     use rustc_hash::FxHashMap;
 
+    #[cfg(feature = "bits")]
     use crate::reader::Reader;
 
     use super::*;

--- a/src/impls/hashmap.rs
+++ b/src/impls/hashmap.rs
@@ -1,5 +1,5 @@
+use core::hash::{BuildHasher, Hash};
 use std::collections::HashMap;
-use std::hash::{BuildHasher, Hash};
 
 use no_std_io::io::{Read, Seek, Write};
 

--- a/src/impls/hashset.rs
+++ b/src/impls/hashset.rs
@@ -188,6 +188,7 @@ impl<T: DekuWriter<Ctx>, S, Ctx: Copy> DekuWriter<Ctx> for HashSet<T, S> {
     /// ```rust
     /// # use deku::{ctx::Endian, DekuWriter};
     /// # use deku::writer::Writer;
+    /// # #[cfg(feature = "bits")]
     /// # use deku::bitvec::{Msb0, bitvec};
     /// # use std::collections::HashSet;
     /// # use std::io::Cursor;
@@ -219,6 +220,7 @@ mod tests {
     use rstest::rstest;
     use rustc_hash::FxHashSet;
 
+    #[cfg(feature = "bits")]
     use crate::reader::Reader;
 
     use super::*;

--- a/src/impls/hashset.rs
+++ b/src/impls/hashset.rs
@@ -1,5 +1,5 @@
+use core::hash::{BuildHasher, Hash};
 use std::collections::HashSet;
-use std::hash::{BuildHasher, Hash};
 
 use crate::writer::Writer;
 use no_std_io::io::{Read, Seek, Write};

--- a/src/impls/ipaddr.rs
+++ b/src/impls/ipaddr.rs
@@ -77,8 +77,10 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
     use no_std_io::io::Cursor;
     use rstest::rstest;
 

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -6,6 +6,8 @@ mod primitive;
 mod slice;
 mod tuple;
 mod unit;
+
+#[cfg(feature = "alloc")]
 mod vec;
 
 #[cfg(feature = "alloc")]

--- a/src/impls/nonzero.rs
+++ b/src/impls/nonzero.rs
@@ -1,14 +1,10 @@
-#[cfg(feature = "alloc")]
-use alloc::borrow::Cow;
-#[cfg(feature = "alloc")]
-use alloc::format;
 use core::num::*;
 use no_std_io::io::{Read, Seek, Write};
 
 use crate::ctx::*;
 use crate::reader::Reader;
 use crate::writer::Writer;
-use crate::{DekuError, DekuReader, DekuWriter};
+use crate::{deku_error, DekuError, DekuReader, DekuWriter};
 
 macro_rules! ImplDekuTraitsCtx {
     ($typ:ty, $readtype:ty, $ctx_arg:tt, $ctx_type:tt) => {
@@ -21,7 +17,7 @@ macro_rules! ImplDekuTraitsCtx {
                 let value = <$typ>::new(value);
 
                 match value {
-                    None => Err(DekuError::Parse(Cow::from(format!("NonZero assertion")))),
+                    None => Err(deku_error!(DekuError::Parse, "NonZero assertion")),
                     Some(v) => Ok(v),
                 }
             }
@@ -76,6 +72,7 @@ ImplDekuTraits!(NonZeroI64, i64);
 ImplDekuTraits!(NonZeroI128, i128);
 ImplDekuTraits!(NonZeroIsize, isize);
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -40,10 +40,11 @@ mod tests {
         assert_eq!(v, Some(0x04030201))
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_option_write() {
-        let mut writer = Writer::new(Cursor::new(vec![]));
+        let mut writer = Writer::new(Cursor::new(alloc::vec![]));
         Some(true).to_writer(&mut writer, ()).unwrap();
-        assert_eq!(vec![1], writer.inner.into_inner());
+        assert_eq!(alloc::vec![1], writer.inner.into_inner());
     }
 }

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -1,6 +1,3 @@
-use alloc::borrow::Cow;
-#[cfg(feature = "alloc")]
-use alloc::format;
 use core::convert::TryInto;
 
 #[cfg(feature = "bits")]
@@ -10,7 +7,7 @@ use no_std_io::io::{Read, Seek, Write};
 use crate::ctx::*;
 use crate::reader::{Reader, ReaderRet};
 use crate::writer::Writer;
-use crate::{DekuError, DekuReader, DekuWriter};
+use crate::{deku_error, DekuError, DekuReader, DekuWriter};
 
 /// "Read" trait: read bits and construct type
 #[cfg(feature = "bits")]
@@ -54,7 +51,7 @@ impl DekuReader<'_, (Endian, ByteSize, Order)> for u8 {
     #[inline(always)]
     fn from_reader_with_ctx<R: Read + Seek>(
         reader: &mut Reader<R>,
-        (endian, size, order): (Endian, ByteSize, Order),
+        (_endian, _size, order): (Endian, ByteSize, Order),
     ) -> Result<u8, DekuError> {
         const MAX_TYPE_BYTES: usize = core::mem::size_of::<u8>();
         let mut buf = [0; MAX_TYPE_BYTES];
@@ -64,9 +61,9 @@ impl DekuReader<'_, (Endian, ByteSize, Order)> for u8 {
             #[cfg(feature = "bits")]
             ReaderRet::Bits(bits) => {
                 let Some(bits) = bits else {
-                    return Err(DekuError::Parse(Cow::from("no bits read from reader")));
+                    return Err(deku_error!(DekuError::Parse, "no bits read from reader"));
                 };
-                let a = <u8>::read(&bits, (endian, size))?;
+                let a = <u8>::read(&bits, (_endian, _size))?;
                 a.1
             }
         };
@@ -104,11 +101,13 @@ impl DekuWriter<(Endian, BitSize, Order)> for u8 {
         let input_bits = input.view_bits::<Msb0>();
 
         if bit_size > input_bits.len() {
-            return Err(DekuError::InvalidParam(Cow::from(format!(
-                "bit size {} is larger than input {}",
+            return Err(deku_error!(
+                DekuError::InvalidParam,
+                "Bit size is larger than input",
+                "{} exceeds {}",
                 bit_size,
                 input_bits.len()
-            ))));
+            ));
         }
 
         // Check for extra bits before sending into writer
@@ -116,11 +115,13 @@ impl DekuWriter<(Endian, BitSize, Order)> for u8 {
         if let Some(first) = input_bits.first_one() {
             let max = MAX_TYPE_BITS - bit_size;
             if max > first {
-                return Err(DekuError::InvalidParam(Cow::from(format!(
-                    "bit size {} of input is larger than bit requested size {}",
+                return Err(deku_error!(
+                    DekuError::InvalidParam,
+                    "bit size of input is larger than bit requested size",
+                    "{} exceeds {}",
                     MAX_TYPE_BITS - first,
-                    bit_size,
-                ))));
+                    bit_size
+                ));
             }
         }
         writer.write_bits_order(&input_bits[input_bits.len() - bit_size..], order)?;
@@ -363,14 +364,17 @@ macro_rules! ImplDekuReadBits {
             ) -> Result<$typ, DekuError> {
                 const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 if size.0 > MAX_TYPE_BITS {
-                    return Err(DekuError::Parse(Cow::from(format!(
-                        "too much data: container of {MAX_TYPE_BITS} bits cannot hold {} bits",
+                    return Err(deku_error!(
+                        DekuError::Parse,
+                        "too much data",
+                        "container of {} bits cannot hold {} bits",
+                        MAX_TYPE_BITS,
                         size.0
-                    ))));
+                    ));
                 }
                 let bits = reader.read_bits(size.0, Order::default())?;
                 let Some(bits) = bits else {
-                    return Err(DekuError::Parse(Cow::from("no bits read from reader")));
+                    return Err(deku_error!(DekuError::Parse, "no bits read from reader"));
                 };
                 let a = <$typ>::read(&bits, (endian, size))?;
                 Ok(a.1)
@@ -386,16 +390,17 @@ macro_rules! ImplDekuReadBits {
             ) -> Result<$typ, DekuError> {
                 const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 if size.0 > MAX_TYPE_BITS {
-                    return Err(DekuError::Parse(Cow::from(format!(
-                        "too much data: container of {MAX_TYPE_BITS} bits cannot hold {} bits",
+                    return Err(deku_error!(
+                        DekuError::Parse,
+                        "too much data",
+                        "container of {} cannot hold {} bits",
+                        MAX_TYPE_BITS,
                         size.0
-                    ))));
+                    ));
                 }
                 let bits = reader.read_bits(size.0, order)?;
                 let Some(bits) = bits else {
-                    return Err(DekuError::Parse(Cow::from(format!(
-                        "no bits read from reader",
-                    ))));
+                    return Err(deku_error!(DekuError::Parse, "no bits read from reader"));
                 };
                 let a = <$typ>::read(&bits, (endian, size, order))?;
                 Ok(a.1)
@@ -442,10 +447,13 @@ macro_rules! ImplDekuReadBytes {
             ) -> Result<$typ, DekuError> {
                 const MAX_TYPE_BYTES: usize = core::mem::size_of::<$typ>();
                 if size.0 > MAX_TYPE_BYTES {
-                    return Err(DekuError::Parse(Cow::from(format!(
-                        "too much data: container of {MAX_TYPE_BYTES} bytes cannot hold {} bytes",
+                    return Err(deku_error!(
+                        DekuError::Parse,
+                        "too much data",
+                        "container of {} bytes cannot hold {} bytes",
+                        MAX_TYPE_BYTES,
                         size.0
-                    ))));
+                    ));
                 }
                 let mut buf = [0; MAX_TYPE_BYTES];
                 let ret = reader.read_bytes(size.0, &mut buf, order)?;
@@ -469,7 +477,7 @@ macro_rules! ImplDekuReadBytes {
                     }
                     #[cfg(feature = "bits")]
                     ReaderRet::Bits(None) => {
-                        return Err(DekuError::Parse(Cow::from("no bits read from reader")));
+                        return Err(deku_error!(DekuError::Parse, "no bits read from reader"));
                     }
                 };
                 Ok(a)
@@ -571,14 +579,17 @@ macro_rules! ImplDekuReadSignExtend {
             ) -> Result<$typ, DekuError> {
                 const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                 if size.0 > MAX_TYPE_BITS {
-                    return Err(DekuError::Parse(Cow::from(format!(
-                        "too much data: container of {MAX_TYPE_BITS} bits cannot hold {} bits",
+                    return Err(deku_error!(
+                        DekuError::Parse,
+                        "too much data",
+                        "container of {} bits cannot hold {} bits",
+                        MAX_TYPE_BITS,
                         size.0
-                    ))));
+                    ));
                 }
                 let bits = reader.read_bits(size.0, order)?;
                 let Some(bits) = bits else {
-                    return Err(DekuError::Parse(Cow::from("no bits read from reader")));
+                    return Err(deku_error!(DekuError::Parse, "no bits read from reader"));
                 };
                 let a = <$typ>::read(&bits, (endian, size, order))?;
                 Ok(a.1)
@@ -593,10 +604,13 @@ macro_rules! ImplDekuReadSignExtend {
             ) -> Result<$typ, DekuError> {
                 const MAX_TYPE_BYTES: usize = core::mem::size_of::<$typ>();
                 if size.0 > MAX_TYPE_BYTES {
-                    return Err(DekuError::Parse(Cow::from(format!(
-                        "too much data: container of {MAX_TYPE_BYTES} bytes cannot hold {} bytes",
+                    return Err(deku_error!(
+                        DekuError::Parse,
+                        "too much data",
+                        "container of {} bytes cannot hold {} bytes",
+                        MAX_TYPE_BYTES,
                         size.0
-                    ))));
+                    ));
                 }
                 let mut buf = [0; MAX_TYPE_BYTES];
                 let ret = reader.read_bytes(size.0, &mut buf, order)?;
@@ -620,7 +634,7 @@ macro_rules! ImplDekuReadSignExtend {
                     }
                     #[cfg(feature = "bits")]
                     ReaderRet::Bits(None) => {
-                        return Err(DekuError::Parse(Cow::from("no bits read from reader")));
+                        return Err(deku_error!(DekuError::Parse, "no bits read from reader"));
                     }
                 };
                 Ok(a)
@@ -678,7 +692,7 @@ macro_rules! ForwardDekuRead {
                     }
                     #[cfg(feature = "bits")]
                     ReaderRet::Bits(None) => {
-                        return Err(DekuError::Parse(Cow::from("no bits read from reader")));
+                        return Err(deku_error!(DekuError::Parse, "no bits read from reader"));
                     }
                 };
                 Ok(a)
@@ -777,11 +791,13 @@ macro_rules! ImplDekuWrite {
                 let input_bits = input.view_bits::<Msb0>();
 
                 if bit_size > input_bits.len() {
-                    return Err(DekuError::InvalidParam(Cow::from(format!(
-                        "bit size {} is larger then input {}",
+                    return Err(deku_error!(
+                        DekuError::InvalidParam,
+                        "bit size is larger than input",
+                        "{} exceeds {}",
                         bit_size,
                         input_bits.len()
-                    ))));
+                    ));
                 }
 
                 match (endian, order) {
@@ -833,10 +849,13 @@ macro_rules! ImplDekuWrite {
 
                 const TYPE_SIZE: usize = core::mem::size_of::<$typ>();
                 if size.0 > TYPE_SIZE {
-                    return Err(DekuError::InvalidParam(Cow::from(format!(
-                        "byte size {} is larger then input {}",
-                        size.0, TYPE_SIZE
-                    ))));
+                    return Err(deku_error!(
+                        DekuError::InvalidParam,
+                        "byte size is larger than input",
+                        "{} exceeds {}",
+                        size.0,
+                        TYPE_SIZE
+                    ));
                 }
 
                 let input = if matches!(endian, Endian::Big) {
@@ -884,11 +903,13 @@ macro_rules! ImplDekuWriteDetails {
                 let input_bits = input.view_bits::<Msb0>();
 
                 if bit_size > input_bits.len() {
-                    return Err(DekuError::InvalidParam(Cow::from(format!(
-                        "bit size {} is larger than input {}",
+                    return Err(deku_error!(
+                        DekuError::InvalidParam,
+                        "bit size is larger than input",
+                        "{} exceeds {}",
                         bit_size,
                         input_bits.len()
-                    ))));
+                    ));
                 }
 
                 if matches!(endian, Endian::Little) {
@@ -899,9 +920,13 @@ macro_rules! ImplDekuWriteDetails {
                         let last = last + 1;
                         let max = bit_size;
                         if last > max {
-                            return Err(DekuError::InvalidParam(Cow::from(format!(
-                                "bit size {last} of input is larger than bit requested size {bit_size}",
-                            ))));
+                            return Err(deku_error!(
+                                DekuError::InvalidParam,
+                                "bit size of input is larger than requested size",
+                                "{} exceeds {}",
+                                last,
+                                bit_size
+                            ));
                         }
                     }
 
@@ -923,11 +948,13 @@ macro_rules! ImplDekuWriteDetails {
                     if let Some(first) = input_bits.first_one() {
                         let max = (MAX_TYPE_BITS - bit_size);
                         if max > first {
-                            return Err(DekuError::InvalidParam(Cow::from(format!(
-                                "bit size {} of input is larger than bit requested size {}",
+                            return Err(deku_error!(
+                                DekuError::InvalidParam,
+                                "bit size of input is larger than bit requested size",
+                                "{} exceeds {}",
                                 MAX_TYPE_BITS - first,
-                                bit_size,
-                            ))));
+                                bit_size
+                            ));
                         }
                     }
                     // Example read 10 bits u32 [0xAB, 0b11_000000]
@@ -957,37 +984,46 @@ macro_rules! ImplDekuWriteDetails {
                 let input_bits = input.view_bits::<Msb0>();
 
                 if bit_size > input_bits.len() {
-                    return Err(DekuError::InvalidParam(Cow::from(format!(
-                        "bit size {} is larger than input {}",
+                    return Err(deku_error!(
+                        DekuError::InvalidParam,
+                        "bit size is larger than input",
+                        "{} exceeds {}",
                         bit_size,
                         input_bits.len()
-                    ))));
+                    ));
                 }
 
                 if matches!(endian, Endian::Little) {
                     // Check if this is a value that will fit inside the required bits, if
                     // not, throw an error
-                    if *self>=0 {
+                    if *self >= 0 {
                         let input_bits_lsb = input.view_bits::<Lsb0>();
                         if let Some(last) = input_bits_lsb.last_one() {
                             let last = last + 2;
                             let max = bit_size;
                             if last > max {
-                                return Err(DekuError::InvalidParam(Cow::from(format!(
-                                    "bit size {last} of input is larger than bit requested size {bit_size}",
-                                ))));
+                                return Err(deku_error!(
+                                    DekuError::InvalidParam,
+                                    "bit size of input is larger than bit requested size",
+                                    "{} exceeds {}",
+                                    last,
+                                    bit_size
+                                ));
                             }
                         }
-                    }
-                    else {
+                    } else {
                         let input_bits_lsb = input.view_bits::<Lsb0>();
                         if let Some(last) = input_bits_lsb.last_zero() {
                             let last = last + 2;
                             let max = bit_size;
                             if last > max {
-                                return Err(DekuError::InvalidParam(Cow::from(format!(
-                                    "bit size {last} of input is larger than bit requested size {bit_size}",
-                                ))));
+                                return Err(deku_error!(
+                                    DekuError::InvalidParam,
+                                    "bit size of input is larger than requested bit size",
+                                    "{} exceeds {}",
+                                    last,
+                                    bit_size
+                                ));
                             }
                         }
                     }
@@ -1007,27 +1043,30 @@ macro_rules! ImplDekuWriteDetails {
                 } else {
                     const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
                     // Check for extra bits before sending into writer
-                    if *self>=0 {
+                    if *self >= 0 {
                         if let Some(first) = input_bits.first_one() {
                             let max = (MAX_TYPE_BITS - bit_size);
-                            if max+1 > first {
-                                return Err(DekuError::InvalidParam(Cow::from(format!(
-                                    "bit size {} of input is larger than bit requested size {}",
+                            if max + 1 > first {
+                                return Err(deku_error!(
+                                    DekuError::InvalidParam,
+                                    "bit size of input is larger than bit requested size",
+                                    "{} exceeds {}",
                                     MAX_TYPE_BITS - first,
-                                    bit_size,
-                                ))));
+                                    bit_size
+                                ));
                             }
                         }
-                    }
-                    else {
+                    } else {
                         if let Some(first) = input_bits.first_zero() {
                             let max = (MAX_TYPE_BITS - bit_size);
-                            if max+1 > first {
-                                return Err(DekuError::InvalidParam(Cow::from(format!(
-                                    "bit size {} of input is larger than bit requested size {}",
+                            if max + 1 > first {
+                                return Err(deku_error!(
+                                    DekuError::InvalidParam,
+                                    "bit size of input is larger than bit requested size",
+                                    "{} exceeds {}",
                                     MAX_TYPE_BITS - first,
-                                    bit_size,
-                                ))));
+                                    bit_size
+                                ));
                             }
                         }
                     }
@@ -1196,6 +1235,7 @@ ImplDekuTraitsBytesUnsigned!(f32, u32);
 ImplDekuTraitsUnsigned!(f64, u64);
 ImplDekuTraitsBytesUnsigned!(f64, u64);
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -1389,9 +1429,9 @@ mod tests {
         case::normal_le(0xDDCC_BBAA, Endian::Little, None, vec![0xAA, 0xBB, 0xCC, 0xDD], vec![]),
         case::normal_be(0xDDCC_BBAA, Endian::Big, None, vec![0xDD, 0xCC, 0xBB, 0xAA], vec![]),
         case::bit_size_be_smaller(0x03AB, Endian::Big, Some(10), vec![0b11_1010_10], vec![true, true]),
-        #[should_panic(expected = "InvalidParam(\"bit size 100 is larger than input 32\")")]
+        #[should_panic(expected = "InvalidParam(\"bit size is larger than input: 100 exceeds 32\")")]
         case::bit_size_le_bigger(0x03AB, Endian::Little, Some(100), vec![0xAB, 0b11_000000], vec![true, true]),
-        #[should_panic(expected = "InvalidParam(\"bit size 10 of input is larger than bit requested size 5\")")]
+        #[should_panic(expected = "InvalidParam(\"bit size of input is larger than requested size: 10 exceeds 5\")")]
         case::bit_size_larger(0x03AB, Endian::Little, Some(5), vec![], vec![]),
     )]
     fn test_bit_writer(
@@ -1416,7 +1456,7 @@ mod tests {
         case::normal_le(0xDDCC_BBAA, Endian::Little, None, vec![0xAA, 0xBB, 0xCC, 0xDD]),
         case::normal_be(0xDDCC_BBAA, Endian::Big, None, vec![0xDD, 0xCC, 0xBB, 0xAA]),
         case::byte_size_be_smaller(0x00FFABAA, Endian::Big, Some(2), vec![0xab, 0xaa]),
-        #[should_panic(expected = "InvalidParam(\"byte size 10 is larger then input 4\")")]
+        #[should_panic(expected = "InvalidParam(\"byte size is larger than input: 10 exceeds 4\")")]
         case::byte_size_le_bigger(0x03AB, Endian::Little, Some(10), vec![0xAB, 0b11_000000]),
     )]
     fn test_byte_writer(input: u32, endian: Endian, byte_size: Option<usize>, expected: Vec<u8>) {
@@ -1461,6 +1501,7 @@ mod tests {
         assert_hex::assert_eq_hex!(expected_write, writer.inner.into_inner());
     }
 
+    #[cfg(feature = "bits")]
     macro_rules! TestSignExtending {
         ($test_name:ident, $typ:ty) => {
             #[test]
@@ -1489,6 +1530,7 @@ mod tests {
     #[cfg(feature = "bits")]
     TestSignExtending!(test_sign_extend_isize, isize);
 
+    #[cfg(feature = "bits")]
     macro_rules! TestSignExtendingPanic {
         ($test_name:ident, $typ:ty, $size:expr) => {
             #[test]
@@ -1499,11 +1541,13 @@ mod tests {
                 let res_read =
                     <$typ>::from_reader_with_ctx(&mut reader, (Endian::Little, BitSize($size + 1)));
                 assert_eq!(
-                    DekuError::Parse(Cow::from(format!(
-                        "too much data: container of {} bits cannot hold {} bits",
+                    deku_error!(
+                        DekuError::Parse,
+                        "too much data",
+                        "container of {} bits cannot hold {} bits",
                         $size,
                         $size + 1
-                    ))),
+                    ),
                     res_read.err().unwrap()
                 );
             }

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -93,13 +93,16 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use super::*;
     use rstest::rstest;
     use std::io::Cursor;
 
-    use crate::{ctx::Endian, reader::Reader, writer::Writer, DekuReader};
+    use crate::{ctx::Endian, writer::Writer};
+    #[cfg(feature = "bits")]
+    use crate::{reader::Reader, DekuReader};
 
     #[cfg(feature = "bits")]
     #[rstest(input,endian,expected,

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -81,6 +81,7 @@ ImplDekuTupleTraits! { A, B, C, D, E, F, G, H, I, }
 ImplDekuTupleTraits! { A, B, C, D, E, F, G, H, I, J, }
 ImplDekuTupleTraits! { A, B, C, D, E, F, G, H, I, J, K, }
 
+#[cfg(all(feature = "alloc", feature = "std"))]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/src/impls/unit.rs
+++ b/src/impls/unit.rs
@@ -22,6 +22,7 @@ impl<Ctx: Copy> DekuWriter<Ctx> for () {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use crate::reader::Reader;

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -2,7 +2,6 @@ use core::mem;
 
 use no_std_io::io::{Read, Seek, Write};
 
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 use crate::reader::Reader;
@@ -179,14 +178,23 @@ impl<T: DekuWriter<Ctx>, Ctx: Copy> DekuWriter<Ctx> for Vec<T> {
     /// ```rust
     /// # use deku::{ctx::Endian, DekuWriter};
     /// # use deku::writer::Writer;
+    /// # #[cfg(feature = "bits")]
     /// # use deku::bitvec::{Msb0, bitvec};
+    /// # #[cfg(feature = "std")]
     /// # use std::io::Cursor;
+    ///
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
     /// let data = vec![1u8];
     /// let mut out_buf = vec![];
     /// let mut cursor = Cursor::new(&mut out_buf);
     /// let mut writer = Writer::new(&mut cursor);
     /// data.to_writer(&mut writer, Endian::Big).unwrap();
     /// assert_eq!(data, out_buf.to_vec());
+    /// # }
+    ///
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
     /// ```
     fn to_writer<W: Write + Seek>(
         &self,
@@ -200,6 +208,7 @@ impl<T: DekuWriter<Ctx>, Ctx: Copy> DekuWriter<Ctx> for Vec<T> {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 mod tests {
@@ -208,6 +217,7 @@ mod tests {
     use rstest::rstest;
     use std::io::Cursor;
 
+    #[cfg(feature = "bits")]
     use crate::reader::Reader;
 
     use super::*;
@@ -291,6 +301,7 @@ mod tests {
         assert_eq!(expected_rest_bytes, buf);
     }
 
+    #[cfg(feature = "alloc")]
     #[rstest(input, endian, expected,
         case::normal(vec![0xAABB, 0xCCDD], Endian::Little, vec![0xBB, 0xAA, 0xDD, 0xCC]),
     )]

--- a/src/noseek.rs
+++ b/src/noseek.rs
@@ -1,8 +1,5 @@
 //! Wrapper type that provides a fake [`Seek`] implementation.
 
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 use crate::no_std_io::{Read, Result, Seek, SeekFrom, Write};
 
 /// A wrapper that provides a limited implementation of
@@ -74,6 +71,7 @@ impl<T: Read> Read for NoSeek<T> {
         Ok(n)
     }
 
+    #[cfg(feature = "std")]
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
         let n = self.inner.read_to_end(buf)?;
         self.pos += n as u64;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,9 @@
 
 [What is a prelude?](std::prelude)
 */
-pub use crate::error::{DekuError, NeedSize};
+pub use crate::error::DekuError;
+
+pub use crate::error::NeedSize;
 pub use crate::{
     deku_derive, reader::Reader, writer::Writer, DekuContainerRead, DekuContainerWrite,
     DekuEnumExt, DekuRead, DekuReader, DekuUpdate, DekuWrite, DekuWriter,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -9,12 +9,12 @@ use no_std_io::io::{Seek, SeekFrom, Write};
 #[cfg(feature = "logging")]
 use log;
 
+#[cfg(feature = "bits")]
 use crate::ctx::Order;
+
 use crate::DekuError;
 
-#[cfg(feature = "alloc")]
-use alloc::borrow::ToOwned;
-
+#[cfg(feature = "bits")]
 const fn bits_of<T>() -> usize {
     core::mem::size_of::<T>().saturating_mul(<u8>::BITS as usize)
 }
@@ -71,6 +71,8 @@ impl<W: Write + Seek> Writer<W> {
         bits: &BitSlice<u8, Msb0>,
         order: Order,
     ) -> Result<(), DekuError> {
+        use alloc::borrow::ToOwned;
+
         #[cfg(feature = "logging")]
         log::trace!("attempting {} bits : {}", bits.len(), bits);
 
@@ -287,6 +289,7 @@ impl<W: Write + Seek> Writer<W> {
     }
 }
 
+#[cfg(all(feature = "std", feature = "bits"))]
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
@@ -295,7 +298,6 @@ mod tests {
     use hexlit::hex;
 
     #[test]
-    #[cfg(feature = "bits")]
     fn test_writer_bits() {
         let mut out_buf = Cursor::new(vec![]);
         let mut writer = Writer::new(&mut out_buf);
@@ -335,7 +337,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "bits")]
     fn test_writer_bytes() {
         let mut out_buf = Cursor::new(vec![]);
         let mut writer = Writer::new(&mut out_buf);
@@ -347,7 +348,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "bits")]
     fn test_bit_order() {
         let mut out_buf = Cursor::new(vec![]);
         let mut writer = Writer::new(&mut out_buf);

--- a/tests/bit_order.rs
+++ b/tests/bit_order.rs
@@ -4,7 +4,7 @@ mod tests {
     use deku::ctx::{BitSize, Order};
     use deku::prelude::*;
 
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
     use std::io::{Read, Seek, Write};
 
     #[derive(Debug, DekuRead, DekuWrite, PartialEq)]

--- a/tests/bit_order.rs
+++ b/tests/bit_order.rs
@@ -5,7 +5,7 @@ mod tests {
     use deku::prelude::*;
 
     use core::convert::TryFrom;
-    use std::io::{Read, Seek, Write};
+    use no_std_io::io::{Read, Seek, Write};
 
     #[derive(Debug, DekuRead, DekuWrite, PartialEq)]
     #[deku(id_type = "u8", bits = "2")]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -2,5 +2,4 @@
 
 mod test_attributes;
 mod test_compile;
-#[cfg(feature = "bits")]
 mod test_to_bits;

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -25,6 +25,7 @@ enum NestedEnum {
 #[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(id_type = "u32", bytes = 2, ctx = "_endian: Endian")]
+#[expect(dead_code)]
 enum NestedEnum2 {
     #[deku(id = "0x01")]
     VarA(u8),

--- a/tests/test_alloc.rs
+++ b/tests/test_alloc.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "bits")]
+
 use alloc_counter::AllocCounterSystem;
 use deku::ctx::Endian;
 use deku::prelude::*;
@@ -7,14 +9,12 @@ use deku::prelude::*;
 #[global_allocator]
 static A: AllocCounterSystem = AllocCounterSystem;
 
-#[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(ctx = "_endian: Endian")]
 struct NestedStruct {
     field_a: u8,
 }
 
-#[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(id_type = "u8", ctx = "_endian: Endian")]
 enum NestedEnum {
@@ -22,7 +22,6 @@ enum NestedEnum {
     VarA(u8),
 }
 
-#[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(id_type = "u32", bytes = 2, ctx = "_endian: Endian")]
 #[expect(dead_code)]
@@ -31,7 +30,6 @@ enum NestedEnum2 {
     VarA(u8),
 }
 
-#[cfg(feature = "bits")]
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(endian = "big")]
 struct TestDeku {
@@ -49,18 +47,19 @@ struct TestDeku {
                  //field_i: NestedEnum2,
 }
 
-#[cfg(feature = "bits")]
 mod tests {
     use alloc_counter::count_alloc;
     use hexlit::hex;
 
     use super::*;
 
+    use no_std_io::io::Cursor;
+
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_simple() {
         let input = hex!("aa_bbbb_cc_0102_dd_ffffff_aa_0100ff");
-        let mut cursor = std::io::Cursor::new(input);
+        let mut cursor = Cursor::new(input);
 
         assert_eq!(
             count_alloc(|| {
@@ -75,7 +74,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_simple_write() {
         let input = hex!("aa_bbbb_cc_0102_dd_ffffff_aa_0100ff");
-        let mut cursor = std::io::Cursor::new(input);
+        let mut cursor = Cursor::new(input);
         let t = TestDeku::from_reader((&mut cursor, 0)).unwrap().1;
 
         assert_eq!(
@@ -91,7 +90,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_to_slice() {
         let input = hex!("aa_bbbb_cc_0102_dd_ffffff_aa_0100ff");
-        let mut cursor = std::io::Cursor::new(input);
+        let mut cursor = Cursor::new(input);
         let t = TestDeku::from_reader((&mut cursor, 0)).unwrap().1;
 
         let mut out = [0x00; 100];

--- a/tests/test_attributes/mod.rs
+++ b/tests/test_attributes/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 mod test_assert;
 mod test_assert_eq;
 #[cfg(feature = "bits")]

--- a/tests/test_attributes/test_assert.rs
+++ b/tests/test_attributes/test_assert.rs
@@ -17,7 +17,7 @@ struct TestStruct {
         field_b: 0x02,
     }),
 
-    #[should_panic(expected = r#"Assertion("TestStruct.field_b field failed assertion: * field_a + * field_b >= 3")"#)]
+    #[should_panic(expected = r#"Assertion("Field failed assertion: TestStruct.field_b: * field_a + * field_b >= 3")"#)]
     case(&hex!("0101"), TestStruct::default())
 )]
 fn test_assert_read(input: &[u8], expected: TestStruct) {
@@ -31,7 +31,7 @@ fn test_assert_read(input: &[u8], expected: TestStruct) {
         field_b: 0x02,
     }, hex!("0102").to_vec()),
 
-    #[should_panic(expected = r#"Assertion("TestStruct.field_b field failed assertion: * field_a + * field_b >= 3")"#)]
+    #[should_panic(expected = r#"Assertion("Field failed assertion: TestStruct.field_b: * field_a + * field_b >= 3")"#)]
     case(TestStruct {
         field_a: 0x01,
         field_b: 0x01,

--- a/tests/test_attributes/test_assert.rs
+++ b/tests/test_attributes/test_assert.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 use hexlit::hex;

--- a/tests/test_attributes/test_assert_eq.rs
+++ b/tests/test_attributes/test_assert_eq.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 use hexlit::hex;

--- a/tests/test_attributes/test_assert_eq.rs
+++ b/tests/test_attributes/test_assert_eq.rs
@@ -17,7 +17,7 @@ struct TestStruct {
         field_b: 0x01,
     }),
 
-    #[should_panic(expected = r#"Assertion("TestStruct.field_b field failed assertion: field_b == * field_a")"#)]
+    #[should_panic(expected = r#"Assertion("Field failed assertion: TestStruct.field_b: field_b == * field_a")"#)]
     case(&hex!("0102"), TestStruct::default())
 )]
 fn test_assert_eq_read(input: &[u8], expected: TestStruct) {
@@ -31,7 +31,7 @@ fn test_assert_eq_read(input: &[u8], expected: TestStruct) {
         field_b: 0x01,
     }, hex!("0101").to_vec()),
 
-    #[should_panic(expected = r#"Assertion("TestStruct.field_b field failed assertion: field_b == * field_a")"#)]
+    #[should_panic(expected = r#"Assertion("Field failed assertion: TestStruct.field_b: field_b == * field_a")"#)]
     case(TestStruct {
         field_a: 0x01,
         field_b: 0x02,

--- a/tests/test_attributes/test_cond.rs
+++ b/tests/test_attributes/test_cond.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_ctx.rs
+++ b/tests/test_attributes/test_ctx.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 use std::io::Cursor;
 
 use deku::prelude::*;

--- a/tests/test_attributes/test_limits/test_bits_read.rs
+++ b/tests/test_attributes/test_limits/test_bits_read.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 use rstest::rstest;

--- a/tests/test_attributes/test_limits/test_bytes_read.rs
+++ b/tests/test_attributes/test_limits/test_bytes_read.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 use rstest::rstest;

--- a/tests/test_attributes/test_limits/test_count.rs
+++ b/tests/test_attributes/test_limits/test_count.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_limits/test_read_all.rs
+++ b/tests/test_attributes/test_limits/test_read_all.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_limits/test_until.rs
+++ b/tests/test_attributes/test_limits/test_until.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_map.rs
+++ b/tests/test_attributes/test_map.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_map.rs
+++ b/tests/test_attributes/test_map.rs
@@ -1,6 +1,6 @@
 use core::convert::TryFrom;
 
-use deku::prelude::*;
+use deku::{prelude::*, DekuError};
 
 #[test]
 fn test_map() {

--- a/tests/test_attributes/test_padding/mod.rs
+++ b/tests/test_attributes/test_padding/mod.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_padding/mod.rs
+++ b/tests/test_attributes/test_padding/mod.rs
@@ -1,7 +1,3 @@
-use core::convert::{TryFrom, TryInto};
-
-use deku::prelude::*;
-
 #[cfg(feature = "bits")]
 mod test_pad_bits_after;
 #[cfg(feature = "bits")]
@@ -10,55 +6,60 @@ mod test_pad_bytes_after;
 mod test_pad_bytes_before;
 
 #[cfg(feature = "bits")]
-#[test]
-#[allow(clippy::identity_op)]
-fn test_pad_bits_before_and_pad_bytes_before() {
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    struct TestStruct {
-        #[deku(bits = 2)]
-        field_a: u8,
-        #[deku(pad_bits_before = "5 + 1", pad_bytes_before = "0 + 1")]
-        field_b: u8,
+#[cfg(test)]
+mod test {
+    use core::convert::{TryFrom, TryInto};
+
+    use deku::prelude::*;
+    #[test]
+    #[allow(clippy::identity_op)]
+    fn test_pad_bits_before_and_pad_bytes_before() {
+        #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+        struct TestStruct {
+            #[deku(bits = 2)]
+            field_a: u8,
+            #[deku(pad_bits_before = "5 + 1", pad_bytes_before = "0 + 1")]
+            field_b: u8,
+        }
+
+        let data: Vec<u8> = vec![0b10_000000, 0xaa, 0xbb];
+
+        let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
+
+        assert_eq!(
+            TestStruct {
+                field_a: 0b10,
+                field_b: 0xbb,
+            },
+            ret_read
+        );
+
+        let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+        assert_eq!(vec![0b10_000000, 0x00, 0xbb], ret_write);
     }
 
-    let data: Vec<u8> = vec![0b10_000000, 0xaa, 0xbb];
+    #[test]
+    fn test_pad_bits_after_and_pad_bytes_after() {
+        #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
+        struct TestStruct {
+            #[deku(bits = 2, pad_bits_after = "6", pad_bytes_after = "1")]
+            field_a: u8,
+            field_b: u8,
+        }
 
-    let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
+        let data: Vec<u8> = vec![0b10_000000, 0xaa, 0xbb];
 
-    assert_eq!(
-        TestStruct {
-            field_a: 0b10,
-            field_b: 0xbb,
-        },
-        ret_read
-    );
+        let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
 
-    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(vec![0b10_000000, 0x00, 0xbb], ret_write);
-}
+        assert_eq!(
+            TestStruct {
+                field_a: 0b10,
+                field_b: 0xbb,
+            },
+            ret_read
+        );
 
-#[cfg(feature = "bits")]
-#[test]
-fn test_pad_bits_after_and_pad_bytes_after() {
-    #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
-    struct TestStruct {
-        #[deku(bits = 2, pad_bits_after = "6", pad_bytes_after = "1")]
-        field_a: u8,
-        field_b: u8,
+        let ret_write: Vec<u8> = ret_read.try_into().unwrap();
+        assert_eq!(vec![0b10_000000, 0x00, 0xbb], ret_write);
     }
-
-    let data: Vec<u8> = vec![0b10_000000, 0xaa, 0xbb];
-
-    let ret_read = TestStruct::try_from(data.as_slice()).unwrap();
-
-    assert_eq!(
-        TestStruct {
-            field_a: 0b10,
-            field_b: 0xbb,
-        },
-        ret_read
-    );
-
-    let ret_write: Vec<u8> = ret_read.try_into().unwrap();
-    assert_eq!(vec![0b10_000000, 0x00, 0xbb], ret_write);
 }

--- a/tests/test_attributes/test_padding/test_pad_bits_after.rs
+++ b/tests/test_attributes/test_padding/test_pad_bits_after.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_padding/test_pad_bits_after.rs
+++ b/tests/test_attributes/test_padding/test_pad_bits_after.rs
@@ -45,9 +45,7 @@ fn test_pad_bits_after_not_enough() {
 }
 
 #[test]
-#[should_panic(
-    expected = r#"InvalidParam("Invalid padding param \"(- 1)\": cannot convert to usize")"#
-)]
+#[should_panic(expected = r#"InvalidParam("Invalid padding param, cannot convert to usize: - 1")"#)]
 fn test_pad_bits_after_read_err() {
     #[derive(PartialEq, Debug, DekuRead)]
     struct TestStruct {
@@ -63,9 +61,7 @@ fn test_pad_bits_after_read_err() {
 }
 
 #[test]
-#[should_panic(
-    expected = r#"InvalidParam("Invalid padding param \"(- 1)\": cannot convert to usize")"#
-)]
+#[should_panic(expected = r#"InvalidParam("Invalid padding param, cannot convert to usize: - 1")"#)]
 fn test_pad_bits_after_write_err() {
     #[derive(PartialEq, Debug, DekuWrite)]
     struct TestStruct {

--- a/tests/test_attributes/test_padding/test_pad_bits_before.rs
+++ b/tests/test_attributes/test_padding/test_pad_bits_before.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_padding/test_pad_bits_before.rs
+++ b/tests/test_attributes/test_padding/test_pad_bits_before.rs
@@ -45,9 +45,7 @@ fn test_pad_bits_before_not_enough() {
 }
 
 #[test]
-#[should_panic(
-    expected = r#"InvalidParam("Invalid padding param \"(- 1)\": cannot convert to usize")"#
-)]
+#[should_panic(expected = r#"InvalidParam("Invalid padding param, cannot convert to usize: - 1")"#)]
 fn test_pad_bits_before_read_err() {
     #[derive(PartialEq, Debug, DekuRead)]
     struct TestStruct {
@@ -63,9 +61,7 @@ fn test_pad_bits_before_read_err() {
 }
 
 #[test]
-#[should_panic(
-    expected = r#"InvalidParam("Invalid padding param \"(- 1)\": cannot convert to usize")"#
-)]
+#[should_panic(expected = r#"InvalidParam("Invalid padding param, cannot convert to usize: - 1")"#)]
 fn test_pad_bits_before_write_err() {
     #[derive(PartialEq, Debug, DekuWrite)]
     struct TestStruct {

--- a/tests/test_attributes/test_padding/test_pad_bytes_after.rs
+++ b/tests/test_attributes/test_padding/test_pad_bytes_after.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_padding/test_pad_bytes_after.rs
+++ b/tests/test_attributes/test_padding/test_pad_bytes_after.rs
@@ -46,7 +46,7 @@ fn test_pad_bytes_after_not_enough() {
 #[cfg(feature = "bits")]
 #[test]
 #[should_panic(
-    expected = r#"InvalidParam("Invalid padding param \"(((- 2) * 8))\": cannot convert to usize")"#
+    expected = r#"InvalidParam("Invalid padding param, cannot convert to usize: ((- 2) * 8)")"#
 )]
 fn test_pad_bytes_after_read_err() {
     #[derive(PartialEq, Debug, DekuRead)]
@@ -65,7 +65,7 @@ fn test_pad_bytes_after_read_err() {
 #[cfg(feature = "bits")]
 #[test]
 #[should_panic(
-    expected = r#"InvalidParam("Invalid padding param \"(((- 2) * 8))\": cannot convert to usize")"#
+    expected = r#"InvalidParam("Invalid padding param, cannot convert to usize: ((- 2) * 8)")"#
 )]
 fn test_pad_bytes_after_write_err() {
     #[derive(PartialEq, Debug, DekuWrite)]

--- a/tests/test_attributes/test_padding/test_pad_bytes_before.rs
+++ b/tests/test_attributes/test_padding/test_pad_bytes_before.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_padding/test_pad_bytes_before.rs
+++ b/tests/test_attributes/test_padding/test_pad_bytes_before.rs
@@ -46,7 +46,7 @@ fn test_pad_bytes_before_not_enough() {
 #[cfg(feature = "bits")]
 #[test]
 #[should_panic(
-    expected = r#"InvalidParam("Invalid padding param \"(((- 2) * 8))\": cannot convert to usize")"#
+    expected = r#"InvalidParam("Invalid padding param, cannot convert to usize: ((- 2) * 8)")"#
 )]
 fn test_pad_bytes_before_read_err() {
     #[derive(PartialEq, Debug, DekuRead)]
@@ -65,7 +65,7 @@ fn test_pad_bytes_before_read_err() {
 #[cfg(feature = "bits")]
 #[test]
 #[should_panic(
-    expected = r#"InvalidParam("Invalid padding param \"(((- 2) * 8))\": cannot convert to usize")"#
+    expected = r#"InvalidParam("Invalid padding param, cannot convert to usize: ((- 2) * 8)")"#
 )]
 fn test_pad_bytes_before_write_err() {
     #[derive(PartialEq, Debug, DekuWrite)]

--- a/tests/test_attributes/test_skip.rs
+++ b/tests/test_attributes/test_skip.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_temp.rs
+++ b/tests/test_attributes/test_temp.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_attributes/test_temp.rs
+++ b/tests/test_attributes/test_temp.rs
@@ -3,6 +3,7 @@ use core::convert::{TryFrom, TryInto};
 use deku::prelude::*;
 
 #[test]
+#[cfg(feature = "alloc")]
 fn test_temp_field_write() {
     #[deku_derive(DekuRead, DekuWrite)]
     #[derive(PartialEq, Debug)]
@@ -23,6 +24,7 @@ fn test_temp_field_write() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 fn test_temp_field_value_ignore_on_read() {
     #[deku_derive(DekuRead, DekuWrite)]
     #[derive(PartialEq, Debug)]
@@ -45,6 +47,7 @@ fn test_temp_field_value_ignore_on_read() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 fn test_temp_field() {
     #[deku_derive(DekuRead, DekuWrite)]
     #[derive(PartialEq, Debug)]
@@ -70,6 +73,7 @@ fn test_temp_field() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 fn test_temp_field_unnamed() {
     #[deku_derive(DekuRead, DekuWrite)]
     #[derive(PartialEq, Debug)]
@@ -85,6 +89,7 @@ fn test_temp_field_unnamed() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 fn test_temp_field_unnamed_write() {
     #[deku_derive(DekuRead, DekuWrite)]
     #[derive(PartialEq, Debug)]
@@ -101,6 +106,7 @@ fn test_temp_field_unnamed_write() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 fn test_temp_enum_field() {
     #[deku_derive(DekuRead, DekuWrite)]
     #[derive(PartialEq, Debug)]
@@ -130,6 +136,7 @@ fn test_temp_enum_field() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 fn test_temp_enum_field_write() {
     #[deku_derive(DekuRead, DekuWrite)]
     #[derive(PartialEq, Debug)]

--- a/tests/test_attributes/test_update.rs
+++ b/tests/test_attributes/test_update.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_bit_container_size.rs
+++ b/tests/test_bit_container_size.rs
@@ -18,19 +18,19 @@ struct Test {
 
 #[rstest(input,
     #[should_panic(
-        expected = "InvalidParam(\"bit size of input is larger than bit requested size: 5 exceeds 4\")"
+        expected = "bit size of input is larger than bit requested size"
     )]
     case::field_u8_be( Test { field_u8_be: 0b11111, ..Test::default()}),
     #[should_panic(
-        expected = "InvalidParam(\"bit size of input is larger than bit requested size: 5 exceeds 4\")"
+        expected = "bit size of input is larger than bit requested size"
     )]
     case::field_be( Test { field_be: 0b11111, ..Test::default()}),
     #[should_panic(
-        expected = "InvalidParam(\"bit size of input is larger than requested size: 13 exceeds 12\")"
+        expected = "bit size of input is larger than requested size"
     )]
     case::field_le( Test { field_le: 0b1111111111111, ..Test::default()}),
     #[should_panic(
-        expected = "InvalidParam(\"bit size of input is larger than bit requested size: 13 exceeds 9\")"
+        expected = "bit size of input is larger than bit requested size"
     )]
     case::field_u32_be( Test { field_u32_be: 0b1111111111111, ..Test::default()}),
 )]

--- a/tests/test_bit_container_size.rs
+++ b/tests/test_bit_container_size.rs
@@ -1,7 +1,8 @@
+#![cfg(feature = "bits")]
+
 use deku::prelude::*;
 use rstest::*;
 
-#[cfg(feature = "bits")]
 #[derive(Debug, Default, PartialEq, DekuWrite, DekuRead)]
 #[deku(endian = "big")]
 struct Test {
@@ -15,22 +16,21 @@ struct Test {
     field_u32_be: u32,
 }
 
-#[cfg(feature = "bits")]
 #[rstest(input,
     #[should_panic(
-        expected = "InvalidParam(\"bit size 5 of input is larger than bit requested size 4\")"
+        expected = "InvalidParam(\"bit size of input is larger than bit requested size: 5 exceeds 4\")"
     )]
     case::field_u8_be( Test { field_u8_be: 0b11111, ..Test::default()}),
     #[should_panic(
-        expected = "InvalidParam(\"bit size 5 of input is larger than bit requested size 4\")"
+        expected = "InvalidParam(\"bit size of input is larger than bit requested size: 5 exceeds 4\")"
     )]
     case::field_be( Test { field_be: 0b11111, ..Test::default()}),
     #[should_panic(
-        expected = "InvalidParam(\"bit size 13 of input is larger than bit requested size 12\")"
+        expected = "InvalidParam(\"bit size of input is larger than requested size: 13 exceeds 12\")"
     )]
     case::field_le( Test { field_le: 0b1111111111111, ..Test::default()}),
     #[should_panic(
-        expected = "InvalidParam(\"bit size 13 of input is larger than bit requested size 9\")"
+        expected = "InvalidParam(\"bit size of input is larger than bit requested size: 13 exceeds 9\")"
     )]
     case::field_u32_be( Test { field_u32_be: 0b1111111111111, ..Test::default()}),
 )]

--- a/tests/test_box.rs
+++ b/tests/test_box.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use deku::prelude::*;
 
 #[derive(DekuRead, DekuWrite)]

--- a/tests/test_catch_all.rs
+++ b/tests/test_catch_all.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::convert::{TryFrom, TryInto};
+    use core::convert::{TryFrom, TryInto};
 
     use deku::prelude::*;
 

--- a/tests/test_catch_all.rs
+++ b/tests/test_catch_all.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 #[cfg(test)]
 mod test {
     use core::convert::{TryFrom, TryInto};

--- a/tests/test_compile/cases/internal_variables.rs
+++ b/tests/test_compile/cases/internal_variables.rs
@@ -49,7 +49,7 @@ struct TestMap {
     field_b: usize,
 }
 
-fn dummy_reader<R: std::io::Read + std::io::Seek>(
+fn dummy_reader<R: no_std_io::io::Read + no_std_io::io::Seek>(
     _offset: usize,
     _reader: &mut Reader<R>,
 ) -> Result<usize, DekuError> {
@@ -72,7 +72,7 @@ struct TestCtx {
     field_b: ChildCtx,
 }
 
-fn dummy_writer<W: std::io::Write + std::io::Seek>(
+fn dummy_writer<W: no_std_io::io::Write + no_std_io::io::Seek>(
     _offset: usize,
     _writer: &mut deku::writer::Writer<W>,
 ) -> Result<(), DekuError> {

--- a/tests/test_cstring.rs
+++ b/tests/test_cstring.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use deku::prelude::*;
 
 use std::ffi::CString;

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -2,7 +2,7 @@
 
 // TODO: These should be divided into smaller tests
 
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 use std::io::Cursor;
 
 use deku::prelude::*;

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -2,11 +2,14 @@
 
 // TODO: These should be divided into smaller tests
 
-use core::convert::{TryFrom, TryInto};
-use std::io::Cursor;
+use core::convert::TryFrom;
+use no_std_io::io::Cursor;
 
 use deku::prelude::*;
+
+#[cfg(any(feature = "bits", feature = "std"))]
 use hexlit::hex;
+#[cfg(any(feature = "bits", feature = "std"))]
 use rstest::*;
 
 #[cfg(feature = "bits")]
@@ -55,7 +58,7 @@ fn test_enum(input: &[u8], expected: TestEnum) {
 }
 
 #[test]
-#[should_panic(expected = "Parse(\"Could not match enum variant id = 2 on enum `TestEnum`\")")]
+#[should_panic(expected = "Could not match enum variant")]
 fn test_enum_error() {
     #[derive(DekuRead)]
     #[deku(id_type = "u8")]
@@ -71,6 +74,7 @@ fn test_enum_error() {
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[repr(u8)]
 #[deku(id_type = "u8")]
+#[cfg(all(feature = "alloc", feature = "std"))]
 enum TestEnumDiscriminant {
     VarA = 0x00,
     VarB,
@@ -82,9 +86,11 @@ enum TestEnumDiscriminant {
     case(&hex!("01"), TestEnumDiscriminant::VarB),
     case(&hex!("02"), TestEnumDiscriminant::VarC),
 
-    #[should_panic(expected = "Could not match enum variant id = 3 on enum `TestEnumDiscriminant`")]
+    #[should_panic(expected = "Could not match enum variant")]
     case(&hex!("03"), TestEnumDiscriminant::VarA),
 )]
+// TODO: Switch std::convert::TryInto to core::convert::TryInto
+#[cfg(all(feature = "alloc", feature = "std"))]
 fn test_enum_discriminant(input: &[u8], expected: TestEnumDiscriminant) {
     let input = input.to_vec();
     let ret_read = TestEnumDiscriminant::try_from(input.as_slice()).unwrap();
@@ -95,6 +101,7 @@ fn test_enum_discriminant(input: &[u8], expected: TestEnumDiscriminant) {
 }
 
 #[test]
+#[cfg(all(feature = "alloc", feature = "std"))]
 fn test_enum_array_type() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     #[deku(id_type = "[u8; 3]")]
@@ -215,6 +222,7 @@ fn test_enum_id_pat_with_discriminant_and_storage() {
 }
 
 #[test]
+#[cfg(all(feature = "alloc", feature = "std"))]
 fn test_id_pat_with_id() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
     pub struct DekuTest {
@@ -341,6 +349,7 @@ fn test_litbool_as_id() {
 
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u16", id_endian = "big", endian = "little")]
+#[cfg(all(feature = "alloc", feature = "std"))]
 enum VariableEndian {
     #[deku(id = "0x01")]
     Little(u16),
@@ -355,6 +364,7 @@ enum VariableEndian {
 case(&hex!("00010100"), VariableEndian::Little(1)),
 case(&hex!("00020100"), VariableEndian::Big{x: 256})
 )]
+#[cfg(all(feature = "alloc", feature = "std"))]
 fn test_variable_endian_enum(input: &[u8], expected: VariableEndian) {
     let ret_read = VariableEndian::try_from(input).unwrap();
     assert_eq!(expected, ret_read);

--- a/tests/test_from_bytes.rs
+++ b/tests/test_from_bytes.rs
@@ -1,6 +1,7 @@
+#![cfg(feature = "bits")]
+
 use deku::prelude::*;
 
-#[cfg(feature = "bits")]
 #[test]
 fn test_from_bytes_struct() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
@@ -29,7 +30,6 @@ fn test_from_bytes_struct() {
     assert_eq!(0, i);
 }
 
-#[cfg(feature = "bits")]
 #[test]
 fn test_from_bytes_enum() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
@@ -55,7 +55,6 @@ fn test_from_bytes_enum() {
     assert_eq!(0b0101_1010u8, rest[0]);
 }
 
-#[cfg(feature = "bits")]
 #[test]
 fn test_from_bytes_long() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]

--- a/tests/test_from_reader.rs
+++ b/tests/test_from_reader.rs
@@ -1,15 +1,16 @@
+#![cfg(all(feature = "bits", feature = "std"))]
+
 use deku::noseek::NoSeek;
 use deku::prelude::*;
-use no_std_io::io::Seek;
+use std::io::{Cursor, Seek};
 
-#[cfg(feature = "bits")]
 #[test]
 fn test_from_reader_struct() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
     struct TestDeku(#[deku(bits = 4)] u8);
 
     let test_data: Vec<u8> = [0b0110_0110u8, 0b0101_1010u8].to_vec();
-    let mut c = std::io::Cursor::new(test_data);
+    let mut c = Cursor::new(test_data);
 
     c.rewind().unwrap();
     let (amt_read, ret_read) = TestDeku::from_reader((&mut c, 0)).unwrap();
@@ -41,7 +42,6 @@ fn test_from_reader_struct() {
     assert_eq!(TestDeku(0b0110), ret_read);
 }
 
-#[cfg(feature = "bits")]
 #[test]
 fn test_from_reader_enum() {
     #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
@@ -54,7 +54,7 @@ fn test_from_reader_enum() {
     }
 
     let test_data = [0b0110_0110u8, 0b0101_1010u8];
-    let mut c = std::io::Cursor::new(test_data);
+    let mut c = Cursor::new(test_data);
 
     let (first_amt_read, ret_read) = TestDeku::from_reader((&mut c, 0)).unwrap();
     assert_eq!(first_amt_read, 8);

--- a/tests/test_generic.rs
+++ b/tests/test_generic.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_generic.rs
+++ b/tests/test_generic.rs
@@ -1,3 +1,8 @@
+#![cfg(feature = "alloc")]
+
+extern crate alloc;
+use alloc::vec::Vec;
+
 use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -1,3 +1,9 @@
+#![cfg(feature = "alloc")]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
 use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
@@ -7,16 +13,16 @@ use rstest::rstest;
 #[rstest(input,
     case(&hex!("64656b75")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
     case(&hex!("64656bde")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
     case(&hex!("6465ad75")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
     case(&hex!("64be6b75")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
     case(&hex!("ef656b75")),
 
     #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
@@ -38,19 +44,19 @@ fn test_magic_struct(input: &[u8]) {
 #[rstest(input,
     case(&hex!("64656b7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
     case(&hex!("64656bde00")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
     case(&hex!("6465ad7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
     case(&hex!("64be6b7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
     case(&hex!("ef656b7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
     case(&hex!("64656b00")),
 
     #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -13,16 +13,16 @@ use rstest::rstest;
 #[rstest(input,
     case(&hex!("64656b75")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Missing magic value")]
     case(&hex!("64656bde")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Missing magic value")]
     case(&hex!("6465ad75")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Missing magic value")]
     case(&hex!("64be6b75")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Missing magic value")]
     case(&hex!("ef656b75")),
 
     #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]
@@ -44,19 +44,19 @@ fn test_magic_struct(input: &[u8]) {
 #[rstest(input,
     case(&hex!("64656b7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Missing magic value")]
     case(&hex!("64656bde00")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Missing magic value")]
     case(&hex!("6465ad7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Missing magic value")]
     case(&hex!("64be6b7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Missing magic value")]
     case(&hex!("ef656b7500")),
 
-    #[should_panic(expected = "Parse(\"Missing magic value: [100, 101, 107, 117]\")")]
+    #[should_panic(expected = "Missing magic value")]
     case(&hex!("64656b00")),
 
     #[should_panic(expected = "Incomplete(NeedSize { bits: 8 })")]

--- a/tests/test_magic.rs
+++ b/tests/test_magic.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 use hexlit::hex;

--- a/tests/test_own_impl.rs
+++ b/tests/test_own_impl.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 #[test]
 fn test_own_impl() {
     use deku::prelude::*;

--- a/tests/test_own_impl.rs
+++ b/tests/test_own_impl.rs
@@ -2,10 +2,10 @@
 fn test_own_impl() {
     use deku::prelude::*;
     use std::io::{Read, Seek, SeekFrom};
+    #[expect(dead_code)]
     pub enum Data {
         /// On read: Save current stream_position() as `Offset`, seek `header.filesize`
         /// This will be used to seek this this position if we want to extract *just* this file
-        #[expect(dead_code)]
         Offset(u64),
     }
 

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -1,4 +1,8 @@
+#![cfg(feature = "std")]
+
 use deku::prelude::*;
+
+#[cfg(feature = "bits")]
 use std::io::Cursor;
 
 // Invalid alignment assumptions when converting

--- a/tests/test_seek.rs
+++ b/tests/test_seek.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use deku::{noseek::NoSeek, prelude::*};
 use hexlit::hex;
 use rstest::*;
@@ -23,6 +25,7 @@ pub struct Test {
     case(&hex!("0200002030"), Test{ skip_u8: 2, byte: 0x20, byte_after: 0x30, byte_after_rewind: 0x02, byte_again: 0x00, another: 0x30 }),
     case(&hex!("00ffaa"), Test{ skip_u8: 0, byte: 0xff, byte_after: 0xaa, byte_after_rewind: 0x00, byte_again: 0xaa, another: 0xaa }),
 )]
+#[cfg(feature = "alloc")]
 fn test_seek(input: &[u8], expected: Test) {
     let input = input.to_vec();
     let mut cursor = std::io::Cursor::new(input.clone());
@@ -44,6 +47,7 @@ pub struct SeekCtxBefore {
     case(&hex!("0003"), 1, SeekCtxBefore{ byte: 0x03 }),
     case(&hex!("000004"), 2, SeekCtxBefore{ byte: 0x04 }),
 )]
+#[cfg(feature = "std")]
 fn test_seek_ctx_before(input: &[u8], ctx: usize, expected: SeekCtxBefore) {
     use std::io::Cursor;
     let input = input.to_vec();
@@ -71,6 +75,7 @@ pub struct SeekCtxBeforeStart {
     case(&hex!("0003"), SeekCtxBeforeStart{ byte: 0x03 }),
     case(&hex!("00ff"), SeekCtxBeforeStart{ byte: 0xff }),
 )]
+#[cfg(feature = "std")]
 fn test_seek_ctx_start(input: &[u8], expected: SeekCtxBeforeStart) {
     use std::io::Cursor;
     let input = input.to_vec();
@@ -98,6 +103,7 @@ pub struct SeekCtxBeforeEnd {
     case(&hex!("000300"), SeekCtxBeforeEnd{ byte: 0x03 }),
     case(&hex!("00ff00"), SeekCtxBeforeEnd{ byte: 0xff }),
 )]
+#[cfg(feature = "std")]
 fn test_seek_ctx_end(input: &[u8], expected: SeekCtxBeforeEnd) {
     use std::io::Cursor;
     let input = input.to_vec();
@@ -125,6 +131,7 @@ pub struct SeekCtxNoSeek {
     case(&hex!("03"), SeekCtxNoSeek { byte: 0x03 }),
     case(&hex!("ff"), SeekCtxNoSeek { byte: 0xff }),
 )]
+#[cfg(feature = "std")]
 fn test_seek_ctx_no_seek(input: &[u8], expected: SeekCtxNoSeek) {
     use std::io::Cursor;
     let input = input.to_vec();

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -4,7 +4,7 @@
 
 #![allow(clippy::unusual_byte_groupings)]
 
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -4,8 +4,10 @@
 
 #![allow(clippy::unusual_byte_groupings)]
 
+#[cfg(any(feature = "bits", feature = "std"))]
 use core::convert::{TryFrom, TryInto};
 
+#[cfg(any(feature = "alloc", feature = "bits", feature = "std"))]
 use deku::prelude::*;
 
 mod test_common;
@@ -169,6 +171,7 @@ fn test_named_struct() {
     assert_eq!(test_data, ret_write);
 }
 
+#[cfg(all(feature = "alloc", feature = "std"))]
 #[test]
 fn test_raw_identifiers_struct() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
@@ -187,6 +190,7 @@ fn test_raw_identifiers_struct() {
     assert_eq!(test_data, ret_write);
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn test_big_endian() {
     #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
@@ -217,6 +221,7 @@ fn test_big_endian() {
     assert_eq!(&bytes[..2], &*new_bytes);
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn test_units() {
     #[derive(DekuRead, DekuWrite)]
@@ -234,6 +239,7 @@ fn test_units() {
 }
 
 /// Issue 513
+#[cfg(feature = "alloc")]
 #[test]
 fn test_zst_vec_1() {
     #[derive(Debug, PartialEq, DekuRead)]
@@ -250,6 +256,7 @@ fn test_zst_vec_1() {
     assert_eq!(x.things.len(), 0);
 }
 /// Issue 513
+#[cfg(feature = "alloc")]
 #[test]
 fn test_zst_vec_2() {
     #[derive(Debug, PartialEq, DekuRead)]

--- a/tests/test_to_bits.rs
+++ b/tests/test_to_bits.rs
@@ -1,10 +1,10 @@
+#![cfg(feature = "bits")]
+
 use core::convert::TryFrom;
 
-#[cfg(feature = "bits")]
 use deku::bitvec::Lsb0;
 use deku::prelude::*;
 
-#[cfg(feature = "bits")]
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 pub struct Test {
     #[deku(bits = "4")]
@@ -13,7 +13,6 @@ pub struct Test {
     pub b: u8,
 }
 
-#[cfg(feature = "bits")]
 #[test]
 fn test_to_bits_correct() {
     let test_data: &[u8] = &[0xf1];
@@ -22,7 +21,6 @@ fn test_to_bits_correct() {
     assert_eq!(deku::bitvec::bitvec![1, 1, 1, 1, 0, 0, 0, 1], bits);
 }
 
-#[cfg(feature = "bits")]
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 pub struct TestOver {
     #[deku(bits = "4")]
@@ -33,7 +31,6 @@ pub struct TestOver {
     pub c: u8,
 }
 
-#[cfg(feature = "bits")]
 #[test]
 fn test_to_bits_correct_over() {
     let test_data: &[u8] = &[0xf1, 0x80];
@@ -42,7 +39,6 @@ fn test_to_bits_correct_over() {
     assert_eq!(deku::bitvec::bitvec![1, 1, 1, 1, 0, 0, 0, 1, 1], bits);
 }
 
-#[cfg(feature = "bits")]
 #[derive(PartialEq, Debug, DekuRead, DekuWrite)]
 #[deku(id_type = "u8", bits = "4")]
 enum TestEnum {

--- a/tests/test_to_bits.rs
+++ b/tests/test_to_bits.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 #[cfg(feature = "bits")]
 use deku::bitvec::Lsb0;

--- a/tests/test_to_slice.rs
+++ b/tests/test_to_slice.rs
@@ -7,6 +7,7 @@ pub struct A {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 fn test_to_slice_bytes() {
     let bytes = [0x11, 0x22, 0x33];
     let a = A::from_bytes((&bytes, 0)).unwrap().1;
@@ -39,6 +40,7 @@ fn test_to_slice_bits() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Io(WriteZero)")]
 fn test_to_slice_panic_writer_failure() {
     let bytes = [0x11, 0x22, 0x33];

--- a/tests/test_tuple.rs
+++ b/tests/test_tuple.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alloc")]
+
 use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;

--- a/tests/test_tuple.rs
+++ b/tests/test_tuple.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use deku::prelude::*;
 use hexlit::hex;


### PR DESCRIPTION
Some environments prefer to avoid `alloc` in addition to building with `no_std`.