### PR TITLE
perf: read and write bit fields as integers

### DIFF
--- a/benches/bebits.rs
+++ b/benches/bebits.rs
@@ -70,6 +70,35 @@ fn bench(c: &mut Criterion) {
             OneBitU64::from_reader_with_ctx(&mut r, ()).unwrap()
         })
     });
+
+    // Write side of the same shapes. Into a reused stack buffer, so the
+    // measurement is the field writes rather than an allocation.
+    let mut r = Reader::new(Cursor::new(&buf));
+    let header = TmPrimaryHeader::from_reader_with_ctx(&mut r, ()).unwrap();
+    let six = SixBytes {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+        e: 5,
+        f: 6,
+    };
+    c.bench_function("be_write_tm_primary_header_11_fields", |b| {
+        let mut out = [0u8; 16];
+        b.iter(|| {
+            let mut w = Writer::new(Cursor::new(out.as_mut_slice()));
+            header.to_writer(&mut w, ()).unwrap();
+            w.finalize().unwrap();
+        })
+    });
+    c.bench_function("be_write_six_bytes_aligned", |b| {
+        let mut out = [0u8; 16];
+        b.iter(|| {
+            let mut w = Writer::new(Cursor::new(out.as_mut_slice()));
+            six.to_writer(&mut w, ()).unwrap();
+            w.finalize().unwrap();
+        })
+    });
 }
 criterion_group!(bebits, bench);
 criterion_main!(bebits);

--- a/benches/bebits.rs
+++ b/benches/bebits.rs
@@ -1,9 +1,29 @@
 //! Big-endian bit-packed headers: the shape used by real network / space
 //! protocols (CCSDS, IPv4, DVB-S2). Mirrors the CCSDS TM Transfer Frame
 //! primary header, 6 octets / 11 fields.
+//!
+//! Each shape is measured twice.
+//!
+//! The single-shot benches handle one struct per iteration. Consecutive
+//! iterations share no state, so the CPU overlaps them and the result is a
+//! throughput figure rather than the cost of one read.
+//!
+//! The `_xN` benches move N structs through one reader or writer, which is what
+//! a stream of frames actually does: each read depends on where the previous one
+//! left the cursor, so nothing overlaps. Every field is folded into a value the
+//! closure returns, so no read can be dropped. Divide by N for the per-struct
+//! cost; that is the number to quote.
 use criterion::{criterion_group, criterion_main, Criterion};
 use deku::prelude::*;
 use no_std_io::io::Cursor;
+use std::hint::black_box;
+
+/// Frames per sequential pass. 128 six-octet frames is 768 bytes, comfortably
+/// inside L1 so the measurement is field decoding rather than memory.
+const FRAMES: usize = 128;
+
+/// 1-bit fields per sequential pass: 1024 bits, i.e. 128 bytes.
+const BITS: usize = 1024;
 
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(endian = "big")]
@@ -30,7 +50,8 @@ struct TmPrimaryHeader {
     fhp: u16,
 }
 
-/// Same 6 octets, byte-aligned: the deku fast path, for scale.
+/// Same 6 octets, byte-aligned: the deku fast path, for scale. Also the control
+/// for any change to the bit paths, which must leave this one alone.
 #[derive(Debug, PartialEq, DekuRead, DekuWrite)]
 #[deku(endian = "big")]
 struct SixBytes {
@@ -50,24 +71,77 @@ struct OneBitU64 {
     a: u64,
 }
 
+/// A frame stream whose bytes are not compile-time constants.
+fn stream() -> [u8; FRAMES * 6] {
+    let mut buf = [0u8; FRAMES * 6];
+    let mut x: u32 = 0x1234_5678;
+    for b in buf.iter_mut() {
+        x = x.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        *b = (x >> 24) as u8;
+    }
+    buf
+}
+
 fn bench(c: &mut Criterion) {
     let buf = [0x2Au8, 0xB5, 0x11, 0x22, 0xC7, 0xFF, 0x00, 0x99];
+    let stream = stream();
+
+    // One struct per iteration.
     c.bench_function("be_tm_primary_header_11_fields", |b| {
         b.iter(|| {
-            let mut r = Reader::new(Cursor::new(&buf));
+            let mut r = Reader::new(Cursor::new(black_box(&buf)));
             TmPrimaryHeader::from_reader_with_ctx(&mut r, ()).unwrap()
         })
     });
     c.bench_function("be_six_bytes_aligned", |b| {
         b.iter(|| {
-            let mut r = Reader::new(Cursor::new(&buf));
+            let mut r = Reader::new(Cursor::new(black_box(&buf)));
             SixBytes::from_reader_with_ctx(&mut r, ()).unwrap()
         })
     });
     c.bench_function("be_one_bit_in_u64", |b| {
         b.iter(|| {
-            let mut r = Reader::new(Cursor::new(&buf));
+            let mut r = Reader::new(Cursor::new(black_box(&buf)));
             OneBitU64::from_reader_with_ctx(&mut r, ()).unwrap()
+        })
+    });
+
+    // A stream of frames through one reader.
+    c.bench_function("be_tm_primary_header_x128", |b| {
+        b.iter(|| {
+            let mut r = Reader::new(Cursor::new(black_box(&stream)));
+            let mut acc: u64 = 0;
+            for _ in 0..FRAMES {
+                let h = TmPrimaryHeader::from_reader_with_ctx(&mut r, ()).unwrap();
+                acc ^= u64::from(h.scid)
+                    ^ u64::from(h.fhp)
+                    ^ u64::from(h.mcfc)
+                    ^ u64::from(h.vcid)
+                    ^ u64::from(h.tfvn)
+                    ^ u64::from(h.sli);
+            }
+            acc
+        })
+    });
+    c.bench_function("be_six_bytes_aligned_x128", |b| {
+        b.iter(|| {
+            let mut r = Reader::new(Cursor::new(black_box(&stream)));
+            let mut acc: u64 = 0;
+            for _ in 0..FRAMES {
+                let s = SixBytes::from_reader_with_ctx(&mut r, ()).unwrap();
+                acc ^= u64::from(s.a) ^ u64::from(s.f);
+            }
+            acc
+        })
+    });
+    c.bench_function("be_one_bit_in_u64_x1024", |b| {
+        b.iter(|| {
+            let mut r = Reader::new(Cursor::new(black_box(&stream)));
+            let mut acc: u64 = 0;
+            for _ in 0..BITS {
+                acc ^= OneBitU64::from_reader_with_ctx(&mut r, ()).unwrap().a;
+            }
+            acc
         })
     });
 
@@ -87,7 +161,7 @@ fn bench(c: &mut Criterion) {
         let mut out = [0u8; 16];
         b.iter(|| {
             let mut w = Writer::new(Cursor::new(out.as_mut_slice()));
-            header.to_writer(&mut w, ()).unwrap();
+            black_box(&header).to_writer(&mut w, ()).unwrap();
             w.finalize().unwrap();
         })
     });
@@ -95,7 +169,29 @@ fn bench(c: &mut Criterion) {
         let mut out = [0u8; 16];
         b.iter(|| {
             let mut w = Writer::new(Cursor::new(out.as_mut_slice()));
-            six.to_writer(&mut w, ()).unwrap();
+            black_box(&six).to_writer(&mut w, ()).unwrap();
+            w.finalize().unwrap();
+        })
+    });
+
+    // A stream of frames through one writer.
+    c.bench_function("be_write_tm_primary_header_x128", |b| {
+        let mut out = [0u8; FRAMES * 6];
+        b.iter(|| {
+            let mut w = Writer::new(Cursor::new(out.as_mut_slice()));
+            for _ in 0..FRAMES {
+                black_box(&header).to_writer(&mut w, ()).unwrap();
+            }
+            w.finalize().unwrap();
+        })
+    });
+    c.bench_function("be_write_six_bytes_aligned_x128", |b| {
+        let mut out = [0u8; FRAMES * 6];
+        b.iter(|| {
+            let mut w = Writer::new(Cursor::new(out.as_mut_slice()));
+            for _ in 0..FRAMES {
+                black_box(&six).to_writer(&mut w, ()).unwrap();
+            }
             w.finalize().unwrap();
         })
     });

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -381,6 +381,12 @@ macro_rules! ImplDekuReadBits {
                         size.0
                     ));
                 }
+                // Fast path: big-endian, and `Order::default()` is Msb0. Reads the
+                // field straight into an integer, with no `BitSlice` in between.
+                if !endian.is_le() && size.0 > 0 && size.0 <= 64 {
+                    let value = reader.read_bits_uint_msb0(size.0)? as $inner;
+                    return Ok(<$typ>::from_be_bytes(value.to_be_bytes()));
+                }
                 let mut bits = ::bitvec::array::BitArray::<[u8; { MAX_TYPE_BITS / 8 }], Msb0>::new(
                     [0; { MAX_TYPE_BITS / 8 }],
                 );
@@ -406,6 +412,11 @@ macro_rules! ImplDekuReadBits {
                         MAX_TYPE_BITS,
                         size.0
                     ));
+                }
+                // Fast path: big-endian, Msb0. See the `(Endian, BitSize)` impl above.
+                if !endian.is_le() && order == Order::Msb0 && size.0 > 0 && size.0 <= 64 {
+                    let value = reader.read_bits_uint_msb0(size.0)? as $inner;
+                    return Ok(<$typ>::from_be_bytes(value.to_be_bytes()));
                 }
                 let mut bits = ::bitvec::array::BitArray::<[u8; { MAX_TYPE_BITS / 8 }], Msb0>::new(
                     [0; { MAX_TYPE_BITS / 8 }],

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -83,9 +83,26 @@ impl DekuWriter<(Endian, BitSize, Order)> for u8 {
         writer: &mut Writer<W>,
         (_, size, order): (Endian, BitSize, Order),
     ) -> Result<(), DekuError> {
-        let input = self.to_le_bytes();
-
         let bit_size: usize = size.0;
+        const MAX_TYPE_BITS: usize = BitSize::of::<u8>().0;
+
+        // Fast path, ahead of the bit-slice view: for a `u8` the checks below are
+        // "does it fit" and "are there bits above `bit_size`", both of which are
+        // integer comparisons. `first_one` over a bit-slice is not.
+        if order == Order::Msb0 && writer.leftover.1 == Order::Msb0 && bit_size <= MAX_TYPE_BITS {
+            if bit_size < MAX_TYPE_BITS && (*self >> bit_size) != 0 {
+                return Err(deku_error!(
+                    DekuError::InvalidParam,
+                    "bit size of input is larger than bit requested size",
+                    "{} exceeds {}",
+                    MAX_TYPE_BITS - (self.leading_zeros() as usize),
+                    bit_size
+                ));
+            }
+            return writer.write_bits_uint_msb0(u64::from(*self), bit_size);
+        }
+
+        let input = self.to_le_bytes();
 
         let input_bits = input.view_bits::<Msb0>();
 
@@ -100,7 +117,6 @@ impl DekuWriter<(Endian, BitSize, Order)> for u8 {
         }
 
         // Check for extra bits before sending into writer
-        const MAX_TYPE_BITS: usize = BitSize::of::<u8>().0;
         if let Some(first) = input_bits.first_one() {
             let max = MAX_TYPE_BITS - bit_size;
             if max > first {
@@ -876,6 +892,39 @@ macro_rules! ImplDekuWrite {
                     }
                     (Endian::Big, Order::Msb0) => {
                         const MAX_TYPE_BITS: usize = BitSize::of::<$typ>().0;
+
+                        // Fast path, ahead of the bit-slice scan. Significant-bit
+                        // count from the big-endian bytes is the same test as
+                        // `first_one`: that check errors when
+                        // `MAX_TYPE_BITS - bit_size > first`, i.e. when
+                        // `MAX_TYPE_BITS - first` (the significant bits) exceeds
+                        // `bit_size`.
+                        if bit_size <= 64 && writer.leftover.1 == Order::Msb0 {
+                            let significant = match input.iter().position(|b| *b != 0) {
+                                Some(i) => {
+                                    (input.len() - i) * 8 - (input[i].leading_zeros() as usize)
+                                }
+                                None => 0,
+                            };
+                            if significant > bit_size {
+                                return Err(deku_error!(
+                                    DekuError::InvalidParam,
+                                    "bit size of input is larger than requested size",
+                                    "{} exceeds {}",
+                                    significant,
+                                    bit_size
+                                ));
+                            }
+                            // The value fits in `bit_size <= 64` bits, so the low
+                            // eight bytes carry all of it even for a 128-bit
+                            // container.
+                            let mut value: u64 = 0;
+                            for &byte in &input[input.len().saturating_sub(8)..] {
+                                value = (value << 8) | u64::from(byte);
+                            }
+                            return writer.write_bits_uint_msb0(value, bit_size);
+                        }
+
                         if let Some(first) = input_bits.first_one() {
                             let max = MAX_TYPE_BITS - bit_size;
                             if max > first {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1000,6 +1000,29 @@ where
     }
 }
 
+/// Integer view of a single-byte `Msb0` leftover, for the reader's fast path.
+///
+/// A leftover of `size` bits always occupies the *high* `size` bits of the byte,
+/// because it is built by copying a bit-slice into a zeroed array at index 0. So
+/// it is a byte and a length, and shifting it is enough: no `BitSlice` needed.
+#[cfg(feature = "bits")]
+impl BoundedBitVec<[u8; 1], crate::bitvec::Msb0> {
+    #[inline]
+    fn from_msb0_byte(byte: u8, size: usize) -> Self {
+        debug_assert!(size <= 8);
+        Self {
+            bits: BitArray::new([byte]),
+            size,
+        }
+    }
+
+    /// The leftover as `(high-aligned byte, bit count)`.
+    #[inline]
+    fn as_msb0_byte(&self) -> (u8, usize) {
+        (self.bits.as_raw_slice()[0], self.size)
+    }
+}
+
 #[cfg(test)]
 #[path = "../tests/test_common/mod.rs"]
 pub mod test_common;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -376,6 +376,72 @@ impl<R: Read + Seek> Reader<R> {
         Ok(())
     }
 
+    /// Reads `amt` bits (`1..=64`) most-significant-bit first, returning them
+    /// right-aligned in a `u64`.
+    ///
+    /// This is the integer fast path for the common big-endian / `Msb0` case. It
+    /// is equivalent to `read_bits_into` followed by `load_be`, but the value
+    /// never touches a `BitSlice`: the leftover is a byte and a length, so
+    /// serving a field is a shift and a mask. `read_bits_into` instead rebuilds a
+    /// `BoundedBitVec` per call, whose bit-unaligned `copy_from_bitslice` falls
+    /// back to copying one bit at a time.
+    ///
+    /// Reads whole bytes from the stream only when the leftover cannot satisfy
+    /// `amt`, exactly as `read_bits_into` does, so it consumes no more input.
+    #[inline]
+    #[cfg(feature = "bits")]
+    pub(crate) fn read_bits_uint_msb0(&mut self, amt: usize) -> Result<u64, DekuError> {
+        debug_assert!((1..=64).contains(&amt));
+
+        // Up to 7 leftover bits plus 64 requested does not fit a u64.
+        let mut acc: u128 = 0;
+        let mut have: usize = 0;
+        match self.leftover.take() {
+            Some(Leftover::Byte(byte)) => {
+                acc = u128::from(byte);
+                have = 8;
+            }
+            Some(Leftover::Bits(bits)) => {
+                let (byte, size) = bits.as_msb0_byte();
+                if size != 0 {
+                    acc = u128::from(byte >> (8 - size));
+                    have = size;
+                }
+            }
+            None => {}
+        }
+
+        // One byte at a time, which reads exactly as much as the field needs and
+        // no more. Batching the whole field into a single variable-length
+        // `read_exact` wins on a microbenchmark over wide fields, but loses on a
+        // realistic multi-protocol pipeline, where fields are mostly narrow and
+        // the extra branch costs more than it saves.
+        while have < amt {
+            let mut buf = [0u8; 1];
+            if let Err(e) = self.inner.read_exact(&mut buf) {
+                if e.kind() == ErrorKind::UnexpectedEof {
+                    return Err(DekuError::Incomplete(NeedSize::new(amt)));
+                }
+                return Err(DekuError::Io(e.kind()));
+            }
+            acc = (acc << 8) | u128::from(buf[0]);
+            have += 8;
+        }
+
+        let rest = have - amt;
+        let value = ((acc >> rest) as u64) & (u64::MAX >> (64 - amt));
+        if rest != 0 {
+            let tail = (acc & ((1u128 << rest) - 1)) as u8;
+            self.leftover = Some(Leftover::Bits(crate::BoundedBitVec::from_msb0_byte(
+                tail << (8 - rest),
+                rest,
+            )));
+        }
+
+        self.bits_read += amt;
+        Ok(value)
+    }
+
     /// Attempt to read bits from `Reader`. If enough bits are already "Read", we just grab
     /// enough bits to satisfy `amt`, but will also "Read" more from the stream and store the
     /// leftovers if enough are not already "Read".

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -62,6 +62,52 @@ impl<W: Write + Seek> Writer<W> {
         self.leftover.0.as_bitslice().iter().by_vals().collect()
     }
 
+    /// Writes the low `amt` bits (`1..=64`) of `value`, most-significant-bit
+    /// first. The integer mirror of `Reader::read_bits_uint_msb0`.
+    ///
+    /// Only valid when the pending leftover is `Msb0`; the caller checks that.
+    /// Equivalent to `write_bits_order(.., Order::Msb0)` over the same bits, but
+    /// the value never becomes a `BitSlice`: whole bytes leave in one `write_all`
+    /// instead of one call per byte, and the leftover is a byte and a length
+    /// rather than a `BoundedBitVec` rebuilt bit by bit.
+    #[inline]
+    #[cfg(feature = "bits")]
+    pub(crate) fn write_bits_uint_msb0(&mut self, value: u64, amt: usize) -> Result<(), DekuError> {
+        debug_assert!((1..=64).contains(&amt));
+        debug_assert_eq!(self.leftover.1, Order::Msb0);
+
+        let (lead, lead_len) = self.leftover.0.as_msb0_byte();
+        // Leftover bits first, then the value's low `amt` bits: at most 7 + 64.
+        let mut acc: u128 = if lead_len == 0 {
+            0
+        } else {
+            u128::from(lead >> (8 - lead_len))
+        };
+        acc = (acc << amt) | u128::from(value & (u64::MAX >> (64 - amt)));
+        let have = lead_len + amt;
+
+        let whole = have / 8;
+        let rest = have % 8;
+        if whole != 0 {
+            let mut buf = [0u8; 9];
+            let aligned = acc >> rest;
+            for (i, slot) in buf[..whole].iter_mut().enumerate() {
+                *slot = (aligned >> ((whole - 1 - i) * 8)) as u8;
+            }
+            self.inner.write_all(&buf[..whole])?;
+            self.bits_written += whole * 8;
+        }
+
+        if rest == 0 {
+            self.leftover.0.clear();
+        } else {
+            let tail = (acc & ((1u128 << rest) - 1)) as u8;
+            self.leftover.0 = BoundedBitVec::from_msb0_byte(tail << (8 - rest), rest);
+        }
+        self.leftover.1 = Order::Msb0;
+        Ok(())
+    }
+
     #[cfg(feature = "bits")]
     fn write_bits_order_msb_msb(
         &mut self,


### PR DESCRIPTION
## What this changes

Reading a `#[deku(bits = N)]` field currently goes through an intermediate
bit-slice: deku copies the bits out of the input one slice operation at a time,
assembles them into a `BitSlice`, and only then turns that into an integer.
Writing does the mirror image. That intermediate is where nearly all the time
goes.

This PR skips it. For **big-endian, `Order::Msb0`** fields only, the value is
read straight into an integer and written straight out of one. No bit-slice is
built at all.

## This does not replace #666

The two changes optimise the same idea on **two different public traits**, and
both stay reachable:

- **#666** speeds up `DekuRead::read(&BitSlice, ctx)`, the slice-level trait.
  That is the entry point for anyone who already holds a `BitSlice`, and it is
  what deku's own delegating impls in `src/impls/primitive.rs` call internally
  (the `ByteSize` and signed-integer wrappers all funnel into it).
- **This PR** speeds up `DekuReader::from_reader_with_ctx`, the reader-level
  trait. Derived `from_reader` *and* derived `from_bytes` both go through it,
  since `from_bytes` builds a `Cursor` and calls `from_reader_with_ctx`.

Where both apply, this one returns first, so a derived big-endian `Msb0` read no
longer reaches #666's line. But `DekuRead::read` is public and still reached by
direct callers, hand-written impls, and deku's internal delegating impls, so
#666 keeps doing its job there. Same optimisation, two layers, neither made
dead by the other.

## What it looks like on real bytes

Take a two-field header:

```rust
#[derive(DekuRead, DekuWrite)]
#[deku(endian = "big")]
struct Header {
    #[deku(bits = 2)]
    version: u8,
    #[deku(bits = 10)]
    id: u16,
}
```

Given the input bytes `[0x2A, 0xB5]`, that is the bit stream
`00 1010101011 0101`, so `version = 0` and `id = 683`.

Reading `version` consumes byte `0x2A`, keeps its top 2 bits, and leaves the
other 6 behind as the reader's "leftover". So both traces below start from:

```text
leftover = 101010        (6 bits)
next byte in the stream = 0xB5
```

### Reading `id` today

```text
1. allocate a 16-bit BitArray, take dst = &mut bits[..10]
   bits = 0000000000 000000
   dst    ^^^^^^^^^^

2. copy the 6 leftover bits into dst[..6]          (copy_from_bitslice)
   dst  = 101010 ????                              4 bits still missing

3. dst[6..10] is 4 bits, less than a whole byte, so the whole-byte loop
   (chunks_exact_mut(8)) runs zero times and hands back a 4-bit remainder

4. read byte 0xB5, view it as a BitSlice, split_at_mut(4)
   0xB5 = 1011 0101
          used rest
   copy `used` into the remainder                  (copy_from_bitslice)
   dst  = 101010 1011                              complete

5. store `rest` as the new leftover, rebuilt as a BoundedBitVec
   leftover = 0101                                 (4 bits)

6. hand dst, a 10-bit BitSlice, to u16::read, which zero-extends it to 16
   bits and reads it big-endian
   000000 1010101011  =  683
```

Six steps, three bit-slice copies, and two `BoundedBitVec`s built and dropped,
to move 10 bits. (Step 6 is the one #666 already fixed: before that PR the
zero-extension was 6 separate `insert(0, false)` calls, each shifting the whole
16-bit array. #666 made it a single `load_be`.)

### Reading `id` with this PR

The whole read is one `u128` accumulator, `acc`, and a count of how many bits
are in it, `have`.

```text
1. start from the leftover. It is stored as one byte, top-aligned, plus a
   length, so shifting it down is all it takes:
   leftover byte = 10101000, length 6
   acc  = 10101000 >> (8 - 6) = 101010
   have = 6

2. we need 10 bits and have 6, so pull one byte and shift it in:
   read 0xB5 = 10110101
   acc  = (101010 << 8) | 10110101 = 101010 10110101
   have = 14

3. we have 4 bits more than we asked for, so the value is `acc` shifted
   right by those 4, masked to 10 bits:
   rest  = 14 - 10 = 4
   value = acc >> 4        = 1010101011   = 683
                              ^^^^^^^^^^ the 10 bits we wanted

4. the 4 bits we shifted off become the new leftover, kept as a byte with a
   length rather than a bit-vector:
   tail     = acc & 0b1111 = 0101
   leftover = 01010000, length 4
```

One byte fetched, one shift, one mask. Steps 1 to 5 of the old path are gone,
and no `BitSlice` or `BoundedBitVec` is ever constructed.

### Writing `id = 683`, after `version` has queued 2 bits

Same accumulator, run backwards. Writing `version` emitted nothing, it only left
2 pending bits (`00`) waiting for the rest of the byte.

```text
1. does 683 fit in the 10 bits the field declares?
   683 as a big-endian u16:  0000 0010 1010 1011
                             ^^^^^^ six leading zeros
   significant bits = 16 - 6 = 10,  and 10 <= 10, so yes

2. shift the 2 pending bits up and OR the value underneath:
   acc  = (00 << 10) | 1010101011 = 00 1010101011
   have = 2 + 10 = 12

3. 12 bits is one whole byte plus 4. Emit the whole byte:
   whole = 12 / 8 = 1,  rest = 12 % 8 = 4
   byte  = acc >> 4 = 00101010 = 0x2A            (one write_all)

4. the 4 bits that did not fill a byte stay pending:
   tail     = acc & 0b1111 = 1011
   leftover = 10110000, length 4
```

That trailing `1011` is the top half of `0xB5`, which is exactly where the next
field continues. Read and write are mirror images of each other.

Step 1 is worth calling out on its own. Today that check scans a bit-slice with
`first_one` to locate the highest set bit:

```text
today:  first_one over the 16-bit slice -> index 6
        error if (16 - 10) > 6   ->  6 > 6   -> false, fits
now:    significant = 16 - leading_zeros = 16 - 6 = 10
        error if 10 > 10         ->  false, fits
```

Identical test. One walks a bit-slice, the other is a single `leading_zeros`
instruction.

### Why this matters more than it looks

The cost removed here is **per field and flat**. It does not depend on how many
bits the field holds, because it is the price of building and tearing down the
bit-slice machinery, not of moving the bits.

The measurements say exactly that. The CCSDS header has 11 bit fields and costs
723 ns, which is 66 ns per field. A single 1-bit field in a `u64` costs 69 ns.
Same number. A field that carries one bit pays what a field carrying eleven
does.

After this PR those become 23.8 ns for 11 fields (2.2 ns each) and 1.66 ns for
the single field. Still flat, just roughly 30 times smaller.

## Concretely, per file

- **`src/reader.rs`**: new `Reader::read_bits_uint_msb0(amt)`, the read shown above.
- **`src/writer.rs`**: new `Writer::write_bits_uint_msb0(value, amt)`, the dual.
  Whole bytes leave in one `write_all` rather than one call per byte.
- **`src/impls/primitive.rs`**: `DekuReader::from_reader_with_ctx` and
  `DekuWriter::to_writer` return early through those helpers when the field is
  big-endian and `Msb0`, plus the integer fit check.
- **`src/lib.rs`**: two small helpers to view a one-byte `Msb0` leftover as
  `(byte, bit count)`.

Little-endian and `Order::Lsb0` are untouched and keep their existing code path.

## Numbers

Measured against `master` at 088018f, so this includes #657, #659, #661 and the
syn v3 upgrade. Per-item cost, from benches that push 128 frames through a
single reader or writer so nothing is overlapped or optimised away:

| | before | after | |
|---|---|---|---|
| CCSDS TM primary header, 11 bit fields, read | 723 ns | **23.8 ns** | 30x |
| Same header, write | 534 ns | **182 ns** | 2.9x |
| 1-bit field in a `u64`, read | 69.1 ns | **1.66 ns** | 42x |
| 6 byte-aligned fields, read (control) | 12.8 ns | 12.8 ns | no change |
| 6 byte-aligned fields, write (control) | 20.4 ns | 22.7 ns | no change, see below |

The two control rows matter as much as the wins, since a change scoped to bit
fields should leave byte-aligned ones alone. Criterion agrees on the read
control, reporting "No change in performance detected".

The byte-aligned **write** control is too noisy on my machine to say anything
with. Re-running the *unmodified* `master` twice against its own baseline, the
same benchmark reported +2.6% and then +13.3%, so its noise floor is at least
±13% here and the +8% on this branch sits inside it. Nothing in this PR touches
that path: the `writer.rs` change is purely additive, and the `primitive.rs`
change is behind a big-endian `Msb0` bit-field guard. Worth watching on CI
hardware.

Reproduce with `cargo bench --bench bebits --all-features`.

## Also in here

One commit improves `benches/bebits.rs` itself: it `black_box`es the inputs
(without it the compiler can see the buffer contents and fold part of the read
away, which made the old numbers look better than they were) and adds benches
that read or write a stream of frames rather than one struct per iteration.

## Testing

`cargo test` across the full CI feature matrix (default, `--all-features`,
`--no-default-features` and each individual feature) plus all examples. No test
changes were needed: the fast path is required to produce bit-identical results
to the path it replaces.
