### PR TITLE
refactor: use &raw const instead of core::ptr::addr_of

### DIFF
--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -40,7 +40,7 @@ where
         // SAFETY: `array` is certain to be initialized
         let array = unsafe {
             // TODO: array_assume_init: https://github.com/rust-lang/rust/issues/96097
-            (core::ptr::addr_of!(array).cast::<[T; N]>()).read()
+            (&raw const array).cast::<[T; N]>().read()
         };
         Ok(array)
     }


### PR DESCRIPTION
From [`core::ptr::addr_of`](https://doc.rust-lang.org/std/ptr/macro.addr_of.html) docs:
> `addr_of!(expr)` is equivalent to `&raw const expr`. The macro is _soft-deprecated_; use `&raw const` instead.