### PR TITLE
perf: zero-extend big-endian bit fields with load_be

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ name = "deku"
 harness = false
 required-features = ["alloc"]
 
+[[bench]]
+name = "bebits"
+harness = false
+required-features = ["alloc", "bits"]
+
 [lints]
 workspace = true
 

--- a/benches/bebits.rs
+++ b/benches/bebits.rs
@@ -1,0 +1,75 @@
+//! Big-endian bit-packed headers: the shape used by real network / space
+//! protocols (CCSDS, IPv4, DVB-S2). Mirrors the CCSDS TM Transfer Frame
+//! primary header, 6 octets / 11 fields.
+use criterion::{criterion_group, criterion_main, Criterion};
+use deku::prelude::*;
+use no_std_io::io::Cursor;
+
+#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+#[deku(endian = "big")]
+struct TmPrimaryHeader {
+    #[deku(bits = 2)]
+    tfvn: u8,
+    #[deku(bits = 10)]
+    scid: u16,
+    #[deku(bits = 3)]
+    vcid: u8,
+    #[deku(bits = 1)]
+    ocf: u8,
+    mcfc: u8,
+    vcfc: u8,
+    #[deku(bits = 1)]
+    tfs: u8,
+    #[deku(bits = 1)]
+    syn: u8,
+    #[deku(bits = 1)]
+    po: u8,
+    #[deku(bits = 2)]
+    sli: u8,
+    #[deku(bits = 11)]
+    fhp: u16,
+}
+
+/// Same 6 octets, byte-aligned: the deku fast path, for scale.
+#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+#[deku(endian = "big")]
+struct SixBytes {
+    a: u8,
+    b: u8,
+    c: u8,
+    d: u8,
+    e: u8,
+    f: u8,
+}
+
+/// Worst case in the docs: a 1-bit field in a wide container.
+#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+#[deku(endian = "big")]
+struct OneBitU64 {
+    #[deku(bits = 1)]
+    a: u64,
+}
+
+fn bench(c: &mut Criterion) {
+    let buf = [0x2Au8, 0xB5, 0x11, 0x22, 0xC7, 0xFF, 0x00, 0x99];
+    c.bench_function("be_tm_primary_header_11_fields", |b| {
+        b.iter(|| {
+            let mut r = Reader::new(Cursor::new(&buf));
+            TmPrimaryHeader::from_reader_with_ctx(&mut r, ()).unwrap()
+        })
+    });
+    c.bench_function("be_six_bytes_aligned", |b| {
+        b.iter(|| {
+            let mut r = Reader::new(Cursor::new(&buf));
+            SixBytes::from_reader_with_ctx(&mut r, ()).unwrap()
+        })
+    });
+    c.bench_function("be_one_bit_in_u64", |b| {
+        b.iter(|| {
+            let mut r = Reader::new(Cursor::new(&buf));
+            OneBitU64::from_reader_with_ctx(&mut r, ()).unwrap()
+        })
+    });
+}
+criterion_group!(bebits, bench);
+criterion_main!(bebits);

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -181,6 +181,22 @@ macro_rules! ImplDekuReadBits {
                     }
                 }
 
+                // Fast path: big-endian, Msb0 bit order.
+                //
+                // The generic paths below zero-extend the value to the container
+                // width by calling `BoundedBitVec::insert(0, false)` once per
+                // padding bit, and each `insert` shifts the entire backing array
+                // right by one bit. That is O(MAX_TYPE_BITS) bit operations per
+                // padding bit, i.e. O(MAX_TYPE_BITS * (MAX_TYPE_BITS - bit_size))
+                // per field -- for a 1-bit field in a u64 that is 63 whole-array
+                // shifts. `load_be` performs the identical zero-extension in one
+                // step. Only Msb0 + big-endian is handled here; the Lsb0 and
+                // little-endian paths keep their existing behaviour.
+                if !input_is_le && order == Order::Msb0 && bit_size > 0 {
+                    let value = bit_slice.load_be::<$inner>();
+                    return Ok((bit_size, <$typ>::from_be_bytes(value.to_be_bytes())));
+                }
+
                 // if read from Lsb order and it's especially cursed since its not just within one byte...
                 // read_bits returned: [0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 1]
                 //                     | second     |    first            |
@@ -284,6 +300,15 @@ macro_rules! ImplDekuReadBits {
                         };
                         return Ok((bit_size, value));
                     }
+                }
+
+                // Fast path: big-endian. This impl has no `Order` parameter and
+                // so is always Msb0. See the comment on the same fast path in
+                // the `(Endian, BitSize, Order)` impl above for why the generic
+                // path below is quadratic in the container width.
+                if !input_is_le && bit_size > 0 {
+                    let value = bit_slice.load_be::<$inner>();
+                    return Ok((bit_size, <$typ>::from_be_bytes(value.to_be_bytes())));
                 }
 
                 // Create a new BoundedBitVec from the slice and pad un-aligned chunks


### PR DESCRIPTION
Closes #665.

Reading a `#[deku(bits = N)]` field zero-extends it to the container width with:

```rust
for _ in 0..(MAX_TYPE_BITS - bits.len()) {
    bits.insert(0, false);
}
```

`BoundedBitVec::insert` shifts the whole backing array right by one bit per call,
bit by bit, because the `split_at_mut` alias defeats bitvec's word-at-a-time
`shift_right`. That makes a field `O(container_bits * (container_bits - N))` bit
operations: a 1-bit field in a `u64` pays 63 whole-array shifts, about 2 us.

`BitField::load_be` does the same zero-extension in one step, and this file
already uses it in the `Lsb0` branch below.

## Change

Two hunks in `src/impls/primitive.rs`, one per `DekuRead::read` impl
(`(Endian, BitSize, Order)` and `(Endian, BitSize)`):

```rust
if !input_is_le && order == Order::Msb0 && bit_size > 0 {
    let value = bit_slice.load_be::<$inner>();
    return Ok((bit_size, <$typ>::from_be_bytes(value.to_be_bytes())));
}
```

`f32` and `f64` are not `funty::Integral`, so the value goes through the unsigned
`$inner` and `from_be_bytes`, as the existing padded-array path does.
`bit_size > 0` leaves `bits = 0` panicking in `insert` as before.

Adds `benches/bebits.rs`, since the existing `DekuBits` bench declares no endian
and never reaches this path.

## Scope

Explicit `endian = "big"` with the default `Msb0` only. Untouched: no `endian`
attribute (which defaults to target endianness, so little-endian on x86),
`endian = "little"`, and any `bit_order = "lsb"`.

I left the little-endian side alone on purpose. #658 is an open correctness bug in
the `Lsb0 + Endian::Little` branch, so mixing a performance change into it seemed
unwise. It is fixable the same way, building `ceil(N/8)` bytes with the final
partial byte right-aligned and combining little-endian, once the intended
semantics are settled. Happy to follow up.

## Testing

The full CI feature matrix passes and all nine examples run. `tests/bit_order.rs`
and `tests/test_lsb_le.rs` stay green.

A differential sweep of the old conversion against the new one, over `u8`, `u16`,
`u32` and `u64`, every valid width and 40k random inputs: 4.8M cases, 0
mismatches.

Two jobs are already red on unpatched `master`, so they are not from this PR:

- `test_compile`: the trybuild expected stderr does not match newer rustc.
  Verified identical by reverting only `primitive.rs`.
- `cargo clippy -- -D warnings`: `src/lib.rs:983` calls `shift_right`, deprecated
  in bitvec 1.1.1, which the `"1.0.1"` requirement now resolves to. Can fix
  separately if you want.

## Performance

`cargo bench --all-features --bench bebits`, against a `master` baseline:

| Bench                                | master  | patched | change         |
| ------------------------------------ | ------: | ------: | -------------- |
| `be_tm_primary_header_11_fields`     | 2827 ns |  712 ns | **-74.7%**     |
| `be_one_bit_in_u64`                  | 2050 ns | 79.1 ns | **-96.1%**     |
| `be_six_bytes_aligned` (byte-aligned control) | 15.9 ns | 15.8 ns | none, p = 0.19 |

`--bench deku` is unchanged: `deku_read_bits` 740 to 729 ns (p = 0.34). It did
report +2.2% on `deku_read_byte`, but the same binary run twice moves that one
-3.0%, so run-to-run drift on an 8 ns benchmark is larger than the effect.

rustc 1.96.0, opt-level 3, no LTO, AMD EPYC 9374F.
