### PR TITLE
Fix to Reader and Writer Seek impls.

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -48,14 +48,18 @@ impl<R: Read + Seek> Seek for Reader<R> {
         #[cfg(feature = "logging")]
         log::trace!("seek: {pos:?}");
 
-        // clear leftover
-        self.leftover = None;
+        if pos == SeekFrom::Current(0) {
+            self.inner.seek(pos)
+        } else {
+            // clear leftover
+            self.leftover = None;
 
-        let new_pos = self.inner.seek(pos)?;
-        self.bits_read = usize::try_from(new_pos)
-            .unwrap_or(usize::MAX)
-            .saturating_mul(8);
-        Ok(new_pos)
+            let new_pos = self.inner.seek(pos)?;
+            self.bits_read = usize::try_from(new_pos)
+                .unwrap_or(usize::MAX)
+                .saturating_mul(8);
+            Ok(new_pos)
+        }
     }
 }
 
@@ -933,6 +937,26 @@ mod tests {
             bits,
             //                     |first               |last                   |left|
             Some(bitvec![u8, Msb0; 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0])
+        );
+    }
+
+    #[cfg(all(feature = "alloc", feature = "bits"))]
+    #[test]
+    // Issue #678
+    fn test_regression_stream_position() {
+        let input = vec![0x0F, 0xFF, 0xF0];
+        let mut reader = Reader::new(Cursor::new(&input));
+
+        let first_bits = reader.read_bits(4, Order::Msb0).unwrap();
+        assert_eq!(first_bits, Some(bitvec!(u8, Msb0; 0, 0, 0, 0)));
+
+        let pos = reader.stream_position().unwrap();
+        assert_eq!(pos, 1);
+
+        let second_bits = reader.read_bits(16, Order::Msb0).unwrap();
+        assert_eq!(
+            second_bits,
+            Some(bitvec![u8, Msb0; 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
         );
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -944,6 +944,8 @@ mod tests {
     #[test]
     // Issue #678
     fn test_regression_stream_position() {
+        use alloc::vec;
+
         let input = vec![0x0F, 0xFF, 0xF0];
         let mut reader = Reader::new(Cursor::new(&input));
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -559,12 +559,16 @@ mod tests {
         let mut target = vec![];
         let mut writer = Writer::new(Cursor::new(&mut target));
 
-        writer.write_bits_order(&bitvec![u8, Msb0; 1, 1, 1, 1], Order::Msb0).unwrap();
+        writer
+            .write_bits_order(&bitvec![u8, Msb0; 1, 1, 1, 1], Order::Msb0)
+            .unwrap();
 
         let pos = writer.stream_position().unwrap();
         assert_eq!(pos, 0);
 
-        writer.write_bits_order(&bitvec![u8, Msb0; 1, 1, 1, 1], Order::Msb0).unwrap();
+        writer
+            .write_bits_order(&bitvec![u8, Msb0; 1, 1, 1, 1], Order::Msb0)
+            .unwrap();
 
         writer.finalize().unwrap();
         assert_eq!(target, [0xFF]);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -32,9 +32,9 @@ impl<W: Write + Seek> Seek for Writer<W> {
         #[cfg(feature = "logging")]
         log::trace!("seek: {pos:?}");
 
-        // clear leftover
+        // clear leftover if the position changes
         #[cfg(feature = "bits")]
-        {
+        if pos != SeekFrom::Current(0) {
             self.leftover.0.clear();
             self.leftover.1 = Order::Msb0;
         }
@@ -550,5 +550,23 @@ mod tests {
             .unwrap();
         writer.finalize().unwrap();
         assert_eq!(out_buf.into_inner(), [0b1001_0101, 0b0000_1010]);
+    }
+
+    #[cfg(all(feature = "alloc", feature = "bits"))]
+    #[test]
+    // Issue #678
+    fn test_regression_stream_position() {
+        let mut target = vec![];
+        let mut writer = Writer::new(Cursor::new(&mut target));
+
+        writer.write_bits_order(&bitvec![u8, Msb0; 1, 1, 1, 1], Order::Msb0).unwrap();
+
+        let pos = writer.stream_position().unwrap();
+        assert_eq!(pos, 0);
+
+        writer.write_bits_order(&bitvec![u8, Msb0; 1, 1, 1, 1], Order::Msb0).unwrap();
+
+        writer.finalize().unwrap();
+        assert_eq!(target, [0xFF]);
     }
 }


### PR DESCRIPTION
This avoids unintentional clearing of internal members on calling stream_position.
Includes small regression tests for both reader and writer.

Fixes sharksforarms/deku#678.