### PR TITLE
Implement DekuContainerWrite on enums regardless of feature selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ descriptive-errors = ["alloc"]
 deku_derive = { version = "^0.20.3", path = "deku-derive", default-features = false}
 bitvec = { version = "1.1.0", default-features = false, optional = true }
 log = { version = "0.4.28", optional = true }
-no_std_io = { version = "0.9.1", default-features = false, package = "no_std_io2" }
+no_std_io = { version = "0.9.4", default-features = false, package = "no_std_io2" }
 rustversion = "1.0.22"
 
 [dev-dependencies]

--- a/deku-derive/src/macros/deku_write.rs
+++ b/deku-derive/src/macros/deku_write.rs
@@ -387,7 +387,9 @@ fn emit_enum(input: &DekuData) -> Result<TokenStream, syn::Error> {
                     }
                 }
             };
+        });
 
+        tokens.extend(quote! {
             #[automatically_derived]
             impl #imp ::#crate_::DekuContainerWrite for #ident #wher {}
         });


### PR DESCRIPTION
The PR also bumps `no-std-io2` to `v0.9.4` to resolve an issue with `Seek::stream_position()` in `Vec`-related tests when built without `std`.