### PR TITLE
reader: Fix bits_read sync on all seek variants

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -50,24 +50,10 @@ impl<R: Read + Seek> Seek for Reader<R> {
 
         // clear leftover
         self.leftover = None;
-        // set bits read
-        match pos {
-            // When reading from the start, reset the bits_read so from_bytes
-            // return can still be reasonable
-            SeekFrom::Start(n) => {
-                if n > 0 {
-                    self.bits_read = (n * 8) as usize;
-                }
-            }
-            SeekFrom::End(_) => (),
-            // If seeking from current, act as if we just read those bytes
-            SeekFrom::Current(n) => {
-                if n > 0 {
-                    self.bits_read += (n * 8) as usize;
-                }
-            }
-        }
-        self.inner.seek(pos)
+
+        let new_pos = self.inner.seek(pos)?;
+        self.bits_read = (new_pos as usize) * 8;
+        Ok(new_pos)
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -52,7 +52,9 @@ impl<R: Read + Seek> Seek for Reader<R> {
         self.leftover = None;
 
         let new_pos = self.inner.seek(pos)?;
-        self.bits_read = (new_pos as usize) * 8;
+        self.bits_read = usize::try_from(new_pos)
+            .unwrap_or(usize::MAX)
+            .saturating_mul(8);
         Ok(new_pos)
     }
 }

--- a/tests/test_seek.rs
+++ b/tests/test_seek.rs
@@ -154,3 +154,25 @@ fn test_seek_ctx_no_seek(input: &[u8], expected: SeekCtxNoSeek) {
     ret_read.to_writer(&mut writer, ()).unwrap();
     assert_eq!(buf, input);
 }
+
+#[derive(DekuRead, DekuWrite, Debug, PartialEq, Eq)]
+pub struct SeekStartZero {
+    #[deku(seek_from_current = "1")]
+    tail: u8,
+
+    #[deku(seek_from_start = "0")]
+    head: u8,
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn test_seek_from_start_zero_rewind() {
+    let input = hex!("aabb");
+    let expected = SeekStartZero {
+        tail: 0xbb,
+        head: 0xaa,
+    };
+
+    let (_, ret_read) = SeekStartZero::from_bytes((&input, 0)).unwrap();
+    assert_eq!(ret_read, expected);
+}

--- a/tests/test_seek.rs
+++ b/tests/test_seek.rs
@@ -159,7 +159,6 @@ fn test_seek_ctx_no_seek(input: &[u8], expected: SeekCtxNoSeek) {
 pub struct SeekStartZero {
     #[deku(seek_from_current = "1")]
     tail: u8,
-
     #[deku(seek_from_start = "0")]
     head: u8,
 }
@@ -175,4 +174,63 @@ fn test_seek_from_start_zero_rewind() {
 
     let (_, ret_read) = SeekStartZero::from_bytes((&input, 0)).unwrap();
     assert_eq!(ret_read, expected);
+}
+
+#[derive(DekuRead, DekuWrite, Debug, PartialEq, Eq)]
+pub struct SeekEndThenRewind {
+    #[deku(seek_from_end = "-1")]
+    tail: u8,
+    #[deku(seek_from_start = "0")]
+    head: u8,
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn test_seek_from_end_rewind() {
+    let input = hex!("aabb");
+    let expected = SeekEndThenRewind {
+        tail: 0xbb,
+        head: 0xaa,
+    };
+
+    let (_, ret_read) = SeekEndThenRewind::from_bytes((&input, 0)).unwrap();
+    assert_eq!(ret_read, expected);
+}
+
+#[derive(DekuRead, DekuWrite, Debug, PartialEq, Eq)]
+pub struct SeekCurrentNegativeRewind {
+    first: u8,
+    second: u8,
+    #[deku(seek_from_current = "-2")]
+    first_again: u8,
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn test_seek_from_current_negative_rewind() {
+    let input = hex!("aabb");
+    let expected = SeekCurrentNegativeRewind {
+        first: 0xaa,
+        second: 0xbb,
+        first_again: 0xaa,
+    };
+
+    let (_, ret_read) = SeekCurrentNegativeRewind::from_bytes((&input, 0)).unwrap();
+    assert_eq!(ret_read, expected);
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn test_seek_error_preserves_bits_read() {
+    use std::io::{Cursor, Seek, SeekFrom};
+    let input = hex!("aabb").to_vec();
+    let mut cursor = Cursor::new(input);
+    let mut reader = Reader::new(&mut cursor);
+
+    reader.seek(SeekFrom::Start(1)).unwrap();
+    let bits_before = reader.bits_read;
+
+    let result = reader.seek(SeekFrom::Current(-100));
+    assert!(result.is_err());
+    assert_eq!(reader.bits_read, bits_before);
 }


### PR DESCRIPTION
Closes #606.

## Bug

`Reader::seek` updates `bits_read` only for some `SeekFrom` variants:

- `SeekFrom::Start(n)` skips the update when `n == 0`
- `SeekFrom::Current(n)` skips when `n <= 0`
- `SeekFrom::End(_)` never updates it

After one of those seeks, the inner reader sits at the right byte position but `bits_read` keeps the old value. The generated `from_bytes` body then computes `idx = bits_read / 8` and slices `input.get(idx..)` at the wrong offset. The result is either:

- `Err(Incomplete(NeedSize { bits: N }))` even though the parse already succeeded, or
- `Ok(...)` with a wrong consumed-byte count.

## Fix

Drop the `SeekFrom` match and read the position back from the inner reader directly:

```rust
let new_pos = self.inner.seek(pos)?;
self.bits_read = usize::try_from(new_pos)
    .unwrap_or(usize::MAX)
    .saturating_mul(8);
Ok(new_pos)
```

Covers `Start(0)`, negative `Current`, and any `End` the same way. The saturating conversion keeps `bits_read` correct on targets where `usize` is narrower than `u64` and for streams larger than `usize::MAX / 8` bytes.

## Tests

New regression tests in `tests/test_seek.rs`:

- `test_seek_from_start_zero_rewind` - round-trips a struct using `seek_from_start = "0"` after a forward seek (minimal repro of the bug).
- `test_seek_from_end_rewind` - round-trips a struct using `seek_from_end`, the variant that was never updating `bits_read` before the fix.
- `test_seek_from_current_negative_rewind` - round-trips a struct using negative `seek_from_current` (original scenario in #606).
- `test_seek_error_preserves_bits_read` - directly asserts `bits_read` is unchanged when the inner seek returns an error.

## Repro

I put together a small repo with three scenarios from #606 showing upstream vs patched outputs side by side:

https://github.com/PedroDeSanti/deku-seek-bug-tests