### PR TITLE
fix: `Order::Lsb0` + `Endian::Little` bit alignment inconsistencies

### DIFF
--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -167,7 +167,7 @@ macro_rules! ImplDekuReadBits {
                 debug_assert!(MAX_TYPE_BITS >= bit_slice.len() + pad);
 
                 // if everything is aligned, just read the value
-                if pad == 0 && bit_slice.len() == MAX_TYPE_BITS {
+                if pad == 0 && bit_slice.len() == MAX_TYPE_BITS && order != Order::Lsb0 {
                     let bytes = bit_slice.domain().region().unwrap().1;
 
                     if bytes.len() * 8 == MAX_TYPE_BITS {
@@ -189,7 +189,7 @@ macro_rules! ImplDekuReadBits {
                 // Turning this into [0x23, 0x01] (then appending till type size)
                 debug_assert_eq!(bit_size, bit_slice.len());
                 const MAX_TYPE_BYTES: usize = core::mem::size_of::<$typ>();
-                if order == Order::Lsb0 && bit_slice.len() > 8 && pad != 0 {
+                if order == Order::Lsb0 {
                     let mut bits = crate::BoundedBitVec::<[u8; MAX_TYPE_BYTES], Msb0>::new();
 
                     bits.extend_from_bitslice(&bit_slice);
@@ -199,7 +199,17 @@ macro_rules! ImplDekuReadBits {
                     }
 
                     let mut buf = [0u8; MAX_TYPE_BYTES];
-                    for (slice, slot) in bits.as_bitslice().rchunks_exact(8).zip(buf.iter_mut()) {
+                    let skip = if input_is_le {
+                        0
+                    } else {
+                        MAX_TYPE_BYTES - bit_slice.len().div_ceil(8)
+                    };
+
+                    for (slice, slot) in bits
+                        .as_bitslice()
+                        .rchunks_exact(8)
+                        .zip(buf.iter_mut().skip(skip))
+                    {
                         *slot = slice.load_be();
                     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -318,31 +318,17 @@ impl<R: Read + Seek> Reader<R> {
                 // read in new bytes
                 // TODO: Profile and optimise
                 let remainder = if order == Order::Lsb0 {
-                    if dst.len() % 8 != 0 {
-                        let mut iter = dst[..end].rchunks_exact_mut(8);
-                        for slot in iter.by_ref() {
-                            let mut buf: [u8; 1] = [0u8];
-                            if let Err(e) = self.inner.read_exact(&mut buf) {
-                                if e.kind() == ErrorKind::UnexpectedEof {
-                                    return Err(DekuError::Incomplete(NeedSize::new(dst.len())));
-                                }
+                    let mut iter = dst[..end].rchunks_exact_mut(8);
+                    for slot in iter.by_ref() {
+                        let mut buf: [u8; 1] = [0u8];
+                        if let Err(e) = self.inner.read_exact(&mut buf) {
+                            if e.kind() == ErrorKind::UnexpectedEof {
+                                return Err(DekuError::Incomplete(NeedSize::new(dst.len())));
                             }
-                            slot.store_be(buf[0]);
                         }
-                        iter.into_remainder()
-                    } else {
-                        let mut iter = dst[..end].chunks_exact_mut(8);
-                        for slot in iter.by_ref() {
-                            let mut buf: [u8; 1] = [0u8];
-                            if let Err(e) = self.inner.read_exact(&mut buf) {
-                                if e.kind() == ErrorKind::UnexpectedEof {
-                                    return Err(DekuError::Incomplete(NeedSize::new(dst.len())));
-                                }
-                            }
-                            slot.store_be(buf[0]);
-                        }
-                        iter.into_remainder()
+                        slot.store_be(buf[0]);
                     }
+                    iter.into_remainder()
                 } else {
                     debug_assert_eq!(order, Order::Msb0);
                     let mut iter = dst[start..end].chunks_exact_mut(8);
@@ -474,6 +460,9 @@ impl<R: Read + Seek> Reader<R> {
             Some(Leftover::Bits(_)) => {
                 let slice = BitSlice::from_slice_mut(&mut buf[..amt]);
                 self.read_bits_into(slice, _order)?;
+                if _order == Order::Lsb0 {
+                    buf[..amt].reverse();
+                }
                 Ok(ReaderRet::Bytes)
             }
             _ => unreachable!(),
@@ -570,6 +559,9 @@ impl<R: Read + Seek> Reader<R> {
             Some(Leftover::Bits(_)) => {
                 let slice = BitSlice::from_slice_mut(buf);
                 self.read_bits_into(slice, _order)?;
+                if _order == Order::Lsb0 {
+                    buf.reverse();
+                }
                 Ok(ReaderRet::Bytes)
             }
             _ => unreachable!(),
@@ -607,6 +599,9 @@ impl<R: Read + Seek> Reader<R> {
             Some(Leftover::Bits(_)) => {
                 let slice = BitSlice::from_slice_mut(buf);
                 self.read_bits_into(slice, _order)?;
+                if _order == Order::Lsb0 {
+                    buf.reverse();
+                }
                 Ok(())
             }
             None => unreachable!(),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -452,15 +452,15 @@ impl<R: Read + Seek> Reader<R> {
         &mut self,
         amt: usize,
         buf: &mut [u8],
-        _order: Order,
+        order: Order,
     ) -> Result<ReaderRet, DekuError> {
         match self.leftover {
             Some(Leftover::Byte(byte)) => self.read_bytes_leftover(buf, byte, amt),
             #[cfg(feature = "bits")]
             Some(Leftover::Bits(_)) => {
                 let slice = BitSlice::from_slice_mut(&mut buf[..amt]);
-                self.read_bits_into(slice, _order)?;
-                if _order == Order::Lsb0 {
+                self.read_bits_into(slice, order)?;
+                if order == Order::Lsb0 {
                     buf[..amt].reverse();
                 }
                 Ok(ReaderRet::Bytes)
@@ -548,7 +548,7 @@ impl<R: Read + Seek> Reader<R> {
     fn read_bytes_const_other<const N: usize>(
         &mut self,
         buf: &mut [u8; N],
-        _order: Order,
+        order: Order,
     ) -> Result<ReaderRet, DekuError> {
         match self.leftover {
             Some(Leftover::Byte(byte)) => {
@@ -558,8 +558,8 @@ impl<R: Read + Seek> Reader<R> {
             #[cfg(feature = "bits")]
             Some(Leftover::Bits(_)) => {
                 let slice = BitSlice::from_slice_mut(buf);
-                self.read_bits_into(slice, _order)?;
-                if _order == Order::Lsb0 {
+                self.read_bits_into(slice, order)?;
+                if order == Order::Lsb0 {
                     buf.reverse();
                 }
                 Ok(ReaderRet::Bytes)
@@ -579,7 +579,7 @@ impl<R: Read + Seek> Reader<R> {
     pub fn read_bytes_const_into<const N: usize>(
         &mut self,
         buf: &mut [u8; N],
-        _order: Order,
+        order: Order,
     ) -> Result<(), DekuError> {
         if self.leftover.is_none() {
             if let Err(e) = self.inner.read_exact(buf) {
@@ -598,8 +598,8 @@ impl<R: Read + Seek> Reader<R> {
             #[cfg(feature = "bits")]
             Some(Leftover::Bits(_)) => {
                 let slice = BitSlice::from_slice_mut(buf);
-                self.read_bits_into(slice, _order)?;
-                if _order == Order::Lsb0 {
+                self.read_bits_into(slice, order)?;
+                if order == Order::Lsb0 {
                     buf.reverse();
                 }
                 Ok(())

--- a/tests/test_lsb_le.rs
+++ b/tests/test_lsb_le.rs
@@ -299,3 +299,33 @@ fn test_misaligned_pad_bits_aaelf32_flags() {
         flags
     );
 }
+
+#[test]
+fn test_lsb_le_misaligned_3() {
+    #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+    #[deku(endian = "little", bit_order = "lsb")]
+    struct TestStruct {
+        #[deku(bits = 1)]
+        optional: bool,
+        #[deku(bits = 24)]
+        value: u32,
+    }
+    let bits = deku::bitvec::bits![
+        u8, deku::bitvec::Lsb0;
+        1, // Optional
+
+        // Value - 24 bits
+        1,1,1,1, 1,1,1,1,
+        0,0,0,0, 0,0,0,0,
+        0,0,0,0, 0,0,0,0,
+
+        // Padding to make it byte aligned
+        0,0,0,0, 0,0,0
+    ]
+    .to_bitvec();
+    let bitvec = bits.into_vec();
+    let (_rem, s) = TestStruct::from_bytes((&bitvec, 0)).unwrap();
+
+    assert!(s.optional, "Boolean value for field `optional` != `true`");
+    assert_eq!(s.value, u8::MAX as u32)
+}


### PR DESCRIPTION
Adding a test-case that I came across when trying to implement a message parsing standard.

Also added a possible fix for the issue.

fixes #658 