### PR TITLE
Restore inlining of read_bytes_const_into hot path

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -564,6 +564,7 @@ impl<R: Read + Seek> Reader<R> {
     ///
     /// # Params
     /// `buf` - result bytes
+    #[inline]
     pub fn read_bytes_const_into<const N: usize>(
         &mut self,
         buf: &mut [u8; N],
@@ -581,6 +582,15 @@ impl<R: Read + Seek> Reader<R> {
             return Ok(());
         }
 
+        // Trying to keep this not in the hot path
+        self.read_bytes_const_into_other::<N>(buf, order)
+    }
+
+    fn read_bytes_const_into_other<const N: usize>(
+        &mut self,
+        buf: &mut [u8; N],
+        order: Order,
+    ) -> Result<(), DekuError> {
         match self.leftover {
             Some(Leftover::Byte(byte)) => self.read_bytes_const_leftover(buf, byte),
             #[cfg(feature = "bits")]


### PR DESCRIPTION
* Follows pattern that we set in the rest of the project.

Measured with the callgrind benches (instructions, vs master):

  read_bytes               137 -> 42     -69.3%
  read_enum                 89 -> 31     -65.2%
  read_all              61,696 -> 37,698 -38.9%
  read_count_no_special 36,233 -> 21,235 -41.4%
  read_vec                 243 -> 201    -17.3%