### PR TITLE
Improve error message for id_type and missing repr

### DIFF
--- a/deku-derive/src/macros/deku_read.rs
+++ b/deku-derive/src/macros/deku_read.rs
@@ -264,7 +264,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
             let Some(repr) = input.repr else {
                 return Err(syn::Error::new(
                     variant.ident.span(),
-                    "DekuRead: `id_type` must be specified on non-unit variants",
+                    "DekuRead: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`",
                 ));
             };
             if let Some(id_type) = id_type {

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -278,7 +278,7 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                     None => {
                         return Err(syn::Error::new(
                             variant.ident.span(),
-                            "DekuWrite: `id_type` must be specified on non-unit variants",
+                            "DekuWrite: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`",
                         ));
                     }
                     Some(repr) => {

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -2054,6 +2054,25 @@ assert_eq!(data, value);
 # fn main() {}
 ```
 
+
+When using `id_type` with non-unit variants, Deku requires [primitive representation](https://doc.rust-lang.org/reference/type-layout.html#primitive-representations).
+Deku uses this for calculating the discriminant when reading and writing.
+```rust
+# use core::convert::{TryInto, TryFrom};
+# use deku::prelude::*;
+# #[cfg(feature = "std")]
+# use std::io::Cursor;
+#[derive(Copy, Clone, Debug, DekuRead, DekuWrite)]
+#[deku(endian = "endian", ctx = "endian: deku::ctx::Endian", id_type = "u8")]
+#[repr(u8)]
+enum OpKind {
+    Id = 0,
+    Opcode = 255,
+}
+```
+
+
+
 # bytes
 
 Set the byte size of the enum variant `id`

--- a/tests/test_compile/cases/enum_validation.stderr
+++ b/tests/test_compile/cases/enum_validation.stderr
@@ -88,13 +88,13 @@ error: DekuWrite: cannot determine write `id`. must provide storage for the id o
 132 |     B,
     |     ^
 
-error: DekuWrite: `id_type` must be specified on non-unit variants
+error: DekuWrite: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`
    --> tests/test_compile/cases/enum_validation.rs:139:5
     |
 139 |     A = 0,
     |     ^
 
-error: DekuRead: `id_type` must be specified on non-unit variants
+error: DekuRead: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`
    --> tests/test_compile/cases/enum_validation.rs:148:5
     |
 148 |     Base = 0x00,
@@ -106,25 +106,25 @@ error: DekuRead: `repr` must match `id_type`
 156 |     Base = 0x00,
     |     ^^^^
 
-error: DekuRead: `id_type` must be specified on non-unit variants
+error: DekuRead: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`
    --> tests/test_compile/cases/enum_validation.rs:163:5
     |
 163 |     Base = 0x00,
     |     ^^^^
 
-error: DekuRead: `id_type` must be specified on non-unit variants
+error: DekuRead: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`
    --> tests/test_compile/cases/enum_validation.rs:170:5
     |
 170 |     Base = 0x00,
     |     ^^^^
 
-error: DekuRead: `id_type` must be specified on non-unit variants
+error: DekuRead: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`
    --> tests/test_compile/cases/enum_validation.rs:177:5
     |
 177 |     Base = 0x00,
     |     ^^^^
 
-error: DekuWrite: `id_type` must be specified on non-unit variants
+error: DekuWrite: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`
    --> tests/test_compile/cases/enum_validation.rs:184:5
     |
 184 |     Base = 0x00,
@@ -136,19 +136,19 @@ error: DekuWrite: `repr` must match `id_type`
 192 |     Base = 0x00,
     |     ^^^^
 
-error: DekuWrite: `id_type` must be specified on non-unit variants
+error: DekuWrite: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`
    --> tests/test_compile/cases/enum_validation.rs:199:5
     |
 199 |     Base = 0x00,
     |     ^^^^
 
-error: DekuWrite: `id_type` must be specified on non-unit variants
+error: DekuWrite: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`
    --> tests/test_compile/cases/enum_validation.rs:206:5
     |
 206 |     Base = 0x00,
     |     ^^^^
 
-error: DekuWrite: `id_type` must be specified on non-unit variants
+error: DekuWrite: `id_type` with non-unit variants requires primitive representation i.e. `repr(inttype)`
    --> tests/test_compile/cases/enum_validation.rs:213:5
     |
 213 |     Base = 0x00,


### PR DESCRIPTION
* This piece of code will only fire if you are using id_type with repr(inttype). Thus, print out what is actually required to fix this error.
* Add to docs

Closes #583 