### PR TITLE
fix: remove unsafe slice MaybeUninit::uninit().assume_init()

### DIFF
--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -17,31 +17,32 @@ where
     where
         Self: Sized,
     {
-        #[allow(clippy::uninit_assumed_init)]
-        // This is safe because we initialize the array immediately after,
-        // and never return it in case of error
-        let mut slice: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
-        for (n, item) in slice.iter_mut().enumerate() {
-            let value = match T::from_reader_with_ctx(reader, ctx) {
-                Ok(it) => it,
+        let mut array: [MaybeUninit<T>; N] = [const { MaybeUninit::uninit() }; N];
+        for (n, item) in array.iter_mut().enumerate() {
+            match T::from_reader_with_ctx(reader, ctx) {
+                Ok(value) => {
+                    item.write(value);
+                }
                 Err(err) => {
-                    // For each item in the array, drop if we allocated it.
-                    for item in &mut slice[0..n] {
+                    // Drop initialized items
+                    for item in &mut array[0..n] {
+                        // SAFETY: `item` is certain to be initialized
                         unsafe {
                             item.assume_init_drop();
                         }
                     }
+
                     return Err(err);
                 }
             };
-            item.write(value);
         }
 
-        let val = unsafe {
+        // SAFETY: `array` is certain to be initialized
+        let array = unsafe {
             // TODO: array_assume_init: https://github.com/rust-lang/rust/issues/96097
-            (core::ptr::addr_of!(slice) as *const [T; N]).read()
+            (core::ptr::addr_of!(array).cast::<[T; N]>()).read()
         };
-        Ok(val)
+        Ok(array)
     }
 }
 


### PR DESCRIPTION
Fix #600 

In addition:
- `slice` has been renamed `array` because it is more descriptive name in this case
- renamed `it` to `value` for clarity
- `item.write(value);` in match `Ok`
- `SAFETY` comments
- rewritten `(core::ptr::addr_of!(slice) as *const [T; N]).read()` into `(core::ptr::addr_of!(array).cast::<[T; N]>()).read()` leveraging [pointer.cast](https://doc.rust-lang.org/core/primitive.pointer.html#method.cast-1)